### PR TITLE
Mood recalibration: recalc on every interaction + happy on level-up

### DIFF
--- a/src/__tests__/self-healing.test.ts
+++ b/src/__tests__/self-healing.test.ts
@@ -1,22 +1,26 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { initDb, db } from '../db/schema.js';
-import { loadCompanion } from '../server/index.js';
+import { loadCompanion, recalcMood } from '../server/index.js';
 import { levelFromXp } from '../lib/leveling.js';
 import { randomUUID } from 'crypto';
 
 // ---------------------------------------------------------------------------
-// Self-Healing: loadCompanion corrects stale DB level
+// Self-Healing & Mood Recalibration
 // ---------------------------------------------------------------------------
 
 const TEST_ID = `test-self-heal-${randomUUID()}`;
+const MOOD_TEST_ID = `test-mood-${randomUUID()}`;
 
 beforeAll(() => {
   initDb();
 });
 
 afterAll(() => {
-  // Clean up test row
+  // Delete xp_events first (foreign key references companions)
+  db.prepare("DELETE FROM xp_events WHERE companion_id = ?").run(TEST_ID);
+  db.prepare("DELETE FROM xp_events WHERE companion_id = ?").run(MOOD_TEST_ID);
   db.prepare("DELETE FROM companions WHERE id = ?").run(TEST_ID);
+  db.prepare("DELETE FROM companions WHERE id = ?").run(MOOD_TEST_ID);
 });
 
 describe('loadCompanion self-healing', () => {
@@ -55,5 +59,47 @@ describe('loadCompanion self-healing', () => {
     // DB should still show level 2 (no unnecessary write)
     const updatedRow = db.prepare("SELECT level FROM companions WHERE id = ?").get(TEST_ID) as any;
     expect(updatedRow.level).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mood Recalibration
+// ---------------------------------------------------------------------------
+
+describe('recalcMood', () => {
+  it('returns grumpy when no recent interactions', () => {
+    // Insert a companion with no xp_events
+    db.prepare(
+      "INSERT INTO companions (id, name, species, level, xp, mood, user_id) VALUES (?, ?, ?, ?, ?, ?, ?)"
+    ).run(MOOD_TEST_ID, 'MoodTest', 'Mushroom', 1, 0, 'grumpy', 'test-user-mood');
+
+    const mood = recalcMood(MOOD_TEST_ID, false);
+    expect(mood).toBe('grumpy');
+  });
+
+  it('trends upward with more interactions', () => {
+    // Add a few xp events — should move past grumpy
+    for (let i = 0; i < 4; i++) {
+      db.prepare(
+        "INSERT INTO xp_events (id, companion_id, event_type, xp_gained) VALUES (?, ?, ?, ?)"
+      ).run(randomUUID(), MOOD_TEST_ID, 'observe', 5);
+    }
+
+    const mood = recalcMood(MOOD_TEST_ID, false);
+    expect(['curious', 'happy', 'content']).toContain(mood);
+  });
+
+  it('returns happy on level-up regardless of interaction count', () => {
+    // Even with 0 interactions, level-up should override to happy
+    const freshId = `test-mood-levelup-${randomUUID()}`;
+    db.prepare(
+      "INSERT INTO companions (id, name, species, level, xp, mood, user_id) VALUES (?, ?, ?, ?, ?, ?, ?)"
+    ).run(freshId, 'LevelUpTest', 'Mushroom', 1, 0, 'grumpy', 'test-user-mood');
+
+    const mood = recalcMood(freshId, true);
+    expect(mood).toBe('happy');
+
+    // Clean up
+    db.prepare("DELETE FROM companions WHERE id = ?").run(freshId);
   });
 });

--- a/src/__tests__/self-healing.test.ts
+++ b/src/__tests__/self-healing.test.ts
@@ -10,6 +10,7 @@ import { randomUUID } from 'crypto';
 
 const TEST_ID = `test-self-heal-${randomUUID()}`;
 const MOOD_TEST_ID = `test-mood-${randomUUID()}`;
+const LEVELUP_TEST_ID = `test-mood-levelup-${randomUUID()}`;
 
 beforeAll(() => {
   initDb();
@@ -17,10 +18,10 @@ beforeAll(() => {
 
 afterAll(() => {
   // Delete xp_events first (foreign key references companions)
-  db.prepare("DELETE FROM xp_events WHERE companion_id = ?").run(TEST_ID);
-  db.prepare("DELETE FROM xp_events WHERE companion_id = ?").run(MOOD_TEST_ID);
-  db.prepare("DELETE FROM companions WHERE id = ?").run(TEST_ID);
-  db.prepare("DELETE FROM companions WHERE id = ?").run(MOOD_TEST_ID);
+  for (const id of [TEST_ID, MOOD_TEST_ID, LEVELUP_TEST_ID]) {
+    db.prepare("DELETE FROM xp_events WHERE companion_id = ?").run(id);
+    db.prepare("DELETE FROM companions WHERE id = ?").run(id);
+  }
 });
 
 describe('loadCompanion self-healing', () => {
@@ -67,39 +68,49 @@ describe('loadCompanion self-healing', () => {
 // ---------------------------------------------------------------------------
 
 describe('recalcMood', () => {
-  it('returns grumpy when no recent interactions', () => {
-    // Insert a companion with no xp_events
-    db.prepare(
-      "INSERT INTO companions (id, name, species, level, xp, mood, user_id) VALUES (?, ?, ?, ?, ?, ?, ?)"
-    ).run(MOOD_TEST_ID, 'MoodTest', 'Mushroom', 1, 0, 'grumpy', 'test-user-mood');
-
-    const mood = recalcMood(MOOD_TEST_ID, false);
-    expect(mood).toBe('grumpy');
-  });
-
-  it('trends upward with more interactions', () => {
-    // Add a few xp events — should move past grumpy
-    for (let i = 0; i < 4; i++) {
+  // Helper to add N xp_events for MOOD_TEST_ID
+  function addEvents(n: number) {
+    for (let i = 0; i < n; i++) {
       db.prepare(
         "INSERT INTO xp_events (id, companion_id, event_type, xp_gained) VALUES (?, ?, ?, ?)"
       ).run(randomUUID(), MOOD_TEST_ID, 'observe', 5);
     }
+  }
 
-    const mood = recalcMood(MOOD_TEST_ID, false);
-    expect(['curious', 'happy', 'content']).toContain(mood);
+  it('returns grumpy with 0 interactions', () => {
+    db.prepare(
+      "INSERT INTO companions (id, name, species, level, xp, mood, user_id) VALUES (?, ?, ?, ?, ?, ?, ?)"
+    ).run(MOOD_TEST_ID, 'MoodTest', 'Mushroom', 1, 0, 'grumpy', 'test-user-mood');
+
+    expect(recalcMood(MOOD_TEST_ID, false)).toBe('grumpy');
+  });
+
+  it('returns neutral with 1 interaction (>0 threshold)', () => {
+    addEvents(1);
+    expect(recalcMood(MOOD_TEST_ID, false)).toBe('neutral');
+  });
+
+  it('returns curious with 4 interactions (>3 threshold)', () => {
+    addEvents(3); // 1 + 3 = 4 total
+    expect(recalcMood(MOOD_TEST_ID, false)).toBe('curious');
+  });
+
+  it('returns happy with 6 interactions (>5 threshold)', () => {
+    addEvents(2); // 4 + 2 = 6 total
+    expect(recalcMood(MOOD_TEST_ID, false)).toBe('happy');
+  });
+
+  it('returns content with 11 interactions (>10 threshold)', () => {
+    addEvents(5); // 6 + 5 = 11 total
+    expect(recalcMood(MOOD_TEST_ID, false)).toBe('content');
   });
 
   it('returns happy on level-up regardless of interaction count', () => {
-    // Even with 0 interactions, level-up should override to happy
-    const freshId = `test-mood-levelup-${randomUUID()}`;
+    // 0 interactions, but leveledUp=true → happy
     db.prepare(
       "INSERT INTO companions (id, name, species, level, xp, mood, user_id) VALUES (?, ?, ?, ?, ?, ?, ?)"
-    ).run(freshId, 'LevelUpTest', 'Mushroom', 1, 0, 'grumpy', 'test-user-mood');
+    ).run(LEVELUP_TEST_ID, 'LevelUpTest', 'Mushroom', 1, 0, 'grumpy', 'test-user-mood');
 
-    const mood = recalcMood(freshId, true);
-    expect(mood).toBe('happy');
-
-    // Clean up
-    db.prepare("DELETE FROM companions WHERE id = ?").run(freshId);
+    expect(recalcMood(LEVELUP_TEST_ID, true)).toBe('happy');
   });
 });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -9,7 +9,7 @@ import {
 import { initDb, db } from "../db/schema.js";
 import {
   SPECIES, SPECIES_LIST,
-  generateName, calculateMood, getReaction,
+  generateName, calculateMood, getReaction, type Mood,
   renderSprite,
 } from "../lib/species.js";
 import { type Companion, STAT_NAMES, RARITY_STARS, RARITY_ANSI, SPARKLE_EYE, getPeakStat, getDumpStat } from "../lib/types.js";
@@ -54,7 +54,7 @@ export function loadCompanion(row: any, userIdOverride?: string): Companion | nu
   };
 }
 
-function recalcMood(companionId: string, leveledUp: boolean): string {
+function recalcMood(companionId: string, leveledUp: boolean): Mood {
   if (leveledUp) return 'happy';
   const recentXp = db.prepare(
     "SELECT * FROM xp_events WHERE companion_id = ? AND created_at > datetime('now', '-1 hour')"
@@ -494,7 +494,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const newMood = recalcMood(row.id, xpResult.leveledUp);
     db.prepare("UPDATE companions SET mood = ? WHERE id = ?").run(newMood, row.id);
 
-    const companion = loadCompanion({ ...row, mood: newMood, xp: xpResult.newXp }, user_id)!;
+    const companion = loadCompanion({ ...row, mood: newMood, xp: xpResult.newXp, level: xpResult.newLevel }, user_id)!;
     const result = buildObserverPrompt(companion, mode, summary);
 
     // Write reaction state to status file (expires in 10s)
@@ -547,7 +547,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const newMood = recalcMood(row.id, xpResult.leveledUp);
     db.prepare("UPDATE companions SET mood = ? WHERE id = ?").run(newMood, row.id);
 
-    const companion = loadCompanion({ ...row, mood: newMood, xp: xpResult.newXp })!;
+    const companion = loadCompanion({ ...row, mood: newMood, xp: xpResult.newXp, level: xpResult.newLevel })!;
     const art = renderSprite(companion);
 
     const hearts = [

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -535,10 +535,19 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return { content: [{ type: "text", text: "No companion to pet! Use buddy_hatch first." }] };
     }
 
-    const companion = loadCompanion(row)!;
     const xpResult = awardXp(row.id, 'session');
-    companion.xp = xpResult.newXp;
-    companion.level = xpResult.newLevel;
+
+    // Recalculate mood — petting adds an interaction, so mood trends upward
+    const recentXp = db.prepare(
+      "SELECT * FROM xp_events WHERE companion_id = ? AND created_at > datetime('now', '-1 hour')"
+    ).all(row.id);
+    const recentMemories = db.prepare(
+      "SELECT count(*) as count FROM memories WHERE companion_id = ? AND created_at > datetime('now', '-1 hour')"
+    ).get(row.id) as any;
+    const newMood = calculateMood(recentXp, recentMemories.count);
+    db.prepare("UPDATE companions SET mood = ? WHERE id = ?").run(newMood, row.id);
+
+    const companion = loadCompanion({ ...row, mood: newMood, xp: xpResult.newXp })!;
     const art = renderSprite(companion);
 
     const hearts = [

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -54,7 +54,7 @@ export function loadCompanion(row: any, userIdOverride?: string): Companion | nu
   };
 }
 
-function recalcMood(companionId: string, leveledUp: boolean): Mood {
+export function recalcMood(companionId: string, leveledUp: boolean): Mood {
   if (leveledUp) return 'happy';
   const recentXp = db.prepare(
     "SELECT * FROM xp_events WHERE companion_id = ? AND created_at > datetime('now', '-1 hour')"

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -54,6 +54,17 @@ export function loadCompanion(row: any, userIdOverride?: string): Companion | nu
   };
 }
 
+function recalcMood(companionId: string, leveledUp: boolean): string {
+  if (leveledUp) return 'happy';
+  const recentXp = db.prepare(
+    "SELECT * FROM xp_events WHERE companion_id = ? AND created_at > datetime('now', '-1 hour')"
+  ).all(companionId);
+  const recentMemories = db.prepare(
+    "SELECT count(*) as count FROM memories WHERE companion_id = ? AND created_at > datetime('now', '-1 hour')"
+  ).get(companionId) as any;
+  return calculateMood(recentXp, recentMemories.count);
+}
+
 function awardXp(companionId: string, eventType: string): { newXp: number; newLevel: number; leveledUp: boolean } {
   const xp = XP_REWARDS[eventType] || 1;
   const id = randomUUID();
@@ -404,13 +415,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     const userId = user_id || row.user_id || 'anon';
 
-    const recentXp = db.prepare(
-      "SELECT * FROM xp_events WHERE companion_id = ? AND created_at > datetime('now', '-1 hour')"
-    ).all(row.id);
-    const recentMemories = db.prepare(
-      "SELECT count(*) as count FROM memories WHERE companion_id = ? AND created_at > datetime('now', '-1 hour')"
-    ).get(row.id) as any;
-    const newMood = calculateMood(recentXp, recentMemories.count);
+    const newMood = recalcMood(row.id, false);
     db.prepare("UPDATE companions SET mood = ? WHERE id = ?").run(newMood, row.id);
 
     const companion = loadCompanion({ ...row, mood: newMood }, userId)!;
@@ -483,13 +488,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return { content: [{ type: "text", text: "No companion hatched yet! Use buddy_hatch first." }] };
     }
 
-    const companion = loadCompanion(row, user_id)!;
-    const result = buildObserverPrompt(companion, mode, summary);
-
-    // Award XP for observation
     const xpResult = awardXp(row.id, 'observe');
-    companion.xp = xpResult.newXp;
-    companion.level = xpResult.newLevel;
+
+    // Recalculate mood — observing adds an interaction, level-up sets happy
+    const newMood = recalcMood(row.id, xpResult.leveledUp);
+    db.prepare("UPDATE companions SET mood = ? WHERE id = ?").run(newMood, row.id);
+
+    const companion = loadCompanion({ ...row, mood: newMood, xp: xpResult.newXp }, user_id)!;
+    const result = buildObserverPrompt(companion, mode, summary);
 
     // Write reaction state to status file (expires in 10s)
     // Level-up overrides: sparkle eyes + special indicator
@@ -537,14 +543,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     const xpResult = awardXp(row.id, 'session');
 
-    // Recalculate mood — petting adds an interaction, so mood trends upward
-    const recentXp = db.prepare(
-      "SELECT * FROM xp_events WHERE companion_id = ? AND created_at > datetime('now', '-1 hour')"
-    ).all(row.id);
-    const recentMemories = db.prepare(
-      "SELECT count(*) as count FROM memories WHERE companion_id = ? AND created_at > datetime('now', '-1 hour')"
-    ).get(row.id) as any;
-    const newMood = calculateMood(recentXp, recentMemories.count);
+    // Recalculate mood — petting adds an interaction, level-up sets happy
+    const newMood = recalcMood(row.id, xpResult.leveledUp);
     db.prepare("UPDATE companions SET mood = ? WHERE id = ?").run(newMood, row.id);
 
     const companion = loadCompanion({ ...row, mood: newMood, xp: xpResult.newXp })!;


### PR DESCRIPTION
## Summary
- **Extract `recalcMood()` helper** — DRYs up identical interaction-counting blocks across buddy_status, buddy_observe, and buddy_pet
- **buddy_observe now recalculates mood** — previously only buddy_status did, so mood was stale most of the time
- **Level-up sets mood to happy** — both observe and pet paths
- **Passive decay unchanged** — mood still declines naturally via the 1-hour interaction window in `calculateMood`

## Mood flow (before → after)
| Event | Before | After |
|-------|--------|-------|
| buddy_status | recalc ✓ | recalc ✓ (via recalcMood) |
| buddy_observe | no recalc ✗ | recalc ✓ |
| buddy_pet | no recalc ✗ | recalc ✓ |
| level-up | no mood change | mood → happy |

## Test plan
- [x] 252 tests pass
- [x] 0 interactions → grumpy (exact assertion)
- [x] 1 interaction → neutral (>0 threshold)
- [x] 4 interactions → curious (>3 threshold)
- [x] 6 interactions → happy (>5 threshold)
- [x] 11 interactions → content (>10 threshold)
- [x] Level-up → happy regardless of interaction count

Supersedes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)