### PR TITLE
Honor CLAUDE_CONFIG_DIR and Claude MCP config paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,24 +101,26 @@ npm install && npm run build
 Then add to your MCP config manually for the client you use:
 
 <details>
-<summary>Claude Code (~/.claude/settings.json)</summary>
+<summary>Claude Code (~/.claude.json or $CLAUDE_CONFIG_DIR/.claude.json)</summary>
 
 ```json
 {
   "mcpServers": {
     "buddy": {
       "command": "node",
-      "args": ["~/.buddy/server/dist/server/index.js"]
+      "args": ["/absolute/path/to/.buddy/server/dist/server/index.js"]
     }
   }
 }
 ```
+
+Claude Code MCP servers belong in `~/.claude.json` by default. If you use `CLAUDE_CONFIG_DIR`, put the MCP config in `$CLAUDE_CONFIG_DIR/.claude.json`.
 </details>
 
 <details>
 <summary>Any MCP-capable CLI client</summary>
 
-Same pattern — point `command` to `node` and `args` to the server entry point at `~/.buddy/server/dist/server/index.js`.
+Same pattern — point `command` to `node` and `args` to the server entry point using an absolute path like `/absolute/path/to/.buddy/server/dist/server/index.js`. Do not use `~` inside JSON config values because many clients do not expand it.
 </details>
 
 ---

--- a/install.ps1
+++ b/install.ps1
@@ -7,6 +7,13 @@
 $ErrorActionPreference = "Stop"
 $REPO = "https://github.com/fiorastudio/buddy.git"
 $INSTALL_DIR = "$env:USERPROFILE\.buddy\server"
+if ($env:CLAUDE_CONFIG_DIR) {
+  $CLAUDE_STATE_DIR = $env:CLAUDE_CONFIG_DIR
+  $CLAUDE_MCP_CONFIG = Join-Path $env:CLAUDE_CONFIG_DIR ".claude.json"
+} else {
+  $CLAUDE_STATE_DIR = "$env:USERPROFILE\.claude"
+  $CLAUDE_MCP_CONFIG = "$env:USERPROFILE\.claude.json"
+}
 
 Write-Host ""
 Write-Host "  Buddy MCP Server Installer" -ForegroundColor Cyan
@@ -91,9 +98,9 @@ Write-Host ""
 Write-Host "  Configuring MCP clients..."
 
 # Claude Code
