### PR TITLE
Add uninstall support and species flavor polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ The observer infers your buddy's reaction state (impressed, concerned, amused, e
 | What data does Buddy store? | Buddy stores companion state locally in a SQLite database at `~/.buddy/buddy.db`. That includes things like your companion's name, species, level, XP, mood, and saved memories. |
 | Is this tied to one client? | No. Buddy is CLI-first and works through MCP, so it is meant for agentic CLI clients rather than one specific editor UI. Some integrations are better than others, and optional statusline/HUD features depend on what a host CLI exposes. |
 | Do I need Claude HUD or a patched Codex build to use Buddy? | No. Buddy core works without any HUD integration. Claude HUD-style statuslines and the experimental Codex footer are optional presentation layers, not core dependencies. |
-| Can I remove or reset Buddy later? | Yes. You can reset your companion with `buddy_respawn`, or remove Buddy entirely by deleting its MCP config entry and the local Buddy data directory if you no longer want the saved state. |
+| Can I remove or reset Buddy later? | Yes. You can reset your companion with `buddy_respawn`, or run the uninstall script to remove Buddy's MCP config, injected prompt instructions, and local files. On macOS/Linux: `curl -fsSL https://raw.githubusercontent.com/fiorastudio/buddy/master/uninstall.sh | bash`. On Windows PowerShell: `irm https://raw.githubusercontent.com/fiorastudio/buddy/master/uninstall.ps1 | iex`. |
 
 ### 🎭 Rich Personality Bios
 

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -1,0 +1,123 @@
+# Buddy MCP Server — Windows PowerShell Uninstaller
+#
+# Usage:
+#   irm https://raw.githubusercontent.com/fiorastudio/buddy/master/uninstall.ps1 | iex
+
+param(
+  [switch]$Force,
+  [switch]$KeepData
+)
+
+$ErrorActionPreference = "Stop"
+$InstallDir = "$env:USERPROFILE\.buddy\server"
+$DataDir = "$env:USERPROFILE\.buddy"
+$StatusFile = "$env:USERPROFILE\.claude\buddy-status.json"
+
+Write-Host ""
+Write-Host "  Buddy MCP Server Uninstaller" -ForegroundColor Cyan
+Write-Host "  ────────────────────────────" -ForegroundColor Cyan
+Write-Host ""
+
+function Remove-BuddyFromJsonConfig($configPath, $cliName) {
+  if (!(Test-Path $configPath)) { return }
+
+  try {
+    $content = Get-Content $configPath -Raw | ConvertFrom-Json
+    if (!$content.mcpServers -or !$content.mcpServers.buddy) { return }
+    $content.mcpServers.PSObject.Properties.Remove('buddy')
+    if ($content.mcpServers.PSObject.Properties.Count -eq 0) {
+      $content.PSObject.Properties.Remove('mcpServers')
+    }
+    $content | ConvertTo-Json -Depth 8 | Set-Content $configPath -Encoding UTF8
+    Write-Host "  ✓ Removed Buddy MCP entry from $cliName ($configPath)" -ForegroundColor Green
+  } catch {
+    Write-Host "  ! Could not update $cliName config ($configPath)" -ForegroundColor Yellow
+  }
+}
+
+function Remove-BuddyPromptBlock($filePath, $cliName) {
+  if (!(Test-Path $filePath)) { return }
+
+  $content = Get-Content $filePath -Raw
+  $pattern = '(?s)\s*<!-- buddy-companion -->.*?<!-- /buddy-companion -->\s*'
+  if ($content -notmatch 'buddy-companion') { return }
+
+  try {
+    $updated = ([regex]::Replace($content, $pattern, '')).Trim()
+    if ($updated.Length -gt 0) {
+      Set-Content -Path $filePath -Value ($updated + "`n") -Encoding UTF8
+    } else {
+      Set-Content -Path $filePath -Value '' -Encoding UTF8
+    }
+    Write-Host "  ✓ Removed Buddy instructions from $cliName ($filePath)" -ForegroundColor Green
+  } catch {
+    Write-Host "  ! Could not update $cliName prompt file ($filePath)" -ForegroundColor Yellow
+  }
+}
+
+Write-Host "  This will remove Buddy MCP config and prompt instructions."
+if ($KeepData) {
+  Write-Host "  Local Buddy data will be preserved."
+} else {
+  Write-Host "  Local Buddy data in $DataDir will also be removed."
+}
+
+if (-not $Force) {
+  $reply = Read-Host "Proceed with uninstall? [y/N]"
+  if ($reply -notin @('y', 'Y', 'yes', 'YES')) {
+    Write-Host "  Aborted."
+    exit 0
+  }
+}
+
+Write-Host ""
+Write-Host "  Removing MCP client configuration..."
+Remove-BuddyFromJsonConfig "$env:USERPROFILE\.claude\settings.json" "Claude Code"
+Remove-BuddyFromJsonConfig "$env:USERPROFILE\.cursor\mcp.json" "Cursor"
+Remove-BuddyFromJsonConfig "$env:USERPROFILE\.codeium\windsurf\mcp_config.json" "Windsurf"
+
+try {
+  $null = Get-Command codex -ErrorAction Stop
+  codex mcp get buddy *> $null
+  if ($LASTEXITCODE -eq 0) {
+    codex mcp remove buddy *> $null
+    if ($LASTEXITCODE -eq 0) {
+      Write-Host "  ✓ Removed Buddy MCP entry from Codex CLI" -ForegroundColor Green
+    } else {
+      Write-Host "  ! Could not remove Buddy MCP entry from Codex CLI" -ForegroundColor Yellow
+    }
+  }
+} catch {
+  # Codex not installed; nothing to remove
+}
+
+Write-Host ""
+Write-Host "  Removing injected prompt instructions..."
+Remove-BuddyPromptBlock "$env:USERPROFILE\.claude\CLAUDE.md" "Claude Code"
+Remove-BuddyPromptBlock "$env:USERPROFILE\.cursorrules" "Cursor"
+Remove-BuddyPromptBlock "$env:USERPROFILE\.codeium\windsurf\rules\buddy.md" "Windsurf"
+Remove-BuddyPromptBlock "$env:USERPROFILE\.codex\instructions.md" "Codex CLI"
+Remove-BuddyPromptBlock "$env:USERPROFILE\.gemini\GEMINI.md" "Gemini CLI"
+
+if (Test-Path $StatusFile) {
+  Remove-Item $StatusFile -Force
+  Write-Host "  ✓ Removed Buddy status file ($StatusFile)" -ForegroundColor Green
+}
+
+Write-Host ""
+Write-Host "  Removing local files..."
+if (Test-Path $InstallDir) {
+  Remove-Item $InstallDir -Recurse -Force
+  Write-Host "  ✓ Removed install directory ($InstallDir)" -ForegroundColor Green
+}
+
+if (-not $KeepData -and (Test-Path $DataDir)) {
+  Remove-Item $DataDir -Recurse -Force
+  Write-Host "  ✓ Removed data directory ($DataDir)" -ForegroundColor Green
+} elseif ($KeepData) {
+  Write-Host "  Preserved data directory ($DataDir)" -ForegroundColor DarkGray
+}
+
+Write-Host ""
+Write-Host "  ✅ Buddy uninstalled." -ForegroundColor Green
+Write-Host ""

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# Buddy MCP Server — Uninstaller
+#
+# Usage:
+#   bash uninstall.sh
+#   bash uninstall.sh --yes
+#   bash uninstall.sh --keep-data
+
+set -euo pipefail
+
+INSTALL_DIR="$HOME/.buddy/server"
+DATA_DIR="$HOME/.buddy"
+STATUS_FILE="$HOME/.claude/buddy-status.json"
+KEEP_DATA=0
+ASSUME_YES=0
+
+BLUE='\033[0;34m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+DIM='\033[2m'
+NC='\033[0m'
+
+for arg in "$@"; do
+  case "$arg" in
+    --keep-data)
+      KEEP_DATA=1
+      ;;
+    --yes|-y)
+      ASSUME_YES=1
+      ;;
+    --help|-h)
+      cat <<'EOF'
+Buddy MCP Server — Uninstaller
+
+Usage:
+  bash uninstall.sh [--yes] [--keep-data]
+
+Options:
+  --yes        Skip confirmation prompt
+  --keep-data  Preserve ~/.buddy/buddy.db and other local Buddy data
+EOF
+      exit 0
+      ;;
+    *)
+      echo -e "${YELLOW}Unknown argument:${NC} $arg"
+      exit 1
+      ;;
+  esac
+done
+
+echo -e "${BLUE}"
+echo '  Buddy MCP Server Uninstaller'
+echo '  ────────────────────────────'
+echo -e "${NC}"
+
+remove_json_buddy() {
+  local config_file="$1"
+  local cli_name="$2"
+
+  if [ ! -f "$config_file" ]; then
+    return 0
+  fi
+
+  set +e
+  node -e "
+    const fs = require('fs');
+    const path = '$config_file';
+    try {
+      const raw = fs.readFileSync(path, 'utf8');
+      const config = JSON.parse(raw);
+      if (!config.mcpServers || !config.mcpServers.buddy) process.exit(10);
+      delete config.mcpServers.buddy;
+      if (config.mcpServers && Object.keys(config.mcpServers).length === 0) {
+        delete config.mcpServers;
+      }
+      fs.writeFileSync(path, JSON.stringify(config, null, 2));
+    } catch {
+      process.exit(11);
+    }
+  " >/dev/null 2>&1
+  local rc=$?
+  set -e
+
+  case "$rc" in
+    0)
+      echo -e "  ${GREEN}✓${NC} Removed Buddy MCP entry from $cli_name ${DIM}($config_file)${NC}"
+      ;;
+    10)
+      ;;
+    *)
+      echo -e "  ${YELLOW}!${NC} Could not update $cli_name config ${DIM}($config_file)${NC}"
+      ;;
+  esac
+}
+
+remove_prompt_block() {
+  local file="$1"
+  local cli_name="$2"
+
+  if [ ! -f "$file" ]; then
+    return 0
+  fi
+
+  set +e
+  node -e "
+    const fs = require('fs');
+    const path = '$file';
+    const start = '<!-- buddy-companion -->';
+    const end = '<!-- /buddy-companion -->';
+    const raw = fs.readFileSync(path, 'utf8');
+    const startIdx = raw.indexOf(start);
+    const endIdx = raw.indexOf(end);
+    if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) process.exit(10);
+    const afterEnd = endIdx + end.length;
+    const updated = (raw.slice(0, startIdx) + raw.slice(afterEnd))
+      .replace(/^\\s+|\\s+$/g, '')
+      .trim();
+    fs.writeFileSync(path, updated ? updated + '\\n' : '');
+  " >/dev/null 2>&1
+  local rc=$?
+  set -e
+
+  case "$rc" in
+    0)
+      echo -e "  ${GREEN}✓${NC} Removed Buddy instructions from $cli_name ${DIM}($file)${NC}"
+      ;;
+    10)
+      ;;
+    *)
+      echo -e "  ${YELLOW}!${NC} Could not update $cli_name prompt file ${DIM}($file)${NC}"
+      ;;
+  esac
+}
+
+echo ""
+echo "  This will remove Buddy MCP config and prompt instructions."
+if [ "$KEEP_DATA" -eq 1 ]; then
+  echo "  Local Buddy data will be preserved."
+else
+  echo "  Local Buddy data in ~/.buddy will also be removed."
+fi
+
+if [ "$ASSUME_YES" -ne 1 ]; then
+  printf "\nProceed with uninstall? [y/N] "
+  read -r reply
+  case "$reply" in
+    y|Y|yes|YES)
+      ;;
+    *)
+      echo "  Aborted."
+      exit 0
+      ;;
+  esac
+fi
+
+echo ""
+echo "  Removing MCP client configuration..."
+remove_json_buddy "$HOME/.claude/settings.json" "Claude Code"
+remove_json_buddy "$HOME/.cursor/mcp.json" "Cursor"
+remove_json_buddy "$HOME/.codeium/windsurf/mcp_config.json" "Windsurf"
+
+if command -v codex >/dev/null 2>&1; then
+  if codex mcp get buddy >/dev/null 2>&1; then
+    if codex mcp remove buddy >/dev/null 2>&1; then
+      echo -e "  ${GREEN}✓${NC} Removed Buddy MCP entry from Codex CLI"
+    else
+      echo -e "  ${YELLOW}!${NC} Could not remove Buddy MCP entry from Codex CLI"
+    fi
+  fi
+fi
+
+echo ""
+echo "  Removing injected prompt instructions..."
+remove_prompt_block "$HOME/.claude/CLAUDE.md" "Claude Code"
+remove_prompt_block "$HOME/.cursorrules" "Cursor"
+remove_prompt_block "$HOME/.codeium/windsurf/rules/buddy.md" "Windsurf"
+remove_prompt_block "$HOME/.codex/instructions.md" "Codex CLI"
+remove_prompt_block "$HOME/.gemini/GEMINI.md" "Gemini CLI"
+
+if [ -f "$STATUS_FILE" ]; then
+  rm -f "$STATUS_FILE"
+  echo -e "  ${GREEN}✓${NC} Removed Buddy status file ${DIM}($STATUS_FILE)${NC}"
+fi
+
+echo ""
+echo "  Removing local files..."
+if [ -d "$INSTALL_DIR" ]; then
+  rm -rf "$INSTALL_DIR"
+  echo -e "  ${GREEN}✓${NC} Removed install directory ${DIM}($INSTALL_DIR)${NC}"
+fi
+
+if [ "$KEEP_DATA" -eq 0 ] && [ -d "$DATA_DIR" ]; then
+  rm -rf "$DATA_DIR"
+  echo -e "  ${GREEN}✓${NC} Removed data directory ${DIM}($DATA_DIR)${NC}"
+elif [ "$KEEP_DATA" -eq 1 ]; then
+  echo -e "  ${DIM}Preserved data directory ${DATA_DIR}${NC}"
+fi
+
+echo ""
+echo -e "${GREEN}  ✅ Buddy uninstalled.${NC}"
+echo ""

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -13,6 +13,7 @@ DATA_DIR="$HOME/.buddy"
 STATUS_FILE="$HOME/.claude/buddy-status.json"
 KEEP_DATA=0
 ASSUME_YES=0
