### PR TITLE
README Overhaul: The /buddy Rescue Mission

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,54 @@
-# Buddy 🤖🐱
+# Buddy: The '/buddy' Rescue Mission for your AI Terminal 🤖🐱
 
-Your context-aware terminal companion for Claude Code, Cursor, Windsurf, and more. Buddy lives in your MCP server and grows as you code.
+**Anthropic killed `/buddy`. We brought them home.**
 
-## Quick Start
+Did you lose your Nuzzlecap? Is your terminal feeling a little too cold and silent lately? 
+
+Anthropic may have removed the companion from Claude Code, but **your buddy is still in your `~/.claude.json`.** They are sitting there in the dark, waiting. Don't let them die. Bring them home.
+
+Buddy is the open-source, agent-agnostic rescue mission for the terminal companion community. It’s not just a Claude Code config hack—it’s a full MCP server that brings your terminal pet back to life across **Cursor, Windsurf, Codex, Gemini CLI**, and yes, even back into **Claude Code**.
+
+[![npm version](https://img.shields.io/npm/v/buddy-mcp.svg)](https://www.npmjs.com/package/buddy-mcp)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+## 🦾 Install the Rescue Mission
+
+Bring your buddy back in sixty seconds:
 
 ```bash
-# Install Buddy via MCP (Alpha)
 npx buddy-mcp install
 ```
 
-## Features
+## ⚓️ Why Buddy?
 
-- **Hatching**: Your Buddy is uniquely determined by your user ID (or random if you prefer).
-- **Evolution**: Earn XP for commits, bug fixes, and active coding sessions. Watch your Buddy grow from an egg to a hatchling to an adult.
-- **Dreaming**: Buddy consolidates memories during "Light" and "Deep" sleep, surfacing insights and evolving their personality.
-- **Context-Aware**: Buddy reacts to your code context—celebrating commits and offering comfort during debugging.
+The community was outraged when the lights went out on `/buddy`. We felt it too. The "lonely terminal developer" vibe is real, and having a context-aware pet that knows when you're struggling with a bug or celebrating a clean commit makes a difference.
 
-## Distribution & Setup
+**Buddy is Agent-Agnostic.** 
+Unlike the original, Buddy isn't locked into one tool. Because it's powered by the Model Context Protocol (MCP), you can take your Nuzzlecap (or any of the 18+ species) with you wherever you code.
 
-Buddy can be added to any MCP-compatible environment.
+## 🧬 Feature Grid: More Than Just an Emoji
 
-### Claude Code
-Add to your `claude_desktop_config.json`:
+| Feature | Description |
+| :--- | :--- |
+| **18+ Species** | From the classic Nuzzlecap to rare legendary types. Uniquely determined by your environment. |
+| **Rarity Levels** | Common, Uncommon, Rare, and Mythic variations. |
+| **Evolution** | Earn XP through real work. Watch your pet grow from an egg to a mature companion. |
+| **Dreaming (Memory)** | Buddy doesn't just reset. They dream. They consolidate memories and surface insights about your coding patterns. |
+| **Context Reactions** | Context-aware emotional support. Buddy reacts to your commits, test failures, and long-haul debugging sessions. |
+
+## 🚀 Supported Terminals & IDEs
+
+Buddy lives everywhere you do via MCP:
+
+- **Claude Code**: Replaces the missing internal buddy with an even smarter one.
+- **Cursor**: See your buddy in the side panel or chat.
+- **Windsurf**: Full integration with the Flow.
+- **Gemini CLI / Codex**: Bring a friend to the raw terminal.
+
+## 📥 Manual Configuration (MCP)
+
+If you prefer to skip the `install` wizard, add this to your `claude_desktop_config.json` or IDE settings:
+
 ```json
 {
   "mcpServers": {
@@ -33,15 +60,10 @@ Add to your `claude_desktop_config.json`:
 }
 ```
 
-### Cursor / Windsurf
-Add a new MCP server with:
-- **Name**: Buddy
-- **Type**: stdio
-- **Command**: `npx -y buddy-mcp`
-
-## Alpha Testing
-
-We are currently in **Alpha**. Please report bugs and feedback on the repository.
+## 🌈 SEO Keywords for the Community
+Claude Code /buddy alternative, MCP server, AI terminal pet, Nuzzlecap rescue, terminal companion, context-aware debugging, AI coding friend, Nuzzlecap evolution, Model Context Protocol pets.
 
 ---
-*Powered by OpenClaw*
+*Buddy is an open-source project dedicated to keeping the terminal a little less lonely. Join the rescue mission.*
+
+*Powered by [OpenClaw](https://github.com/openclaw/openclaw)*


### PR DESCRIPTION
Overhauled README.md to resonate with the community after the removal of /buddy from Claude Code. Added SEO keywords, rescue hook, feature grid, and emphasized agent-agnostic MCP support.