-$claudeDir = "$env:USERPROFILE\.claude"
-if (!(Test-Path $claudeDir)) { New-Item -ItemType Directory -Path $claudeDir -Force | Out-Null }
-Add-BuddyToConfig "$claudeDir\settings.json" "Claude Code"
+$claudeMcpDir = Split-Path $CLAUDE_MCP_CONFIG -Parent
+if (!(Test-Path $claudeMcpDir)) { New-Item -ItemType Directory -Path $claudeMcpDir -Force | Out-Null }
+Add-BuddyToConfig $CLAUDE_MCP_CONFIG "Claude Code"
 
 # Cursor
 if (Test-Path "$env:USERPROFILE\.cursor") {
@@ -139,7 +146,7 @@ function Inject-BuddyPrompt($filePath, $cliName) {
 Write-Host ""
 Write-Host "  Injecting buddy instructions..."
 
-Inject-BuddyPrompt "$env:USERPROFILE\.claude\CLAUDE.md" "Claude Code"
+Inject-BuddyPrompt (Join-Path $CLAUDE_STATE_DIR "CLAUDE.md") "Claude Code"
 Inject-BuddyPrompt "$env:USERPROFILE\.cursorrules" "Cursor"
 
 $windsurfRulesDir = "$env:USERPROFILE\.codeium\windsurf\rules"

--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,13 @@ set -e
 
 REPO="https://github.com/fiorastudio/buddy.git"
 INSTALL_DIR="$HOME/.buddy/server"
+if [ -n "${CLAUDE_CONFIG_DIR:-}" ]; then
+  CLAUDE_STATE_DIR="$CLAUDE_CONFIG_DIR"
+  CLAUDE_MCP_CONFIG="$CLAUDE_CONFIG_DIR/.claude.json"
+else
+  CLAUDE_STATE_DIR="$HOME/.claude"
+  CLAUDE_MCP_CONFIG="$HOME/.claude.json"
+fi
 BLUE='\033[0;34m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -60,8 +67,9 @@ CODEX_CONFIGURED=0
 # ── Auto-configure MCP for detected CLIs ──
 
 configure_claude_code() {
-  local config_file="$HOME/.claude/settings.json"
-  local config_dir="$HOME/.claude"
+  local config_file="$CLAUDE_MCP_CONFIG"
+  local config_dir
+  config_dir="$(dirname "$config_file")"
 
   mkdir -p "$config_dir"
 
@@ -220,7 +228,7 @@ inject_prompt() {
 
 echo ""
 echo "  Injecting buddy instructions..."
-inject_prompt "$HOME/.claude/CLAUDE.md" "Claude Code"
+inject_prompt "$CLAUDE_STATE_DIR/CLAUDE.md" "Claude Code"
 inject_prompt "$HOME/.cursorrules" "Cursor"
 
 # Windsurf uses a rules directory

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -23,7 +23,8 @@ import { writeFileSync, mkdirSync, unlinkSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 
-const BUDDY_STATUS_PATH = join(homedir(), ".claude", "buddy-status.json");
+const CLAUDE_STATE_DIR = process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
+const BUDDY_STATUS_PATH = join(CLAUDE_STATE_DIR, "buddy-status.json");
 let statusDirEnsured = false;
 const RESET = '\x1b[0m';
 
@@ -190,7 +191,7 @@ function hatchAnimation(companion: Companion): string {
 function writeBuddyStatus(companion: Companion, reaction?: { state: string; text: string; expires: number; eyeOverride?: string; indicator?: string }) {
   try {
     if (!statusDirEnsured) {
-      mkdirSync(join(homedir(), ".claude"), { recursive: true });
+      mkdirSync(CLAUDE_STATE_DIR, { recursive: true });
       statusDirEnsured = true;
     }
     writeFileSync(BUDDY_STATUS_PATH, JSON.stringify({

--- a/src/statusline-wrapper.ts
+++ b/src/statusline-wrapper.ts
@@ -13,7 +13,8 @@ const GREEN = "\x1b[32m";
 const MAGENTA = "\x1b[35m";
 
 const toUnix = (p: string) => p.replace(/\\/g, "/");
-const BUDDY_STATUS_PATH = join(homedir(), ".claude", "buddy-status.json");
+const CLAUDE_STATE_DIR = process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
+const BUDDY_STATUS_PATH = join(CLAUDE_STATE_DIR, "buddy-status.json");
 const FRAME_INTERVAL_MS = 800;
 
 // True randomness for animation — each render picks a fresh random value.
@@ -29,7 +30,7 @@ try {
 } catch { /* no stdin */ }
 
 // Run claude-hud with caching (HUD data changes slowly, no need to re-run every render)
-const HUD_CACHE_PATH = join(homedir(), ".claude", "hud-cache.json");
+const HUD_CACHE_PATH = join(CLAUDE_STATE_DIR, "hud-cache.json");
 const HUD_CACHE_TTL = 10_000; // 10 seconds
 
 let hudLines: string[] = [];
@@ -45,8 +46,7 @@ try {
   } catch { /* no cache or stale */ }
 
   if (!cacheHit) {
-    const configDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
-    const cacheDir = join(configDir, "plugins", "cache", "claude-hud", "claude-hud");
+    const cacheDir = join(CLAUDE_STATE_DIR, "plugins", "cache", "claude-hud", "claude-hud");
 
     let pluginDir = "";
     try {


### PR DESCRIPTION
## Summary
- honor `CLAUDE_CONFIG_DIR` for Buddy's Claude-facing files
- write Claude MCP config to `.claude.json` instead of `settings.json`
- document that MCP JSON args should use absolute paths, not `~`

## Details
This fixes three related Claude integration issues:

1. Claude MCP config location
- Buddy was writing MCP config to `~/.claude/settings.json`
- Claude Code MCP servers belong in `~/.claude.json` by default
- when `CLAUDE_CONFIG_DIR` is set, Buddy now writes Claude MCP config to `$CLAUDE_CONFIG_DIR/.claude.json`

2. Claude state dir consistency
- Buddy status output and Claude HUD cache now respect `CLAUDE_CONFIG_DIR`
- Claude prompt injection also uses the resolved Claude state dir

3. README manual config example
- replace `~/.buddy/...` JSON args with an absolute path example
- clarify that `~` should not be used inside JSON config values because many clients do not expand it

## Verification
- `bash -n install.sh`
- `npm run build`

## Notes
- This PR does not change Codex/Gemini/Cursor/Windsurf config behavior.
- The PowerShell installer was updated to follow the same Claude path rules, but I did not execute it locally because this environment does not have `pwsh`/`powershell`.