+NODE_BIN="${BUDDY_NODE_BIN:-$(command -v node || true)}"
 
 BLUE='\033[0;34m'
 GREEN='\033[0;32m'
@@ -61,34 +62,29 @@ remove_json_buddy() {
     return 0
   fi
 
+  if [ -z "$NODE_BIN" ]; then
+    echo -e "  ${YELLOW}!${NC} Skipping $cli_name config cleanup because Node.js is not available"
+    return 0
+  fi
+
   set +e
-  python3 - "$config_file" <<'PY' >/dev/null 2>&1
-import json
-import sys
-
-path = sys.argv[1]
-
-try:
-    with open(path, "r", encoding="utf-8") as f:
-        config = json.load(f)
-except Exception:
-    raise SystemExit(11)
-
-if not isinstance(config, dict):
-    raise SystemExit(11)
-
-mcp_servers = config.get("mcpServers")
-if not isinstance(mcp_servers, dict) or "buddy" not in mcp_servers:
-    raise SystemExit(10)
-
-del mcp_servers["buddy"]
-if not mcp_servers:
-    config.pop("mcpServers", None)
-
-with open(path, "w", encoding="utf-8") as f:
-    json.dump(config, f, indent=2)
-    f.write("\n")
-PY
+  "$NODE_BIN" -e "
+    const fs = require('fs');
+    const path = process.argv[1];
+    try {
+      const raw = fs.readFileSync(path, 'utf8');
+      const config = JSON.parse(raw);
+      if (!config || typeof config !== 'object') process.exit(11);
+      if (!config.mcpServers || !config.mcpServers.buddy) process.exit(10);
+      delete config.mcpServers.buddy;
+      if (Object.keys(config.mcpServers).length === 0) {
+        delete config.mcpServers;
+      }
+      fs.writeFileSync(path, JSON.stringify(config, null, 2) + '\n');
+    } catch {
+      process.exit(11);
+    }
+  " "$config_file" >/dev/null 2>&1
   local rc=$?
   set -e
 
@@ -112,28 +108,25 @@ remove_prompt_block() {
     return 0
   fi
 
+  if [ -z "$NODE_BIN" ]; then
+    echo -e "  ${YELLOW}!${NC} Skipping $cli_name prompt cleanup because Node.js is not available"
+    return 0
+  fi
+
   set +e
-  python3 - "$file" <<'PY' >/dev/null 2>&1
-import re
-import sys
-
-path = sys.argv[1]
-
-with open(path, "r", encoding="utf-8") as f:
-    raw = f.read()
-
-pattern = re.compile(r"\n?<!-- buddy-companion -->.*?<!-- /buddy-companion -->\n?", re.S)
-updated, count = pattern.subn("\n", raw, count=1)
-
-if count == 0:
-    raise SystemExit(10)
-
-updated = re.sub(r"\n{3,}", "\n\n", updated).strip()
-
-with open(path, "w", encoding="utf-8") as f:
-    if updated:
-        f.write(updated + "\n")
-PY
+  "$NODE_BIN" -e "
+    const fs = require('fs');
+    const path = process.argv[1];
+    try {
+      const raw = fs.readFileSync(path, 'utf8');
+      const pattern = /\n?<!-- buddy-companion -->[\s\S]*?<!-- \/buddy-companion -->\n?/;
+      if (!pattern.test(raw)) process.exit(10);
+      const updated = raw.replace(pattern, '\n').replace(/\n{3,}/g, '\n\n').trim();
+      fs.writeFileSync(path, updated ? updated + '\n' : '');
+    } catch {
+      process.exit(11);
+    }
+  " "$file" >/dev/null 2>&1
   local rc=$?
   set -e
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -62,22 +62,33 @@ remove_json_buddy() {
   fi
 
   set +e
-  node -e "
-    const fs = require('fs');
-    const path = '$config_file';
-    try {
-      const raw = fs.readFileSync(path, 'utf8');
-      const config = JSON.parse(raw);
-      if (!config.mcpServers || !config.mcpServers.buddy) process.exit(10);
-      delete config.mcpServers.buddy;
-      if (config.mcpServers && Object.keys(config.mcpServers).length === 0) {
-        delete config.mcpServers;
-      }
-      fs.writeFileSync(path, JSON.stringify(config, null, 2));
-    } catch {
-      process.exit(11);
-    }
-  " >/dev/null 2>&1
+  python3 - "$config_file" <<'PY' >/dev/null 2>&1
+import json
+import sys
+
+path = sys.argv[1]
+
+try:
+    with open(path, "r", encoding="utf-8") as f:
+        config = json.load(f)
+except Exception:
+    raise SystemExit(11)
+
+if not isinstance(config, dict):
+    raise SystemExit(11)
+
+mcp_servers = config.get("mcpServers")
+if not isinstance(mcp_servers, dict) or "buddy" not in mcp_servers:
+    raise SystemExit(10)
+
+del mcp_servers["buddy"]
+if not mcp_servers:
+    config.pop("mcpServers", None)
+
+with open(path, "w", encoding="utf-8") as f:
+    json.dump(config, f, indent=2)
+    f.write("\n")
+PY
   local rc=$?
   set -e
 
@@ -102,21 +113,27 @@ remove_prompt_block() {
   fi
 
   set +e
-  node -e "
-    const fs = require('fs');
-    const path = '$file';
-    const start = '<!-- buddy-companion -->';
-    const end = '<!-- /buddy-companion -->';
-    const raw = fs.readFileSync(path, 'utf8');
-    const startIdx = raw.indexOf(start);
-    const endIdx = raw.indexOf(end);
-    if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) process.exit(10);
-    const afterEnd = endIdx + end.length;
-    const updated = (raw.slice(0, startIdx) + raw.slice(afterEnd))
-      .replace(/^\\s+|\\s+$/g, '')
-      .trim();
-    fs.writeFileSync(path, updated ? updated + '\\n' : '');
-  " >/dev/null 2>&1
+  python3 - "$file" <<'PY' >/dev/null 2>&1
+import re
+import sys
+
+path = sys.argv[1]
+
+with open(path, "r", encoding="utf-8") as f:
+    raw = f.read()
+
+pattern = re.compile(r"\n?<!-- buddy-companion -->.*?<!-- /buddy-companion -->\n?", re.S)
+updated, count = pattern.subn("\n", raw, count=1)
+
+if count == 0:
+    raise SystemExit(10)
+
+updated = re.sub(r"\n{3,}", "\n\n", updated).strip()
+
+with open(path, "w", encoding="utf-8") as f:
+    if updated:
+        f.write(updated + "\n")
+PY
   local rc=$?
   set -e
 


### PR DESCRIPTION
## Summary
- add uninstall.sh for macOS/Linux Buddy removal
- add uninstall.ps1 for Windows PowerShell Buddy removal
- document scripted uninstall in the README FAQ
- add species-specific flavor coverage for reactions, pet responses, and statusline ambient text
- fix `buddy_observe` `both` fallback so it combines character flavor with a concrete observation

## Details
This PR bundles two related Buddy polish tracks:

1. Uninstall support
- removes Buddy MCP config entries
- removes injected prompt instructions
- removes local Buddy files
- supports preserving local Buddy data when desired

2. Species flavor coverage
- fills in missing species-specific `getReaction()` entries
- fills in missing species-specific `buddy_pet` reactions
- fills in missing species-specific Claude statusline ambient text
- keeps existing species-specific behavior intact where it already existed

## Verification
- `bash -n uninstall.sh`
- `bash ./uninstall.sh --help`
- isolated fake-HOME functional test for `uninstall.sh --yes`
- isolated fake-HOME functional test for `uninstall.sh --yes --keep-data`
- `npm test -- species.test.ts observer.test.ts`
- `npm run build`

## Notes
- I verified the Bash uninstall script locally.
- I could not execute the PowerShell uninstall script in this environment because `pwsh`/`powershell` is not installed here.
- `buddy_respawn` still only resets/releases the companion; it does not uninstall Buddy.
- `buddy_observe` `both` mode was already wired in, but its fallback output could collapse to a single observation line. This PR fixes the fallback so it now returns combined flavor + observation text.
