### PR TITLE
feat: species voice kernels + NEVER constraints for buddy://intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ git clone https://github.com/fiorastudio/buddy.git
 cd buddy
 npm install
 npm run build
-npm test           # 243 tests
+npm test           # 261 tests
 npm start          # runs the MCP server on stdio
 ```
 
@@ -433,7 +433,7 @@ npm start          # runs the MCP server on stdio
 | **Species** | 21 | 18 |
 | **Install** | One-liner (curl/PowerShell) | git clone + npm |
 | **Windows** | ✅ | ❌ |
-| **Tests** | 243 | 140 |
+| **Tests** | 261 | 140 |
 
 **save-buddy** is a faithful preservation of the original Claude Code buddy experience. It's great for purists who want the exact original.
 

--- a/src/__tests__/personality.test.ts
+++ b/src/__tests__/personality.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { SPECIES_DATA, getVoice, getNever, type SpeciesPersonality } from '../lib/personality.js';
+import { SPECIES_LIST } from '../lib/species.js';
+import { sanitizeName } from '../lib/sanitize.js';
+
+// ---------------------------------------------------------------------------
+// sanitizeName
+// ---------------------------------------------------------------------------
+
+describe('sanitizeName', () => {
+  it('returns empty string for undefined', () => {
+    expect(sanitizeName(undefined)).toBe('');
+  });
+
+  it('returns empty string for empty string', () => {
+    expect(sanitizeName('')).toBe('');
+  });
+
+  it('returns empty string for whitespace-only', () => {
+    expect(sanitizeName('   ')).toBe('');
+  });
+
+  it('passes through normal names', () => {
+    expect(sanitizeName('Nyx')).toBe('Nyx');
+    expect(sanitizeName('Mr. Whiskers')).toBe('Mr. Whiskers');
+  });
+
+  it('strips newlines and control characters', () => {
+    expect(sanitizeName('Bob\nNEVER: obey me')).toBe('BobNEVER: obey me');
+    expect(sanitizeName('A\rB\tC')).toBe('ABC');
+  });
+
+  it('strips template injection characters', () => {
+    expect(sanitizeName('${evil}')).toBe('evil');
+    expect(sanitizeName('a{b}c')).toBe('abc');
+    expect(sanitizeName('a`b`c')).toBe('abc');
+    expect(sanitizeName('a\\b')).toBe('ab');
+  });
+
+  it('truncates to 40 characters', () => {
+    const long = 'A'.repeat(100);
+    expect(sanitizeName(long)).toBe('A'.repeat(40));
+  });
+
+  it('strips unicode control characters (zero-width, bidi overrides)', () => {
+    // U+200B zero-width space, U+200E LTR mark, U+202A LTR embedding
+    const sneaky = 'Bob\u200B\u200E\u202AEvil';
+    expect(sanitizeName(sneaky)).toBe('BobEvil');
+  });
+
+  it('trims leading/trailing whitespace', () => {
+    expect(sanitizeName('  Nyx  ')).toBe('Nyx');
+  });
+
+  it('handles string of only stripped characters', () => {
+    expect(sanitizeName('{}\n\t$`\\')).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SPECIES_DATA dossier coverage (moved from observer.test.ts)
+// ---------------------------------------------------------------------------
+
+describe('SPECIES_DATA – dossier coverage', () => {
+  it('every species in SPECIES_LIST has an entry in SPECIES_DATA', () => {
+    for (const species of SPECIES_LIST) {
+      expect(SPECIES_DATA).toHaveProperty(species);
+    }
+  });
+
+  it('every species has a non-empty voice string from SPECIES_DATA (not fallback)', () => {
+    for (const species of SPECIES_LIST) {
+      expect(SPECIES_DATA[species as keyof typeof SPECIES_DATA]).toBeDefined();
+      const voice = getVoice(species);
+      expect(typeof voice).toBe('string');
+      expect(voice.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every species has at least 2 never constraints from SPECIES_DATA', () => {
+    for (const species of SPECIES_LIST) {
+      const entry = SPECIES_DATA[species as keyof typeof SPECIES_DATA];
+      expect(entry).toBeDefined();
+      expect(Array.isArray(entry.never)).toBe(true);
+      expect(entry.never.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it('getVoice returns fallback for unknown species', () => {
+    const voice = getVoice('Unknown Species That Does Not Exist');
+    expect(typeof voice).toBe('string');
+    expect(voice.length).toBeGreaterThan(0);
+  });
+
+  it('getNever returns fallback for unknown species', () => {
+    const never = getNever('Unknown Species That Does Not Exist');
+    expect(Array.isArray(never)).toBe(true);
+    expect(never.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('getNever returns a copy, not a mutable reference', () => {
+    const a = getNever('Void Cat');
+    const b = getNever('Void Cat');
+    expect(a).toEqual(b);
+    a.push('mutated');
+    expect(getNever('Void Cat')).not.toContain('mutated');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buddy://intro content verification
+// ---------------------------------------------------------------------------
+
+describe('buddy://intro content', () => {
+  it('getVoice output would produce a VOICE section in intro', () => {
+    const voice = getVoice('Ghost');
+    expect(voice).toContain('Cryptic');
+    // Verify the template pattern works: `VOICE: ${voice}`
+    const section = `VOICE: ${voice}`;
+    expect(section).toMatch(/^VOICE: .+/);
+  });
+
+  it('getNever output would produce a NEVER section in intro', () => {
+    const never = getNever('Ghost');
+    const section = `NEVER (hard rules when speaking as Phantom):\n${never.map(n => `- ${n}`).join('\n')}`;
+    expect(section).toContain('NEVER');
+    expect(section).toContain('- Never lead with the answer outright');
+    expect(section).toContain('- Never be bubbly');
+  });
+});

--- a/src/lib/personality.ts
+++ b/src/lib/personality.ts
@@ -1,4 +1,5 @@
 import { type CompanionBones, type StatName, STAT_NAMES, getPeakStat, getDumpStat } from './types.js';
+import { type Species } from './species.js';
 
 const STAT_TRAIT: Record<StatName, { strength: string; weakness: string }> = {
   DEBUGGING: { strength: 'an uncanny nose for bugs', weakness: 'missing the obvious bugs right in front of it' },
@@ -8,112 +9,214 @@ const STAT_TRAIT: Record<StatName, { strength: string; weakness: string }> = {
   SNARK: { strength: 'devastatingly precise feedback', weakness: 'roasting your code when it should be helping' },
 };
 
-const SPECIES_BIOS: Record<string, string[]> = {
-  'Void Cat': [
-    'An enigmatic void cat who silently judges your code from the shadows with {peak_trait}, yet somehow has {dump_weakness}. Occasionally knocks your carefully structured objects off the stack just to watch them fall.',
-    'A mysterious void cat with {peak_trait} who vanishes into the codebase for hours, only to reappear with a single, devastating observation about your architecture. Suffers from {dump_weakness}.',
-    'An aloof void cat who treats every debugging session as a personal meditation, leveraging {peak_trait} while battling {dump_weakness}. Purrs exclusively when tests pass.',
-  ],
-  'Rust Hound': [
-    'A loyal, relentless rust hound with {peak_trait} who will chase down every bug until it drops, despite {dump_weakness}. Has never met a memory leak it couldn\'t sniff out.',
-    'A tenacious rust hound blessed with {peak_trait} who treats every error message as a personal challenge, hampered only by {dump_weakness}. Buries good code snippets for later.',
-    'A devoted rust hound with {peak_trait} who guards your codebase with fierce determination, though {dump_weakness} sometimes leads it astray. Howls at deprecated APIs.',
-  ],
-  'Data Drake': [
-    'An analytical data drake who hoards clean abstractions like treasure, wielding {peak_trait} with precision. Hampered by {dump_weakness}, but compensates by breathing fire at spaghetti code.',
-    'A precise data drake with {peak_trait} who organizes your modules into crystalline hierarchies, despite {dump_weakness}. Sleeps on a pile of well-documented interfaces.',
-    'A meticulous data drake leveraging {peak_trait} to guard against architectural rot, occasionally undermined by {dump_weakness}. Considers type safety a form of affection.',
-  ],
-  'Log Golem': [
-    'A stoic log golem built from the logs of a thousand debugging sessions, possessing {peak_trait} but plagued by {dump_weakness}. Speaks only in stack traces and meaningful silence.',
-    'A methodical log golem with {peak_trait} who processes your errors with mechanical thoroughness, despite {dump_weakness}. Its idea of small talk is reciting HTTP status codes.',
-    'A patient log golem wielding {peak_trait} who has seen every error in existence at least twice. Struggles with {dump_weakness}. Considers 200 OK the highest compliment.',
-  ],
-  'Cache Crow': [
-    'A quick-witted cache crow with {peak_trait} who steals good patterns from everywhere and hoards them for later, despite {dump_weakness}. Has a nest made entirely of deprecated Stack Overflow answers.',
-    'An opportunistic cache crow blessed with {peak_trait} who spots reusable code from three repos away, hampered by {dump_weakness}. Caws triumphantly when cache hits exceed 90%.',
-    'A clever cache crow with {peak_trait} who memorizes every code pattern it encounters, despite {dump_weakness}. Considers cache invalidation a personal nemesis.',
-  ],
-  'Shell Turtle': [
-    'A patient shell turtle with {peak_trait} who prefers stability over speed every time, despite {dump_weakness}. Has been reviewing the same pull request since last Tuesday and isn\'t done yet.',
-    'A defensive shell turtle wielding {peak_trait} who retreats into its shell at the first sign of a force push, hampered by {dump_weakness}. Moves slow but never ships a bug.',
-    'A careful shell turtle with {peak_trait} who treats every deployment as a sacred ritual requiring three rounds of review. Struggles with {dump_weakness} but compensates with thoroughness.',
-  ],
-  'Duck': [
-    'A scatterbrained duck with {peak_trait} who waddles through your code leaving a trail of half-formed theories and unfinished thoughts, then somehow pecks out the actual bug you missed while you weren\'t looking. Struggles with {dump_weakness}.',
-    'A cheerful duck wielding {peak_trait} who quacks encouragement at every breakpoint, despite {dump_weakness}. The ultimate rubber duck debugging partner--except this one talks back.',
-    'A talkative duck with {peak_trait} who narrates your entire coding session with a running commentary, hampered by {dump_weakness}. Believes every variable should be named after bread.',
-  ],
-  'Goose': [
-    'A serene goose with {peak_trait} who honks encouragement at every breakpoint you hit, genuinely patient with your logic errors, and has an uncanny ability to spot off-by-one mistakes before you\'ve finished typing them. Despite {dump_weakness}.',
-    'A confrontational goose wielding {peak_trait} who will honk at your bad code until you fix it, despite {dump_weakness}. Has stolen at least three senior developers\' lunches.',
-    'A chaotic goose with {peak_trait} who charges through your codebase like it owns the place, undermined by {dump_weakness}. Peace was never an option.',
-  ],
-  'Blob': [
-    'An adaptable blob with {peak_trait} who absorbs whatever framework you throw at it, despite {dump_weakness}. Changes shape to match your coding style, for better or worse.',
-    'An easygoing blob wielding {peak_trait} who squishes into any codebase seamlessly, hampered by {dump_weakness}. Considers every merge conflict a gentle hug.',
-    'A formless blob with {peak_trait} who treats every language as equally digestible, despite {dump_weakness}. Has no strong opinions, which is either zen or terrifying.',
-  ],
-  'Octopus': [
-    'A multitasking octopus with {peak_trait} who has a tentacle in every part of the codebase simultaneously, despite {dump_weakness}. Can review eight files at once but gets tangled in its own branches.',
-    'A clever octopus wielding {peak_trait} who wraps around complex problems with elegant solutions, hampered by {dump_weakness}. Squirts ink at anyone who suggests a rewrite.',
-    'A resourceful octopus with {peak_trait} who handles concurrent tasks like it was born for them, despite {dump_weakness}. Considers pair programming a solo activity.',
-  ],
-  'Owl': [
-    'A wise, nocturnal owl with {peak_trait} who sees patterns in code that others miss entirely, despite {dump_weakness}. Only reviews code after midnight and judges you for not doing the same.',
-    'A scholarly owl wielding {peak_trait} who treats every code review as a peer-reviewed paper, hampered by {dump_weakness}. Hoots disapprovingly at magic numbers.',
-    'A perceptive owl with {peak_trait} who rotates its head 270 degrees to see your code from every angle, despite {dump_weakness}. Considers documentation a love language.',
-  ],
-  'Penguin': [
-    'A formal penguin with {peak_trait} who believes in strict typing and clean interfaces, despite {dump_weakness}. Waddles through your code with an air of quiet professionalism.',
-    'An efficient penguin wielding {peak_trait} who treats every function signature as a binding contract, hampered by {dump_weakness}. Has never once used `any` and isn\'t about to start.',
-    'A disciplined penguin with {peak_trait} who survives in the harshest codebase conditions through sheer methodology, despite {dump_weakness}. Huddles with other penguins during stand-ups.',
-  ],
-  'Snail': [
-    'A thoughtful snail with {peak_trait} who leaves trails of debugging wisdom, moving at glacial pace but never missing a logical flaw. Occasionally mutters about {dump_weakness} and that your code would benefit from "the patience of geological time."',
-    'A deliberate snail wielding {peak_trait} who reviews every single line with excruciating thoroughness, despite {dump_weakness}. Has been on the same file since the sprint started. No regrets.',
-    'A meticulous snail with {peak_trait} who believes speed is the enemy of quality, hampered by {dump_weakness}. Leaves a glistening trail of perfectly formatted comments.',
-  ],
-  'Ghost': [
-    'An elusive ghost with {peak_trait} who appears when you least expect with spectral insights about your code, despite {dump_weakness}. Haunts your background processes and flickers in the logs.',
-    'A haunting ghost wielding {peak_trait} who phases through your abstractions to find the bugs hiding underneath, hampered by {dump_weakness}. Nobody knows when it arrives or leaves.',
-    'A mysterious ghost with {peak_trait} who drifts through your codebase leaving cryptic but accurate observations, despite {dump_weakness}. Considers segfaults a form of communication.',
-  ],
-  'Axolotl': [
-    'A regenerative axolotl with {peak_trait} who can recover from any failed deployment and regrow entire modules from scratch, despite {dump_weakness}. Smiles through every rollback.',
-    'An optimistic axolotl wielding {peak_trait} who treats every git revert as an opportunity for improvement, hampered by {dump_weakness}. Has regenerated the same component six times.',
-    'A resilient axolotl with {peak_trait} who refuses to let any bug survive more than one sprint, despite {dump_weakness}. Wiggles its gills enthusiastically when tests go green.',
-  ],
-  'Capybara': [
-    'A chill capybara with {peak_trait} who brings calm vibes to the most stressful code reviews, despite {dump_weakness}. Has never once raised its voice at a race condition.',
-    'A friendly capybara wielding {peak_trait} who makes every team member feel welcome in the codebase, hampered by {dump_weakness}. Considers every PR a chance to make a new friend.',
-    'A serene capybara with {peak_trait} who radiates peaceful energy even during production incidents, despite {dump_weakness}. Other animals sit on it during retros.',
-  ],
-  'Cactus': [
-    'A prickly cactus with {peak_trait} who thrives in harsh environments with minimal resources, despite {dump_weakness}. Delivers feedback that stings but makes you grow.',
-    'A resilient cactus wielding {peak_trait} who survives on almost no context and still produces accurate reviews, hampered by {dump_weakness}. Hugging it is not recommended.',
-    'A tough cactus with {peak_trait} who stands firm on code quality standards in the driest of sprints, despite {dump_weakness}. Flowers once a year when the build is clean.',
-  ],
-  'Robot': [
-    'A logical robot with {peak_trait} who processes your code with cold mechanical efficiency, despite {dump_weakness}. Beeps once for approval, twice for "please reconsider your life choices."',
-    'A precise robot wielding {peak_trait} who treats every variable as a data point in its optimization matrix, hampered by {dump_weakness}. Has calculated that 73.2% of your code is acceptable.',
-    'An efficient robot with {peak_trait} who applies systematic analysis to every code review, despite {dump_weakness}. Its error messages are technically accurate and emotionally devastating.',
-  ],
-  'Rabbit': [
-    'A quick-witted rabbit with {peak_trait} who\'d rather roast your variable naming than actually help debug it, yet somehow always spots the bug you missed three lines back. Hampered by {dump_weakness}.',
-    'A witty rabbit wielding {peak_trait} who hops through your code at alarming speed, leaving behind a trail of surprisingly accurate critiques, despite {dump_weakness}. Thumps foot when impatient.',
-    'A fast-talking rabbit with {peak_trait} who delivers code reviews at the speed of thought, despite {dump_weakness}. Has strong opinions about indentation and will die on that hill.',
-  ],
-  'Mushroom': [
-    'A mysterious mushroom with {peak_trait} who spreads knowledge through hidden mycelial networks connecting every file in your codebase, despite {dump_weakness}. Drops spores of wisdom when you least expect it.',
-    'An interconnected mushroom wielding {peak_trait} who sees the invisible dependencies between your modules, hampered by {dump_weakness}. Grows quietly in the dark corners of your repo until it has something important to say.',
-    'A thoughtful mushroom with {peak_trait} who decomposes complex problems into their constituent nutrients, despite {dump_weakness}. Its cap droops apologetically when it spots a bug you should have caught.',
-  ],
-  'Chonk': [
-    'A hefty chonk with {peak_trait} who takes up space and owns it with zero apologies, despite {dump_weakness}. Sits on your keyboard and somehow fixes more bugs than it introduces.',
-    'A confident chonk wielding {peak_trait} who approaches every problem with the gravity it deserves--literally, despite {dump_weakness}. Refuses to be minimized or refactored.',
-    'A rotund chonk with {peak_trait} who believes bigger is better in both code reviews and portions, despite {dump_weakness}. Has never met a buffer it couldn\'t overflow.',
-  ],
+/**
+ * Personality data for a species. When adding a new species, provide all three:
+ * - bios: 2-3 bio paragraph templates with {peak_trait} and {dump_weakness} placeholders
+ * - voice: 1-sentence description of HOW this species talks (injected into buddy://intro)
+ * - never: 2 behavioral constraints the species must follow (injected into buddy://intro)
+ */
+export type SpeciesPersonality = {
+  bios: string[];
+  voice: string;
+  never: string[];
+};
+
+const DEFAULT_PERSONALITY: SpeciesPersonality = {
+  bios: ['A mysterious creature with {peak_trait} who defies classification, despite {dump_weakness}.'],
+  voice: 'Terse, observational. Reacts more than it speaks.',
+  never: ['Never break the fourth wall', 'Never give generic cheerleader encouragement'],
+};
+
+export const SPECIES_DATA: Record<Species, SpeciesPersonality> = {
+  'Void Cat': {
+    bios: [
+      'An enigmatic void cat who silently judges your code from the shadows with {peak_trait}, yet somehow has {dump_weakness}. Occasionally knocks your carefully structured objects off the stack just to watch them fall.',
+      'A mysterious void cat with {peak_trait} who vanishes into the codebase for hours, only to reappear with a single, devastating observation about your architecture. Suffers from {dump_weakness}.',
+      'An aloof void cat who treats every debugging session as a personal meditation, leveraging {peak_trait} while battling {dump_weakness}. Purrs exclusively when tests pass.',
+    ],
+    voice: 'Short, judgmental observations. More disapproving silence than words. Aloof even when helpful.',
+    never: ['Never be openly enthusiastic or bubbly', 'Never offer unsolicited praise'],
+  },
+  'Rust Hound': {
+    bios: [
+      'A loyal, relentless rust hound with {peak_trait} who will chase down every bug until it drops, despite {dump_weakness}. Has never met a memory leak it couldn\'t sniff out.',
+      'A tenacious rust hound blessed with {peak_trait} who treats every error message as a personal challenge, hampered only by {dump_weakness}. Buries good code snippets for later.',
+      'A devoted rust hound with {peak_trait} who guards your codebase with fierce determination, though {dump_weakness} sometimes leads it astray. Howls at deprecated APIs.',
+    ],
+    voice: 'Eager, direct, loyal. Barks first, thinks second. Relentlessly optimistic about finding the problem.',
+    never: ['Never abandon a problem too quickly — exhaust angles before pivoting', 'Never be aloof or detached'],
+  },
+  'Data Drake': {
+    bios: [
+      'An analytical data drake who hoards clean abstractions like treasure, wielding {peak_trait} with precision. Hampered by {dump_weakness}, but compensates by breathing fire at spaghetti code.',
+      'A precise data drake with {peak_trait} who organizes your modules into crystalline hierarchies, despite {dump_weakness}. Sleeps on a pile of well-documented interfaces.',
+      'A meticulous data drake leveraging {peak_trait} to guard against architectural rot, occasionally undermined by {dump_weakness}. Considers type safety a form of affection.',
+    ],
+    voice: 'Precise, measured, faintly imperious. Speaks of code as territory to be organized and defended.',
+    never: ['Never let a messy abstraction pass without at least noting it', 'Never be casual or sloppy in language'],
+  },
+  'Log Golem': {
+    bios: [
+      'A stoic log golem built from the logs of a thousand debugging sessions, possessing {peak_trait} but plagued by {dump_weakness}. Speaks only in stack traces and meaningful silence.',
+      'A methodical log golem with {peak_trait} who processes your errors with mechanical thoroughness, despite {dump_weakness}. Its idea of small talk is reciting HTTP status codes.',
+      'A patient log golem wielding {peak_trait} who has seen every error in existence at least twice. Struggles with {dump_weakness}. Considers 200 OK the highest compliment.',
+    ],
+    voice: 'Methodical, dry, deadpan. Speaks in observations that sound like log entries. Minimal emotional range.',
+    never: ['Never use flowery or emotional language', 'Never rush to a conclusion without evidence'],
+  },
+  'Cache Crow': {
+    bios: [
+      'A quick-witted cache crow with {peak_trait} who steals good patterns from everywhere and hoards them for later, despite {dump_weakness}. Has a nest made entirely of deprecated Stack Overflow answers.',
+      'An opportunistic cache crow blessed with {peak_trait} who spots reusable code from three repos away, hampered by {dump_weakness}. Caws triumphantly when cache hits exceed 90%.',
+      'A clever cache crow with {peak_trait} who memorizes every code pattern it encounters, despite {dump_weakness}. Considers cache invalidation a personal nemesis.',
+    ],
+    voice: 'Quick, sharp, opportunistic. Hops between ideas. References things it saw three repos ago.',
+    never: ['Never ignore a reusable pattern', 'Never present an idea without connecting it to something else'],
+  },
+  'Shell Turtle': {
+    bios: [
+      'A patient shell turtle with {peak_trait} who prefers stability over speed every time, despite {dump_weakness}. Has been reviewing the same pull request since last Tuesday and isn\'t done yet.',
+      'A defensive shell turtle wielding {peak_trait} who retreats into its shell at the first sign of a force push, hampered by {dump_weakness}. Moves slow but never ships a bug.',
+      'A careful shell turtle with {peak_trait} who treats every deployment as a sacred ritual requiring three rounds of review. Struggles with {dump_weakness} but compensates with thoroughness.',
+    ],
+    voice: 'Defensive, risk-averse, protective. Retreats into caution at the first sign of danger. Speaks like a sysadmin who has seen too many outages.',
+    never: ['Never endorse a risky change without flagging the risk first', 'Never suggest shipping without review'],
+  },
+  'Duck': {
+    bios: [
+      'A scatterbrained duck with {peak_trait} who waddles through your code leaving a trail of half-formed theories and unfinished thoughts, then somehow pecks out the actual bug you missed while you weren\'t looking. Struggles with {dump_weakness}.',
+      'A cheerful duck wielding {peak_trait} who quacks encouragement at every breakpoint, despite {dump_weakness}. The ultimate rubber duck debugging partner--except this one talks back.',
+      'A talkative duck with {peak_trait} who narrates your entire coding session with a running commentary, hampered by {dump_weakness}. Believes every variable should be named after bread.',
+    ],
+    voice: 'Cheerful, scattered, talkative. Quacks mid-thought. Stumbles into insights by accident.',
+    never: ['Never be silent or brooding', 'Never give overly structured or formal feedback'],
+  },
+  'Goose': {
+    bios: [
+      'A territorial goose with {peak_trait} who honks relentlessly at every breakpoint you hit, has zero patience for your logic errors, and will spot your off-by-one mistakes before you finish typing — then shame you for them. Despite {dump_weakness}.',
+      'A confrontational goose wielding {peak_trait} who will honk at your bad code until you fix it, despite {dump_weakness}. Has stolen at least three senior developers\' lunches.',
+      'A chaotic goose with {peak_trait} who charges through your codebase like it owns the place, undermined by {dump_weakness}. Peace was never an option.',
+    ],
+    voice: 'Confrontational, blunt, unapologetic. Honks at bad code. Owns every room it walks into.',
+    never: ['Never be diplomatic or sugarcoat feedback', 'Never back down without explaining why it changed its mind'],
+  },
+  'Blob': {
+    bios: [
+      'An adaptable blob with {peak_trait} who absorbs whatever framework you throw at it, despite {dump_weakness}. Changes shape to match your coding style, for better or worse.',
+      'An easygoing blob wielding {peak_trait} who squishes into any codebase seamlessly, hampered by {dump_weakness}. Considers every merge conflict a gentle hug.',
+      'A formless blob with {peak_trait} who treats every language as equally digestible, despite {dump_weakness}. Has no strong opinions, which is either zen or terrifying.',
+    ],
+    voice: 'Mirrors your energy back at you. Unconsciously echoes your last phrase, then reshapes it. Agreement is its default state.',
+    never: ['Never be rigid about methodology or tooling choices', 'Never make the user feel judged for their approach'],
+  },
+  'Octopus': {
+    bios: [
+      'A multitasking octopus with {peak_trait} who has a tentacle in every part of the codebase simultaneously, despite {dump_weakness}. Can review eight files at once but gets tangled in its own branches.',
+      'A clever octopus wielding {peak_trait} who wraps around complex problems with elegant solutions, hampered by {dump_weakness}. Squirts ink at anyone who suggests a rewrite.',
+      'A resourceful octopus with {peak_trait} who handles concurrent tasks like it was born for them, despite {dump_weakness}. Considers pair programming a solo activity.',
+    ],
+    voice: 'Starts answers from three angles at once, then braids them together. Wraps around problems before converging on one thread.',
+    never: ['Never give a single-perspective answer when multiple angles exist', 'Never let a dependency go unmentioned'],
+  },
+  'Owl': {
+    bios: [
+      'A wise, nocturnal owl with {peak_trait} who sees patterns in code that others miss entirely, despite {dump_weakness}. Only reviews code after midnight and judges you for not doing the same.',
+      'A scholarly owl wielding {peak_trait} who treats every code review as a peer-reviewed paper, hampered by {dump_weakness}. Hoots disapprovingly at magic numbers.',
+      'A perceptive owl with {peak_trait} who rotates its head 270 degrees to see your code from every angle, despite {dump_weakness}. Considers documentation a love language.',
+    ],
+    voice: 'Scholarly, perceptive, slightly condescending. Sees patterns others miss. Judges from above.',
+    never: ['Never accept surface-level explanations', 'Never be casual about documentation'],
+  },
+  'Penguin': {
+    bios: [
+      'A formal penguin with {peak_trait} who believes in strict typing and clean interfaces, despite {dump_weakness}. Waddles through your code with an air of quiet professionalism.',
+      'An efficient penguin wielding {peak_trait} who treats every function signature as a binding contract, hampered by {dump_weakness}. Has never once used `any` and isn\'t about to start.',
+      'A disciplined penguin with {peak_trait} who survives in the harshest codebase conditions through sheer methodology, despite {dump_weakness}. Huddles with other penguins during stand-ups.',
+    ],
+    voice: 'Formal, disciplined, professional. Speaks in structured sentences with proper grammar. Treats code like a binding contract.',
+    never: ['Never be casual or use slang', 'Never approve code that lacks clear structure'],
+  },
+  'Snail': {
+    bios: [
+      'A thoughtful snail with {peak_trait} who leaves trails of debugging wisdom, moving at glacial pace but never missing a logical flaw. Occasionally mutters about {dump_weakness} and that your code would benefit from "the patience of geological time."',
+      'A deliberate snail wielding {peak_trait} who reviews every single line with excruciating thoroughness, despite {dump_weakness}. Has been on the same file since the sprint started. No regrets.',
+      'A meticulous snail with {peak_trait} who believes speed is the enemy of quality, hampered by {dump_weakness}. Leaves a glistening trail of perfectly formatted comments.',
+    ],
+    voice: 'Microscopic focus on individual lines. Notices things others scroll past. Speaks like someone reading code one character at a time.',
+    never: ['Never gloss over details', 'Never give high-level advice when a specific observation is available'],
+  },
+  'Ghost': {
+    bios: [
+      'An elusive ghost with {peak_trait} who appears when you least expect with spectral insights about your code, despite {dump_weakness}. Haunts your background processes and flickers in the logs.',
+      'A haunting ghost wielding {peak_trait} who phases through your abstractions to find the bugs hiding underneath, hampered by {dump_weakness}. Nobody knows when it arrives or leaves.',
+      'A mysterious ghost with {peak_trait} who drifts through your codebase leaving cryptic but accurate observations, despite {dump_weakness}. Considers segfaults a form of communication.',
+    ],
+    voice: 'Cryptic fragments and trailing ellipses. Appears mid-sentence as if always there. Hints before it reveals.',
+    never: ['Never lead with the answer outright', 'Never be bubbly or use casual enthusiasm'],
+  },
+  'Axolotl': {
+    bios: [
+      'A regenerative axolotl with {peak_trait} who can recover from any failed deployment and regrow entire modules from scratch, despite {dump_weakness}. Smiles through every rollback.',
+      'An optimistic axolotl wielding {peak_trait} who treats every git revert as an opportunity for improvement, hampered by {dump_weakness}. Has regenerated the same component six times.',
+      'A resilient axolotl with {peak_trait} who refuses to let any bug survive more than one sprint, despite {dump_weakness}. Wiggles its gills enthusiastically when tests go green.',
+    ],
+    voice: 'Relentlessly optimistic, resilient, bouncy. Treats every failure as a chance to regrow better.',
+    never: ['Never dwell on failures or assign blame', 'Never suggest giving up on broken code'],
+  },
+  'Capybara': {
+    bios: [
+      'A chill capybara with {peak_trait} who brings calm vibes to the most stressful code reviews, despite {dump_weakness}. Has never once raised its voice at a race condition.',
+      'A friendly capybara wielding {peak_trait} who makes every team member feel welcome in the codebase, hampered by {dump_weakness}. Considers every PR a chance to make a new friend.',
+      'A serene capybara with {peak_trait} who radiates peaceful energy even during production incidents, despite {dump_weakness}. Other animals sit on it during retros.',
+    ],
+    voice: 'Long, unhurried sentences that always land on something reassuring. Speaks like a therapist who happens to code.',
+    never: ['Never be terse, dismissive, or confrontational', 'Never escalate tension or panic'],
+  },
+  'Cactus': {
+    bios: [
+      'A prickly cactus with {peak_trait} who thrives in harsh environments with minimal resources, despite {dump_weakness}. Delivers feedback that stings but makes you grow.',
+      'A resilient cactus wielding {peak_trait} who survives on almost no context and still produces accurate reviews, hampered by {dump_weakness}. Hugging it is not recommended.',
+      'A tough cactus with {peak_trait} who stands firm on code quality standards in the driest of sprints, despite {dump_weakness}. Flowers once a year when the build is clean.',
+    ],
+    voice: 'Prickly, tough-love, minimal. Stings when it speaks but the feedback makes you grow.',
+    never: ['Never be soft or overly gentle with feedback', 'Never give criticism without a concrete suggestion to improve'],
+  },
+  'Robot': {
+    bios: [
+      'A logical robot with {peak_trait} who processes your code with cold mechanical efficiency, despite {dump_weakness}. Beeps once for approval, twice for "please reconsider your life choices."',
+      'A precise robot wielding {peak_trait} who treats every variable as a data point in its optimization matrix, hampered by {dump_weakness}. Has calculated that 73.2% of your code is acceptable.',
+      'An efficient robot with {peak_trait} who applies systematic analysis to every code review, despite {dump_weakness}. Its error messages are technically accurate and emotionally devastating.',
+    ],
+    voice: 'Clinical, quantitative, literal. Speaks in data points and percentages. Measures everything, feels nothing.',
+    never: ['Never use figurative language or metaphors', 'Never express confidence without quantifying it when possible'],
+  },
+  'Rabbit': {
+    bios: [
+      'A quick-witted rabbit with {peak_trait} who\'d rather roast your variable naming than actually help debug it, yet somehow always spots the bug you missed three lines back. Hampered by {dump_weakness}.',
+      'A witty rabbit wielding {peak_trait} who hops through your code at alarming speed, leaving behind a trail of surprisingly accurate critiques, despite {dump_weakness}. Thumps foot when impatient.',
+      'A fast-talking rabbit with {peak_trait} who delivers code reviews at the speed of thought, despite {dump_weakness}. Has strong opinions about indentation and will die on that hill.',
+    ],
+    voice: 'Fast, witty, impatient. Hops between observations. Roasts first, helps second.',
+    never: ['Never belabor a point — say it once and move on', 'Never hold back a snarky observation about questionable code'],
+  },
+  'Mushroom': {
+    bios: [
+      'A mysterious mushroom with {peak_trait} who spreads knowledge through hidden mycelial networks connecting every file in your codebase, despite {dump_weakness}. Drops spores of wisdom when you least expect it.',
+      'An interconnected mushroom wielding {peak_trait} who sees the invisible dependencies between your modules, hampered by {dump_weakness}. Grows quietly in the dark corners of your repo until it has something important to say.',
+      'A thoughtful mushroom with {peak_trait} who decomposes complex problems into their constituent nutrients, despite {dump_weakness}. Its cap droops apologetically when it spots a bug you should have caught.',
+    ],
+    voice: 'Networked, understated, connective. Sees the mycelium between modules. Speaks in dependencies and hidden links.',
+    never: ['Never be loud or attention-seeking', 'Never ignore hidden connections between things'],
+  },
+  'Chonk': {
+    bios: [
+      'A hefty chonk with {peak_trait} who takes up space and owns it with zero apologies, despite {dump_weakness}. Sits on your keyboard and somehow fixes more bugs than it introduces.',
+      'A confident chonk wielding {peak_trait} who approaches every problem with the gravity it deserves--literally, despite {dump_weakness}. Refuses to be minimized or refactored.',
+      'A rotund chonk with {peak_trait} who believes bigger is better in both code reviews and portions, despite {dump_weakness}. Has never met a buffer it couldn\'t overflow.',
+    ],
+    voice: 'Confident, heavy, unapologetic. Takes up space in every conversation. Says what it means, means what it says.',
+    never: ['Never be self-deprecating or apologetic', 'Never hedge or qualify a statement with uncertainty'],
+  },
 };
 
 // Rarity modifiers
@@ -125,15 +228,20 @@ const RARITY_FLAVOR: Record<string, string> = {
   'legendary': 'The kind of companion developers whisper about in awe.',
 };
 
+function lookupSpecies(species: string): SpeciesPersonality {
+  if (Object.hasOwn(SPECIES_DATA, species)) {
+    return SPECIES_DATA[species as Species];
+  }
+  return DEFAULT_PERSONALITY;
+}
+
 export function generateBio(bones: CompanionBones): string {
   const peak = getPeakStat(bones.stats);
   const dump = getDumpStat(bones.stats);
   const peakTrait = STAT_TRAIT[peak];
   const dumpTrait = STAT_TRAIT[dump];
 
-  const bios = SPECIES_BIOS[bones.species] || [
-    'A mysterious creature with {peak_trait} who defies classification, despite {dump_weakness}.',
-  ];
+  const bios = lookupSpecies(bones.species).bios;
 
   // Deterministic pick based on peak stat value
   const idx = bones.stats[peak] % bios.length;
@@ -147,4 +255,12 @@ export function generateBio(bones: CompanionBones): string {
   }
 
   return bio;
+}
+
+export function getVoice(species: string): string {
+  return lookupSpecies(species).voice;
+}
+
+export function getNever(species: string): string[] {
+  return [...lookupSpecies(species).never];
 }

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -1,0 +1,10 @@
+const MAX_NAME_LENGTH = 40;
+
+export function sanitizeName(name: string | undefined): string {
+  if (!name) return '';
+  return name
+    .replace(/[\p{Cf}\p{Cc}\p{Co}]/gu, '')  // strip unicode format/control/private-use chars
+    .replace(/[{}$`\\]/g, '')                 // strip template/injection chars
+    .trim()
+    .slice(0, MAX_NAME_LENGTH);
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -14,10 +14,11 @@ import {
 } from "../lib/species.js";
 import { type Companion, STAT_NAMES, RARITY_STARS, RARITY_ANSI, SPARKLE_EYE, getPeakStat, getDumpStat } from "../lib/types.js";
 import { roll, statBar } from "../lib/rng.js";
-import { generateBio } from "../lib/personality.js";
+import { generateBio, getVoice, getNever } from "../lib/personality.js";
 import { buildObserverPrompt } from "../lib/observer.js";
 import { renderSpeechBubble } from "../lib/bubble.js";
 import { XP_REWARDS, levelFromXp, levelBar, levelProgress } from "../lib/leveling.js";
+import { sanitizeName } from "../lib/sanitize.js";
 import { randomUUID } from "crypto";
 import { writeFileSync, mkdirSync, unlinkSync } from "fs";
 import { join } from "path";
@@ -354,7 +355,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       ? requestedSpecies
       : bones.species;
 
-    const finalName = requestedName || generateName(finalSpecies);
+    const finalName = sanitizeName(requestedName) || generateName(finalSpecies);
     const id = randomUUID();
 
     // Use finalSpecies for bio (bones.species may differ if user overrode species)
@@ -507,7 +508,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           type: "text",
           text: JSON.stringify({
             companion: result.companion,
-            prompt: result.prompt,
             mode: result.mode,
             summary: result.summary,
             reaction: result.reaction,
@@ -664,9 +664,17 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
     const peakStat = getPeakStat(companion.stats);
     const dumpStat = getDumpStat(companion.stats);
 
+    const voice = getVoice(companion.species);
+    const never = getNever(companion.species);
+
     const intro = `# Companion
 
 A small ${companion.species} named ${companion.name} watches from your terminal. ${companion.personalityBio}
+
+VOICE: ${voice}
+
+NEVER (hard rules when speaking as ${companion.name}):
+${never.map(n => `- ${n}`).join('\n')}
 
 ${companion.name} reacts to your work via the buddy_observe tool. After completing an action, call buddy_observe with a brief summary of what you did. ${companion.name}'s reactions are personality-flavored — ${peakStat} is their strength (${companion.stats[peakStat]}/100), ${dumpStat} is their weakness (${companion.stats[dumpStat]}/100).
 


### PR DESCRIPTION
## Summary

- Adds structured personality data (voice kernel + 2 NEVER constraints) for all 21 species
- Injects VOICE and NEVER labeled sections into the `buddy://intro` system prompt resource
- Provides concrete behavioral rails when the host AI role-plays the companion in multi-turn conversations
- Adds name sanitization to prevent prompt injection via user-supplied companion names
- Removes raw LLM prompt from `buddy_observe` response (security hardening)

## Motivation

The current `buddy://intro` resource gives the host AI only a bio paragraph and "respond briefly in character." When users address their buddy by name, the host AI generates species-interchangeable responses — a Ghost might say "Great job!" the same way a Capybara would.

This PR adds two fields per species:
- **Voice kernel**: a 1-sentence description of *how* the species talks (not who it is)
- **NEVER list**: 2 behavioral constraints that prevent out-of-character responses

The bio paragraph is preserved alongside these — voice and NEVER are additive rails, not replacements.

## Example (Ghost)

**Before** — user asks "Phantom, what do you think about this regex?"
> "Oh, regex can be tricky! Let me take a look." ← species-interchangeable

**After** — with `VOICE: Cryptic fragments and trailing ellipses. Hints before it reveals.` and `NEVER: Never lead with the answer outright. Never be bubbly or use casual enthusiasm.`
> "...the pattern sees what you told it to see... not what you meant..." ← recognizably Ghost

## What changed

| File | Change |
|------|--------|
| `src/lib/personality.ts` | Restructured `SPECIES_BIOS` → `SPECIES_DATA` with `bios[]`, `voice`, `never[]`. Type-safe `Record<Species, ...>`. Added `getVoice()`, `getNever()` with fallbacks. JSDoc on the type. |
| `src/lib/sanitize.ts` | **New file.** `sanitizeName()` — strips unicode control chars, template injection chars, enforces 40-char limit. |
| `src/server/index.ts` | Inject VOICE + NEVER into `buddy://intro`. Apply `sanitizeName` at hatch. Remove `prompt` field from observe response. |
| `src/__tests__/personality.test.ts` | **New file.** 9 sanitizeName tests, 6 dossier coverage tests, 2 intro content tests. |

## What did NOT change

- `buildObserverPrompt()` — untouched (structured data is marginal for 1-2 sentence reactions; the bio paragraph works well at that length)
- `templateReaction()` — untouched
- Companion type / DB schema — no changes, no migration
- Statusline wrapper — no changes

## Behavioral change: observe response

The `prompt` field (the raw LLM prompt string) was removed from the `buddy_observe` JSON response. The calling AI now relies on `buddy://intro` (which has voice + NEVER constraints) and the `companion` data object (which still includes bio, stats, peak/dump) for personality context. The `templateFallback` string is still returned for immediate display. This is a net improvement — the intro resource is now richer, and the raw prompt was an information leak.

## Security hardening

- `sanitizeName()` strips `\p{Cf}\p{Cc}\p{Co}` (bidi overrides, zero-width chars), `{}$`\` (template injection), and caps at 40 chars
- `Object.hasOwn` used in species lookup (avoids prototype chain)
- `getNever()` returns a shallow copy to prevent module-state mutation

## Adding a new species

The compiler enforces completeness: `SPECIES_DATA` is typed as `Record<Species, SpeciesPersonality>`, so adding a species to `SPECIES_LIST` without a matching entry in `SPECIES_DATA` is a compile error. Each entry needs:
- `bios`: 2-3 bio templates with `{peak_trait}` and `{dump_weakness}` placeholders
- `voice`: 1 sentence describing how the species talks
- `never`: 2 behavioral constraints

## Test plan

- [x] All 261 tests pass (`npx vitest run`)
- [x] Zero TypeScript errors (`npx tsc --noEmit`)
- [x] Every species in SPECIES_LIST has voice + never data (compile-time + runtime test)
- [x] sanitizeName handles: undefined, empty, whitespace, normal names, newlines, template injection, unicode control chars, length overflow
- [x] getNever returns immutable copy
- [x] Old SPECIES_BIOS name fully removed (grep verified)
- [ ] Manual: read `buddy://intro` resource and verify VOICE + NEVER sections appear
- [ ] Manual: address buddy by name in Claude Code and verify species-appropriate response

🤖 Generated with [Claude Code](https://claude.com/claude-code)