### PR TITLE
fix: use execFileSync to avoid shell injection in statusline wrapper

### DIFF
--- a/src/statusline-wrapper.ts
+++ b/src/statusline-wrapper.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { readFileSync, readdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
@@ -66,10 +66,9 @@ try {
     if (pluginDir) {
       const bunPath = process.env.BUN_PATH || 'bun';
       const entryPoint = toUnix(join(pluginDir, "src", "index.ts"));
-      const result = execSync(
-        `"${bunPath}" --env-file /dev/null "${entryPoint}"`,
-        { input: stdinData, timeout: 5000, encoding: "utf-8", shell: "bash", stdio: ["pipe", "pipe", "pipe"] }
-      );
+      const result = execFileSync(bunPath, ["--env-file", "/dev/null", entryPoint], {
+        input: stdinData, timeout: 5000, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"],
+      });
       if (result) {
         hudLines = result.trimEnd().split("\n");
         // Write cache


### PR DESCRIPTION
Hi! Love this project — I've been running Buddy as an MCP in my personal environment and it's a lot of fun.

While doing a security review of the codebase I noticed a small hardening opportunity in the statusline wrapper. Wanted to send a fix your way in case it's useful.

## Summary

- `statusline-wrapper.ts` uses `execSync` with `shell: "bash"` to invoke bun, which means `process.env.BUN_PATH` is interpreted by the shell. A crafted `BUN_PATH` value could inject arbitrary commands.
- This switches to `execFileSync`, which bypasses the shell entirely — args are passed directly to the process, so shell metacharacters in env vars are harmless.

## What changed

One file, two lines:
- `execSync` → `execFileSync` (import + call site)
- Command string + `shell: "bash"` → args array, no shell

## Verified

- `execFileSync` does PATH lookup for bare command names (e.g. `'bun'`) the same as `execSync`
- `--env-file` and `/dev/null` work correctly as separate args to bun
- `input:` stdin piping and `encoding: "utf-8"` string return behave identically
- Existing try/catch error handling is unchanged

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)