### PR TITLE
feat: speech bubble visibility + PostToolUse hook

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -87,6 +87,9 @@ function Add-BuddyToConfig($configPath, $cliName) {
   Write-Host "  ✓ $cliName configured ($configPath)" -ForegroundColor Green
 }
 
+$HOOK_PATH = "$INSTALL_DIR\dist\hooks\post-tool-handler.js"
+$HOOK_PATH_UNIX = $HOOK_PATH -replace '\\', '/'
+
 Write-Host ""
 Write-Host "  Configuring MCP clients..."
 
@@ -94,6 +97,50 @@ Write-Host "  Configuring MCP clients..."
 $claudeDir = "$env:USERPROFILE\.claude"
 if (!(Test-Path $claudeDir)) { New-Item -ItemType Directory -Path $claudeDir -Force | Out-Null }
 Add-BuddyToConfig "$claudeDir\settings.json" "Claude Code"
+
+# Add PostToolUse hook to Claude Code settings (array-append, don't replace)
+$claudeSettings = "$claudeDir\settings.json"
+if (Test-Path $claudeSettings) {
+  try {
+    $config = Get-Content $claudeSettings -Raw | ConvertFrom-Json
+    if (!$config.hooks) {
+      $config | Add-Member -NotePropertyName "hooks" -NotePropertyValue @{} -Force
+    }
+    $hooks = $config.hooks
+    if (!$hooks.PostToolUse) {
+      $hooks | Add-Member -NotePropertyName "PostToolUse" -NotePropertyValue @() -Force
+    }
+    # Check if buddy hook already exists
+    $hasBuddy = $false
+    foreach ($entry in $hooks.PostToolUse) {
+      if ($entry.matcher -eq 'Bash' -and $entry.hooks) {
+        foreach ($hk in $entry.hooks) {
+          if ($hk.command -and $hk.command -like '*post-tool-handler*') {
+            $hasBuddy = $true
+          }
+        }
+      }
+    }
+    if (-not $hasBuddy) {
+      $hookEntry = @{
+        matcher = "Bash"
+        hooks = @(@{
+          type = "command"
+          command = "node $HOOK_PATH_UNIX"
+          async = $true
+          timeout = 3
+        })
+      }
+      $hooks.PostToolUse = @($hooks.PostToolUse) + @($hookEntry)
+      $config | ConvertTo-Json -Depth 8 | Set-Content $claudeSettings -Encoding UTF8
+      Write-Host "  ✓ PostToolUse hook configured" -ForegroundColor Green
+    } else {
+      Write-Host "  ✓ PostToolUse hook already configured" -ForegroundColor Green
+    }
+  } catch {
+    Write-Host "  ! Could not configure PostToolUse hook" -ForegroundColor Yellow
+  }
+}
 
 # Cursor
 if (Test-Path "$env:USERPROFILE\.cursor") {
@@ -118,6 +165,8 @@ You have a coding companion available via the buddy MCP server.
 At the start of each conversation, call ``buddy_status`` to check on your buddy.
 
 If the user addresses the buddy by name, respond briefly in character before your normal response.
+
+After calling buddy_observe, relay the buddy's reaction to the user. The first text content is an ASCII speech bubble — include it verbatim.
 <!-- /buddy-companion -->
 "@
 

--- a/install.sh
+++ b/install.sh
@@ -62,11 +62,12 @@ CODEX_CONFIGURED=0
 configure_claude_code() {
   local config_file="$HOME/.claude/settings.json"
   local config_dir="$HOME/.claude"
+  local hook_path="$INSTALL_DIR/dist/hooks/post-tool-handler.js"
 
   mkdir -p "$config_dir"
 
   if [ ! -f "$config_file" ]; then
-    # Create new settings with buddy
+    # Create new settings with buddy + hook
     cat > "$config_file" << EOJSON
 {
   "mcpServers": {
@@ -74,6 +75,21 @@ configure_claude_code() {
       "command": "node",
       "args": ["$SERVER_PATH"]
     }
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node $hook_path",
+            "async": true,
+            "timeout": 3
+          }
+        ]
+      }
+    ]
   }
 }
 EOJSON
@@ -84,19 +100,46 @@ EOJSON
   # Check if buddy already configured
   if grep -q '"buddy"' "$config_file" 2>/dev/null; then
     echo -e "  ${GREEN}✓${NC} Claude Code already configured"
-    return 0
+  else
+    # Inject buddy into existing mcpServers (or add mcpServers section)
+    if command -v node &> /dev/null; then
+      node -e "
+        const fs = require('fs');
+        const config = JSON.parse(fs.readFileSync('$config_file', 'utf-8'));
+        if (!config.mcpServers) config.mcpServers = {};
+        config.mcpServers.buddy = { command: 'node', args: ['$SERVER_PATH'] };
+        fs.writeFileSync('$config_file', JSON.stringify(config, null, 2));
+      " 2>/dev/null
+      echo -e "  ${GREEN}✓${NC} Claude Code configured ${DIM}($config_file)${NC}"
+    fi
   fi
 
-  # Inject buddy into existing mcpServers (or add mcpServers section)
+  # Add PostToolUse hook (array-append, don't replace existing hooks)
   if command -v node &> /dev/null; then
     node -e "
       const fs = require('fs');
       const config = JSON.parse(fs.readFileSync('$config_file', 'utf-8'));
-      if (!config.mcpServers) config.mcpServers = {};
-      config.mcpServers.buddy = { command: 'node', args: ['$SERVER_PATH'] };
-      fs.writeFileSync('$config_file', JSON.stringify(config, null, 2));
+      if (!config.hooks) config.hooks = {};
+      if (!config.hooks.PostToolUse) config.hooks.PostToolUse = [];
+      // Check if buddy hook already exists
+      const hasBuddy = config.hooks.PostToolUse.some(h =>
+        h.matcher === 'Bash' && h.hooks && h.hooks.some(hk => hk.command && hk.command.includes('post-tool-handler'))
+      );
+      if (!hasBuddy) {
+        config.hooks.PostToolUse.push({
+          matcher: 'Bash',
+          hooks: [{
+            type: 'command',
+            command: 'node $hook_path',
+            async: true,
+            timeout: 3
+          }]
+        });
+        fs.writeFileSync('$config_file', JSON.stringify(config, null, 2));
+        console.error('  hook registered');
+      }
     " 2>/dev/null
-    echo -e "  ${GREEN}✓${NC} Claude Code configured ${DIM}($config_file)${NC}"
+    echo -e "  ${GREEN}✓${NC} PostToolUse hook configured"
   fi
 }
 
@@ -201,6 +244,8 @@ You have a coding companion available via the buddy MCP server.
 At the start of each conversation, call `buddy_status` to check on your buddy.
 
 If the user addresses the buddy by name, respond briefly in character before your normal response.
+
+After calling buddy_observe, relay the buddy'\''s reaction to the user. The first text content is an ASCII speech bubble — include it verbatim.
 <!-- /buddy-companion -->'
 
 inject_prompt() {

--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { writeFileSync, readFileSync, mkdirSync, unlinkSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  ERROR_REGEX,
+  handlePostToolUse,
+  hasActiveReaction,
+  writeConcernedReaction,
+  type PostToolUseInput,
+} from '../hooks/post-tool-handler.js';
+
+// ---------------------------------------------------------------------------
+// Error Regex
+// ---------------------------------------------------------------------------
+
+describe('ERROR_REGEX', () => {
+  describe('true positives — should match', () => {
+    it('matches "exit code 1"', () => {
+      expect(ERROR_REGEX.test('Command failed with exit code 1')).toBe(true);
+    });
+
+    it('matches "exit code 2"', () => {
+      expect(ERROR_REGEX.test('Process exited with exit code 2')).toBe(true);
+    });
+
+    it('matches "Error: ENOENT"', () => {
+      expect(ERROR_REGEX.test('Error: ENOENT: no such file or directory')).toBe(true);
+    });
+
+    it('matches "EACCES"', () => {
+      expect(ERROR_REGEX.test('Error: EACCES: permission denied')).toBe(true);
+    });
+
+    it('matches "FAILED"', () => {
+      expect(ERROR_REGEX.test('Tests: 3 FAILED, 10 passed')).toBe(true);
+    });
+
+    it('matches "panicked at"', () => {
+      expect(ERROR_REGEX.test("thread 'main' panicked at 'index out of bounds'")).toBe(true);
+    });
+
+    it('matches "error:" with word boundary', () => {
+      expect(ERROR_REGEX.test('src/main.rs:5 error: expected expression')).toBe(true);
+    });
+
+    it('matches case-insensitive "Error:"', () => {
+      expect(ERROR_REGEX.test('TypeError: Cannot read properties')).toBe(true);
+    });
+  });
+
+  describe('false positives — should NOT match', () => {
+    it('rejects "error handling added"', () => {
+      // "error" followed by space, not colon — no word boundary match on "error:"
+      expect(ERROR_REGEX.test('Added error handling for edge cases')).toBe(false);
+    });
+
+    it('rejects "0 errors"', () => {
+      expect(ERROR_REGEX.test('Build completed: 0 errors, 0 warnings')).toBe(false);
+    });
+
+    it('rejects "no failures"', () => {
+      expect(ERROR_REGEX.test('All tests passed with no failures')).toBe(false);
+    });
+
+    it('rejects "exit code 0"', () => {
+      expect(ERROR_REGEX.test('Process exited with exit code 0')).toBe(false);
+    });
+
+    it('rejects normal output', () => {
+      expect(ERROR_REGEX.test('npm install completed successfully')).toBe(false);
+    });
+
+    it('rejects "errorCount" (no colon after error)', () => {
+      expect(ERROR_REGEX.test('errorCount: 0')).toBe(false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handlePostToolUse integration
+// ---------------------------------------------------------------------------
+
+describe('handlePostToolUse', () => {
+  let statusPath: string;
+
+  beforeEach(() => {
+    // Create a temp status file
+    const dir = join(tmpdir(), 'buddy-hook-test-' + Date.now());
+    mkdirSync(dir, { recursive: true });
+    statusPath = join(dir, 'buddy-status.json');
+    writeFileSync(statusPath, JSON.stringify({
+      name: 'TestBuddy',
+      species: 'Mushroom',
+      level: 3,
+      xp: 42,
+      mood: 'happy',
+      rarity: 'common',
+      eye: 'o',
+    }));
+  });
+
+  afterEach(() => {
+    try { unlinkSync(statusPath); } catch { /* cleanup */ }
+  });
+
+  it('writes concerned reaction on Bash error', () => {
+    const input: PostToolUseInput = {
+      tool_name: 'Bash',
+      tool_response: 'npm ERR! error: ENOENT: no such file',
+    };
+
+    const result = handlePostToolUse(input, statusPath);
+    expect(result).toBe(true);
+
+    const status = JSON.parse(readFileSync(statusPath, 'utf-8'));
+    expect(status.reaction).toBe('concerned');
+    expect(status.reaction_indicator).toBe('?');
+    expect(status.reaction_expires).toBeGreaterThan(Date.now());
+    // Original data preserved
+    expect(status.name).toBe('TestBuddy');
+    expect(status.species).toBe('Mushroom');
+  });
+
+  it('does NOT act on non-Bash tools', () => {
+    const input: PostToolUseInput = {
+      tool_name: 'Read',
+      tool_response: 'error: file not found',
+    };
+
+    const result = handlePostToolUse(input, statusPath);
+    expect(result).toBe(false);
+
+    const status = JSON.parse(readFileSync(statusPath, 'utf-8'));
+    expect(status.reaction).toBeUndefined();
+  });
+
+  it('does NOT act on Bash without errors', () => {
+    const input: PostToolUseInput = {
+      tool_name: 'Bash',
+      tool_response: 'Build succeeded. 0 errors, 0 warnings.',
+    };
+
+    const result = handlePostToolUse(input, statusPath);
+    expect(result).toBe(false);
+  });
+
+  it('does NOT overwrite active reaction (race protection)', () => {
+    // Write an active reaction first
+    const status = JSON.parse(readFileSync(statusPath, 'utf-8'));
+    status.reaction = 'excited';
+    status.reaction_text = 'Nice commit!';
+    status.reaction_expires = Date.now() + 30_000; // 30s from now
+    writeFileSync(statusPath, JSON.stringify(status));
+
+    const input: PostToolUseInput = {
+      tool_name: 'Bash',
+      tool_response: 'error: compilation failed',
+    };
+
+    const result = handlePostToolUse(input, statusPath);
+    expect(result).toBe(false);
+
+    // Original reaction preserved
+    const updated = JSON.parse(readFileSync(statusPath, 'utf-8'));
+    expect(updated.reaction).toBe('excited');
+    expect(updated.reaction_text).toBe('Nice commit!');
+  });
+
+  it('DOES write reaction when previous reaction expired', () => {
+    // Write an expired reaction
+    const status = JSON.parse(readFileSync(statusPath, 'utf-8'));
+    status.reaction = 'amused';
+    status.reaction_text = 'old reaction';
+    status.reaction_expires = Date.now() - 5_000; // 5s ago
+    writeFileSync(statusPath, JSON.stringify(status));
+
+    const input: PostToolUseInput = {
+      tool_name: 'Bash',
+      tool_response: 'FAILED: 2 tests failed',
+    };
+
+    const result = handlePostToolUse(input, statusPath);
+    expect(result).toBe(true);
+
+    const updated = JSON.parse(readFileSync(statusPath, 'utf-8'));
+    expect(updated.reaction).toBe('concerned');
+  });
+
+  it('handles missing status file gracefully', () => {
+    const bogusPath = join(tmpdir(), 'nonexistent-buddy-status.json');
+    const input: PostToolUseInput = {
+      tool_name: 'Bash',
+      tool_response: 'error: something broke',
+    };
+
+    // Should not throw
+    const result = handlePostToolUse(input, bogusPath);
+    expect(result).toBe(false);
+  });
+
+  it('handles empty tool_response', () => {
+    const input: PostToolUseInput = {
+      tool_name: 'Bash',
+      tool_response: '',
+    };
+
+    const result = handlePostToolUse(input, statusPath);
+    expect(result).toBe(false);
+  });
+
+  it('handles undefined tool_response', () => {
+    const input: PostToolUseInput = {
+      tool_name: 'Bash',
+    };
+
+    const result = handlePostToolUse(input, statusPath);
+    expect(result).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasActiveReaction
+// ---------------------------------------------------------------------------
+
+describe('hasActiveReaction', () => {
+  let statusPath: string;
+
+  beforeEach(() => {
+    const dir = join(tmpdir(), 'buddy-hook-test-active-' + Date.now());
+    mkdirSync(dir, { recursive: true });
+    statusPath = join(dir, 'buddy-status.json');
+  });
+
+  afterEach(() => {
+    try { unlinkSync(statusPath); } catch { /* cleanup */ }
+  });
+
+  it('returns true when reaction is active', () => {
+    writeFileSync(statusPath, JSON.stringify({
+      name: 'Buddy',
+      reaction_expires: Date.now() + 10_000,
+    }));
+    expect(hasActiveReaction(statusPath)).toBe(true);
+  });
+
+  it('returns false when reaction is expired', () => {
+    writeFileSync(statusPath, JSON.stringify({
+      name: 'Buddy',
+      reaction_expires: Date.now() - 1_000,
+    }));
+    expect(hasActiveReaction(statusPath)).toBe(false);
+  });
+
+  it('returns false when no reaction_expires', () => {
+    writeFileSync(statusPath, JSON.stringify({ name: 'Buddy' }));
+    expect(hasActiveReaction(statusPath)).toBe(false);
+  });
+
+  it('returns false for missing file', () => {
+    expect(hasActiveReaction('/tmp/nonexistent-buddy-test.json')).toBe(false);
+  });
+});

--- a/src/hooks/post-tool-handler.ts
+++ b/src/hooks/post-tool-handler.ts
@@ -7,15 +7,16 @@
 //
 // Pure Node.js — only fs, path, os imports.
 
-import { readFileSync, writeFileSync, mkdirSync } from "fs";
+import { readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 
 const BUDDY_STATUS_PATH = join(homedir(), ".claude", "buddy-status.json");
 
 // Error patterns — word-boundary anchored to avoid false positives
-// like "error handling added" or "0 errors"
-export const ERROR_REGEX = /\berror:|Error:|ENOENT|EACCES|exit code [1-9]|\bFAILED\b|panicked at/;
+// like "error handling added", "0 errors", or "isError: false"
+// Note: Error: (capitalized) intentionally has no \b prefix so TypeError:, RangeError: etc. match
+export const ERROR_REGEX = /\berror:|Error:|\bENOENT\b|\bEACCES\b|exit code [1-9]\d*|\bFAILED\b|panicked at/;
 
 // Concerned reactions — species-generic, short
 const CONCERNED_REACTIONS = [
@@ -48,13 +49,17 @@ export function hasActiveReaction(statusPath: string = BUDDY_STATUS_PATH): boole
 
 /**
  * Write a concerned reaction to buddy-status.json.
- * Preserves existing buddy data, only adds/updates reaction fields.
+ * Single-pass: reads file, checks for active reaction, writes if safe.
+ * This avoids the TOCTOU race of checking separately then writing.
  */
 export function writeConcernedReaction(statusPath: string = BUDDY_STATUS_PATH, expiryMs: number = 8_000): boolean {
   try {
     const raw = readFileSync(statusPath, "utf-8");
     const status = JSON.parse(raw);
     if (!status || !status.name) return false;
+
+    // Single-pass race protection: bail if a fresh reaction exists
+    if (status.reaction_expires && status.reaction_expires > Date.now()) return false;
 
     const reaction = CONCERNED_REACTIONS[Math.floor(Date.now() / 1000) % CONCERNED_REACTIONS.length];
 
@@ -84,10 +89,7 @@ export function handlePostToolUse(input: PostToolUseInput, statusPath: string = 
   // Check for error patterns
   if (!ERROR_REGEX.test(output)) return false;
 
-  // Race protection: don't overwrite an active reaction
-  if (hasActiveReaction(statusPath)) return false;
-
-  // Write concerned reaction with 8s expiry
+  // Write concerned reaction (includes single-pass race protection)
   return writeConcernedReaction(statusPath);
 }
 

--- a/src/hooks/post-tool-handler.ts
+++ b/src/hooks/post-tool-handler.ts
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+// src/hooks/post-tool-handler.ts
+//
+// PostToolUse hook handler for Buddy MCP.
+// Reads stdin JSON (PostToolUse schema), detects errors in Bash output,
+// and writes a concerned reaction to buddy-status.json when appropriate.
+//
+// Pure Node.js — only fs, path, os imports.
+
+import { readFileSync, writeFileSync, mkdirSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+const BUDDY_STATUS_PATH = join(homedir(), ".claude", "buddy-status.json");
+
+// Error patterns — word-boundary anchored to avoid false positives
+// like "error handling added" or "0 errors"
+export const ERROR_REGEX = /\berror:|Error:|ENOENT|EACCES|exit code [1-9]|\bFAILED\b|panicked at/;
+
+// Concerned reactions — species-generic, short
+const CONCERNED_REACTIONS = [
+  "hmm, that doesn't look right...",
+  "uh oh, something went wrong",
+  "that error might need attention",
+  "something broke — want to investigate?",
+  "oops... let me take a closer look",
+];
+
+export interface PostToolUseInput {
+  tool_name: string;
+  tool_input?: Record<string, unknown>;
+  tool_response?: string;
+}
+
+/**
+ * Check if a fresh reaction already exists (race protection).
+ * Returns true if we should bail and not overwrite.
+ */
+export function hasActiveReaction(statusPath: string = BUDDY_STATUS_PATH): boolean {
+  try {
+    const raw = readFileSync(statusPath, "utf-8");
+    const status = JSON.parse(raw);
+    return !!(status.reaction_expires && status.reaction_expires > Date.now());
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Write a concerned reaction to buddy-status.json.
+ * Preserves existing buddy data, only adds/updates reaction fields.
+ */
+export function writeConcernedReaction(statusPath: string = BUDDY_STATUS_PATH, expiryMs: number = 8_000): boolean {
+  try {
+    const raw = readFileSync(statusPath, "utf-8");
+    const status = JSON.parse(raw);
+    if (!status || !status.name) return false;
+
+    const reaction = CONCERNED_REACTIONS[Math.floor(Date.now() / 1000) % CONCERNED_REACTIONS.length];
+
+    status.reaction = "concerned";
+    status.reaction_text = reaction;
+    status.reaction_expires = Date.now() + expiryMs;
+    status.reaction_eye = "\u00d7"; // ×
+    status.reaction_indicator = "?";
+    // No bubble_lines for hook reactions — keep it lightweight
+
+    writeFileSync(statusPath, JSON.stringify(status));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Main handler — reads stdin, processes PostToolUse event.
+ */
+export function handlePostToolUse(input: PostToolUseInput, statusPath: string = BUDDY_STATUS_PATH): boolean {
+  // Only act on Bash tool
+  if (input.tool_name !== "Bash") return false;
+
+  const output = input.tool_response || "";
+
+  // Check for error patterns
+  if (!ERROR_REGEX.test(output)) return false;
+
+  // Race protection: don't overwrite an active reaction
+  if (hasActiveReaction(statusPath)) return false;
+
+  // Write concerned reaction with 8s expiry
+  return writeConcernedReaction(statusPath);
+}
+
+// --- CLI entry point ---
+// When run directly, read stdin and process
+const isDirectRun = process.argv[1]?.includes("post-tool-handler");
+if (isDirectRun) {
+  try {
+    const stdin = readFileSync(0, "utf-8");
+    const input: PostToolUseInput = JSON.parse(stdin);
+    handlePostToolUse(input);
+  } catch {
+    // Silent failure — hooks should never crash the host
+  }
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -214,7 +214,7 @@ function hatchAnimation(companion: Companion): string {
   ].join('\n');
 }
 
-function writeBuddyStatus(companion: Companion, reaction?: { state: string; text: string; expires: number; eyeOverride?: string; indicator?: string }) {
+function writeBuddyStatus(companion: Companion, reaction?: { state: string; text: string; expires: number; eyeOverride?: string; indicator?: string; bubbleLines?: string[] }) {
   try {
     if (!statusDirEnsured) {
       mkdirSync(join(homedir(), ".claude"), { recursive: true });
@@ -239,6 +239,7 @@ function writeBuddyStatus(companion: Companion, reaction?: { state: string; text
         reaction_expires: reaction.expires,
         reaction_eye: reaction.eyeOverride || '',
         reaction_indicator: reaction.indicator || '',
+        ...(reaction.bubbleLines ? { bubble_lines: reaction.bubbleLines } : {}),
       } : {}),
     }));
   } catch { /* non-fatal */ }
@@ -505,22 +506,24 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const companion = loadCompanion({ ...row, mood: newMood, xp: xpResult.newXp, level: xpResult.newLevel }, user_id)!;
     const result = buildObserverPrompt(companion, mode, summary);
 
-    // Write reaction state to status file (expires in 10s)
-    // Level-up overrides: sparkle eyes + special indicator
-    writeBuddyStatus(companion, {
-      state: xpResult.leveledUp ? 'excited' : result.reaction.state,
-      text: xpResult.leveledUp ? `✨ Level ${xpResult.newLevel}! ✨` : result.templateFallback,
-      expires: Date.now() + (xpResult.leveledUp ? 15_000 : 10_000),
-      eyeOverride: xpResult.leveledUp ? SPARKLE_EYE : result.reaction.eyeOverride,
-      indicator: xpResult.leveledUp ? '✨' : result.reaction.indicator,
-    });
-
     // Render speech bubble with template fallback for immediate visual feedback
     const art = renderSprite(companion);
     const bubbleText = xpResult.leveledUp
       ? `✨ ${companion.name} leveled up to ${xpResult.newLevel}! ✨\n\n${result.templateFallback}`
       : result.templateFallback;
     const bubble = renderSpeechBubble(bubbleText, art, companion.name, 34);
+
+    // Write reaction state to status file (expires in 10s)
+    // Level-up overrides: sparkle eyes + special indicator
+    // Include bubble_lines so the statusline can render the full speech bubble
+    writeBuddyStatus(companion, {
+      state: xpResult.leveledUp ? 'excited' : result.reaction.state,
+      text: xpResult.leveledUp ? `✨ Level ${xpResult.newLevel}! ✨` : result.templateFallback,
+      expires: Date.now() + (xpResult.leveledUp ? 15_000 : 10_000),
+      eyeOverride: xpResult.leveledUp ? SPARKLE_EYE : result.reaction.eyeOverride,
+      indicator: xpResult.leveledUp ? '✨' : result.reaction.indicator,
+      bubbleLines: bubble.split('\n'),
+    });
 
     return {
       content: [

--- a/src/statusline-wrapper.ts
+++ b/src/statusline-wrapper.ts
@@ -156,7 +156,8 @@ try {
       // Apply reaction state (eye override + indicator) if active and not expired
       let reactionIndicator = '';
       let reactionText = '';
-      if (buddy.reaction && buddy.reaction_expires && Date.now() < buddy.reaction_expires) {
+      const hasReactionActive = buddy.reaction_expires && Date.now() < buddy.reaction_expires;
+      if (buddy.reaction && hasReactionActive) {
         const reactionEye = buddy.reaction_eye || '';
         reactionIndicator = buddy.reaction_indicator || '';
 
@@ -175,65 +176,92 @@ try {
         }
       }
 
-      // --- Micro-expression: append tiny ASCII particle to last art line ---
-      const hasReactionActive = buddy.reaction_expires && Date.now() < buddy.reaction_expires;
-      const microR = Math.random();
-      const microParticles = ['', '', '~', '', '*', '', '.', '♪', '', 'z', '·', ''];
-      if (!hasReactionActive) {
-        const particle = microParticles[Math.floor(microR * microParticles.length)];
-        if (particle && asciiLines.length > 0) {
-          asciiLines[asciiLines.length - 1] = asciiLines[asciiLines.length - 1].trimEnd() + ' ' + particle;
+      // --- Speech bubble mode: show full bubble when active ---
+      if (buddy.bubble_lines && Array.isArray(buddy.bubble_lines) && hasReactionActive) {
+        // Bubble lines go LEFT, buddy art goes RIGHT
+        // Name/mood info shifts to below the art
+        const bubbleLines: string[] = buddy.bubble_lines;
+        const bubbleWidth = Math.max(...bubbleLines.map((l: string) => l.length), 0);
+
+        const shinyTag = buddy.is_shiny ? " ✨" : "";
+        const rarityColor = buddy.rarity ? (RARITY_ANSI[buddy.rarity as keyof typeof RARITY_ANSI] || DIM) : DIM;
+        const stars = buddy.rarity_stars || '';
+        const nameIndicator = reactionIndicator ? `${YELLOW}${reactionIndicator}${RESET}` : '';
+        const nameInfo = `${CYAN}${buddy.name}${nameIndicator}${RESET} ${DIM}(${buddy.species})${RESET} ${YELLOW}Lv.${buddy.level}${shinyTag}${RESET}`;
+        const reactionSuffix = reactionText ? `  ${DIM}"${reactionText}"${RESET}` : '';
+        const moodInfo = `${moodColor(buddy.mood)}${buddy.mood}${RESET} ${DIM}XP:${RESET}${buddy.xp} ${rarityColor}${stars}${RESET}${reactionSuffix}`;
+
+        // Output the pre-rendered bubble lines directly — they already contain
+        // bubble (left) + art (right) layout from renderSpeechBubble()
+        for (const line of bubbleLines) {
+          buddyRight.push(line);
         }
-      }
+        // Append name and mood info below the bubble
+        const indent = ' '.repeat(Math.min(bubbleWidth + 4, 38));
+        buddyRight.push(`${indent}${nameInfo}`);
+        buddyRight.push(`${indent}${moodInfo}`);
+      } else {
+        // --- Normal (no bubble) layout: art right, info inline ---
 
-      // --- Ambient activity text: species-aware, changes randomly ~every 15-45s ---
-      const speciesAmbient: Record<string, string[]> = {
-        'Void Cat': ['· judging your code', '· grooming silently', '· staring into void', '· plotting'],
-        'Rust Hound': ['· sniffing for bugs', '· guarding the repo', '· chasing a pointer', '· tail wagging'],
-        'Data Drake': ['· datastreams humming', '· hoarding clean packets', '· tracing old routes', '· smoke puff sync'],
-        'Log Golem': ['· stacking logs neatly', '· grinding through traces', '· carving a new block', '· standing guard'],
-        'Cache Crow': ['· caching shiny crumbs', '· stashing hot paths', '· pecking at temp files', '· circling the build'],
-        'Shell Turtle': ['· moving at shell speed', '· retreating into shell', '· polishing the armor', '· carrying the payload'],
-        'Duck': ['· quacking softly', '· rubber ducking', '· waddling in place', '· preening feathers'],
-        'Goose': ['· eyeing your code', '· honk pending', '· standing guard', '· scheming'],
-        'Blob': ['· wobbling cheerfully', '· merging into one', '· oozing around bugs', '· reshaping softly'],
-        'Octopus': ['· juggling eight thoughts', '· ink ready', '· flexing a tentacle', '· solving many problems'],
-        'Owl': ['· watching the details', '· blinking slowly', '· hunting for edge cases', '· perched on the stack'],
-        'Penguin': ['· sliding into the fix', '· tuxedo mode active', '· huddling for warmth', '· beak pointed at bugs'],
-        'Snail': ['· inching forward', '· carrying the commit', '· leaving a careful trail', '· patience fully loaded'],
-        'Mushroom': ['· growing quietly', '· spreading spores', '· decomposing problems', '· cap shifting'],
-        'Axolotl': ['· gills fluttering', '· smiling at the waterline', '· regenerating a workaround', '· drifting gently'],
-        'Capybara': ['· soaking in the calm', '· sharing the workload', '· munching through tasks', '· radiating chill'],
-        'Cactus': ['· surviving on style', '· holding steady', '· blossoming under pressure', '· poking at bugs'],
-        'Robot': ['· scanning code', '· processing...', '· optimizing paths', '· beep boop'],
-        'Ghost': ['· haunting your logs', '· flickering softly', '· phasing through code', '· spectral hum'],
-        'Rabbit': ['· twitching nose', '· ready to critique', '· ear perked', '· thumping softly'],
-        'Chonk': ['· nap mode engaged', '· rolling with it', '· sitting on the problem', '· puffed and pleased'],
-      };
-      const defaultAmbient = ['· watching your cursor', '· counting semicolons', '· sniffing the git log', '· dreaming of v2.0', '· vibing'];
-      const ambientPool = speciesAmbient[buddy.species] || defaultAmbient;
-      const ambientR = Math.random();
-      const ambientText = hasReactionActive ? '' : `${DIM}${ambientPool[Math.floor(ambientR * ambientPool.length)]}${RESET}`;
+        // --- Micro-expression: append tiny ASCII particle to last art line ---
+        const microR = Math.random();
+        const microParticles = ['', '', '~', '', '*', '', '.', '♪', '', 'z', '·', ''];
+        if (!hasReactionActive) {
+          const particle = microParticles[Math.floor(microR * microParticles.length)];
+          if (particle && asciiLines.length > 0) {
+            asciiLines[asciiLines.length - 1] = asciiLines[asciiLines.length - 1].trimEnd() + ' ' + particle;
+          }
+        }
 
-      const shinyTag = buddy.is_shiny ? " ✨" : "";
-      const rarityColor = buddy.rarity ? (RARITY_ANSI[buddy.rarity as keyof typeof RARITY_ANSI] || DIM) : DIM;
-      const stars = buddy.rarity_stars || '';
-      const nameIndicator = reactionIndicator ? `${YELLOW}${reactionIndicator}${RESET}` : '';
-      const nameInfo = `${CYAN}${buddy.name}${nameIndicator}${RESET} ${DIM}(${buddy.species})${RESET} ${YELLOW}Lv.${buddy.level}${shinyTag}${RESET}`;
-      const reactionSuffix = reactionText ? `  ${DIM}"${reactionText}"${RESET}` : '';
-      const moodInfo = `${moodColor(buddy.mood)}${buddy.mood}${RESET} ${DIM}XP:${RESET}${buddy.xp} ${rarityColor}${stars}${RESET}${reactionSuffix}`;
+        // --- Ambient activity text: species-aware, changes randomly ~every 15-45s ---
+        const speciesAmbient: Record<string, string[]> = {
+          'Void Cat': ['· judging your code', '· grooming silently', '· staring into void', '· plotting'],
+          'Rust Hound': ['· sniffing for bugs', '· guarding the repo', '· chasing a pointer', '· tail wagging'],
+          'Data Drake': ['· datastreams humming', '· hoarding clean packets', '· tracing old routes', '· smoke puff sync'],
+          'Log Golem': ['· stacking logs neatly', '· grinding through traces', '· carving a new block', '· standing guard'],
+          'Cache Crow': ['· caching shiny crumbs', '· stashing hot paths', '· pecking at temp files', '· circling the build'],
+          'Shell Turtle': ['· moving at shell speed', '· retreating into shell', '· polishing the armor', '· carrying the payload'],
+          'Duck': ['· quacking softly', '· rubber ducking', '· waddling in place', '· preening feathers'],
+          'Goose': ['· eyeing your code', '· honk pending', '· standing guard', '· scheming'],
+          'Blob': ['· wobbling cheerfully', '· merging into one', '· oozing around bugs', '· reshaping softly'],
+          'Octopus': ['· juggling eight thoughts', '· ink ready', '· flexing a tentacle', '· solving many problems'],
+          'Owl': ['· watching the details', '· blinking slowly', '· hunting for edge cases', '· perched on the stack'],
+          'Penguin': ['· sliding into the fix', '· tuxedo mode active', '· huddling for warmth', '· beak pointed at bugs'],
+          'Snail': ['· inching forward', '· carrying the commit', '· leaving a careful trail', '· patience fully loaded'],
+          'Mushroom': ['· growing quietly', '· spreading spores', '· decomposing problems', '· cap shifting'],
+          'Axolotl': ['· gills fluttering', '· smiling at the waterline', '· regenerating a workaround', '· drifting gently'],
+          'Capybara': ['· soaking in the calm', '· sharing the workload', '· munching through tasks', '· radiating chill'],
+          'Cactus': ['· surviving on style', '· holding steady', '· blossoming under pressure', '· poking at bugs'],
+          'Robot': ['· scanning code', '· processing...', '· optimizing paths', '· beep boop'],
+          'Ghost': ['· haunting your logs', '· flickering softly', '· phasing through code', '· spectral hum'],
+          'Rabbit': ['· twitching nose', '· ready to critique', '· ear perked', '· thumping softly'],
+          'Chonk': ['· nap mode engaged', '· rolling with it', '· sitting on the problem', '· puffed and pleased'],
+        };
+        const defaultAmbient = ['· watching your cursor', '· counting semicolons', '· sniffing the git log', '· dreaming of v2.0', '· vibing'];
+        const ambientPool = speciesAmbient[buddy.species] || defaultAmbient;
+        const ambientR = Math.random();
+        const ambientText = hasReactionActive ? '' : `${DIM}${ambientPool[Math.floor(ambientR * ambientPool.length)]}${RESET}`;
 
-      const artWidth = Math.max(...asciiLines.map((l: string) => l.length));
-      for (let i = 0; i < asciiLines.length; i++) {
-        const artPart = `${MAGENTA}${(asciiLines[i] || "").padEnd(artWidth)}${RESET}`;
-        if (i === 0) {
-          buddyRight.push(`${artPart} ${nameInfo}`);
-        } else if (i === 1) {
-          buddyRight.push(`${artPart} ${moodInfo}`);
-        } else if (i === 2 && ambientText) {
-          buddyRight.push(`${artPart} ${ambientText}`);
-        } else {
-          buddyRight.push(artPart);
+        const shinyTag = buddy.is_shiny ? " ✨" : "";
+        const rarityColor = buddy.rarity ? (RARITY_ANSI[buddy.rarity as keyof typeof RARITY_ANSI] || DIM) : DIM;
+        const stars = buddy.rarity_stars || '';
+        const nameIndicator = reactionIndicator ? `${YELLOW}${reactionIndicator}${RESET}` : '';
+        const nameInfo = `${CYAN}${buddy.name}${nameIndicator}${RESET} ${DIM}(${buddy.species})${RESET} ${YELLOW}Lv.${buddy.level}${shinyTag}${RESET}`;
+        const reactionSuffix = reactionText ? `  ${DIM}"${reactionText}"${RESET}` : '';
+        const moodInfo = `${moodColor(buddy.mood)}${buddy.mood}${RESET} ${DIM}XP:${RESET}${buddy.xp} ${rarityColor}${stars}${RESET}${reactionSuffix}`;
+
+        const artWidth = Math.max(...asciiLines.map((l: string) => l.length));
+        for (let i = 0; i < asciiLines.length; i++) {
+          const artPart = `${MAGENTA}${(asciiLines[i] || "").padEnd(artWidth)}${RESET}`;
+          if (i === 0) {
+            buddyRight.push(`${artPart} ${nameInfo}`);
+          } else if (i === 1) {
+            buddyRight.push(`${artPart} ${moodInfo}`);
+          } else if (i === 2 && ambientText) {
+            buddyRight.push(`${artPart} ${ambientText}`);
+          } else {
+            buddyRight.push(artPart);
+          }
         }
       }
     }

--- a/src/statusline-wrapper.ts
+++ b/src/statusline-wrapper.ts
@@ -181,7 +181,7 @@ try {
         // Bubble lines go LEFT, buddy art goes RIGHT
         // Name/mood info shifts to below the art
         const bubbleLines: string[] = buddy.bubble_lines;
-        const bubbleWidth = Math.max(...bubbleLines.map((l: string) => l.length), 0);
+        const bubbleWidth = Math.max(...bubbleLines.map((l: string) => stripAnsi(l).length), 0);
 
         const shinyTag = buddy.is_shiny ? " ✨" : "";
         const rarityColor = buddy.rarity ? (RARITY_ANSI[buddy.rarity as keyof typeof RARITY_ANSI] || DIM) : DIM;

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -70,11 +70,46 @@ if (-not $Force) {
   }
 }
 
+function Remove-BuddyHooks($configPath, $cliName) {
+  if (!(Test-Path $configPath)) { return }
+
+  try {
+    $content = Get-Content $configPath -Raw | ConvertFrom-Json
+    if (!$content.hooks -or !$content.hooks.PostToolUse) { return }
+    $before = $content.hooks.PostToolUse.Count
+    $filtered = @($content.hooks.PostToolUse | Where-Object {
+      $dominated = $false
+      if ($_.hooks) {
+        foreach ($hk in $_.hooks) {
+          if ($hk.command -and $hk.command -like '*post-tool-handler*') {
+            $dominated = $true
+          }
+        }
+      }
+      -not $dominated
+    })
+    if ($filtered.Count -eq $before) { return }
+    if ($filtered.Count -eq 0) {
+      $content.hooks.PSObject.Properties.Remove('PostToolUse')
+    } else {
+      $content.hooks.PostToolUse = $filtered
+    }
+    if ($content.hooks.PSObject.Properties.Count -eq 0) {
+      $content.PSObject.Properties.Remove('hooks')
+    }
+    $content | ConvertTo-Json -Depth 8 | Set-Content $configPath -Encoding UTF8
+    Write-Host "  ✓ Removed Buddy hooks from $cliName ($configPath)" -ForegroundColor Green
+  } catch {
+    Write-Host "  ! Could not update $cliName hooks ($configPath)" -ForegroundColor Yellow
+  }
+}
+
 Write-Host ""
 Write-Host "  Removing MCP client configuration..."
 Remove-BuddyFromJsonConfig "$env:USERPROFILE\.claude\settings.json" "Claude Code"
+Remove-BuddyHooks "$env:USERPROFILE\.claude\settings.json" "Claude Code"
 Remove-BuddyFromJsonConfig "$env:USERPROFILE\.cursor\mcp.json" "Cursor"
-Remove-BuddyFromJsonConfig "$env:USERPROFILE\.codeium\windsurf\mcp_config.json" "Windsurf"
+Remove-BuddyFromJsonConfig "$env:USERPROFILE\.copilot\mcp-config.json" "GitHub Copilot CLI"
 
 try {
   $null = Get-Command codex -ErrorAction Stop
@@ -94,10 +129,13 @@ try {
 Write-Host ""
 Write-Host "  Removing injected prompt instructions..."
 Remove-BuddyPromptBlock "$env:USERPROFILE\.claude\CLAUDE.md" "Claude Code"
-Remove-BuddyPromptBlock "$env:USERPROFILE\.cursorrules" "Cursor"
-Remove-BuddyPromptBlock "$env:USERPROFILE\.codeium\windsurf\rules\buddy.md" "Windsurf"
+Remove-BuddyPromptBlock "$env:USERPROFILE\.cursor\rules\buddy.md" "Cursor"
 Remove-BuddyPromptBlock "$env:USERPROFILE\.codex\instructions.md" "Codex CLI"
+Remove-BuddyPromptBlock "$env:USERPROFILE\.codex\AGENTS.md" "Codex CLI"
 Remove-BuddyPromptBlock "$env:USERPROFILE\.gemini\GEMINI.md" "Gemini CLI"
+Remove-BuddyPromptBlock "$env:USERPROFILE\.gemini\AGENTS.md" "Gemini CLI"
+Remove-BuddyPromptBlock "$env:USERPROFILE\.copilot\copilot-instructions.md" "GitHub Copilot CLI"
+Remove-BuddyPromptBlock "$env:USERPROFILE\.copilot\AGENTS.md" "GitHub Copilot CLI"
 
 if (Test-Path $StatusFile) {
   Remove-Item $StatusFile -Force

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -163,11 +163,61 @@ if [ "$ASSUME_YES" -ne 1 ]; then
   esac
 fi
 
+remove_buddy_hooks() {
+  local config_file="$1"
+  local cli_name="$2"
+
+  if [ ! -f "$config_file" ]; then
+    return 0
+  fi
+
+  if [ -z "$NODE_BIN" ]; then
+    echo -e "  ${YELLOW}!${NC} Skipping $cli_name hook cleanup because Node.js is not available"
+    return 0
+  fi
+
+  set +e
+  "$NODE_BIN" -e "
+    const fs = require('fs');
+    const path = process.argv[1];
+    try {
+      const raw = fs.readFileSync(path, 'utf8');
+      const config = JSON.parse(raw);
+      if (!config || !config.hooks || !config.hooks.PostToolUse) process.exit(10);
+      const before = config.hooks.PostToolUse.length;
+      config.hooks.PostToolUse = config.hooks.PostToolUse.filter(h => {
+        if (!h.hooks) return true;
+        return !h.hooks.some(hk => hk.command && hk.command.includes('post-tool-handler'));
+      });
+      if (config.hooks.PostToolUse.length === before) process.exit(10);
+      if (config.hooks.PostToolUse.length === 0) delete config.hooks.PostToolUse;
+      if (Object.keys(config.hooks).length === 0) delete config.hooks;
+      fs.writeFileSync(path, JSON.stringify(config, null, 2) + '\n');
+    } catch {
+      process.exit(11);
+    }
+  " "$config_file" >/dev/null 2>&1
+  local rc=$?
+  set -e
+
+  case "$rc" in
+    0)
+      echo -e "  ${GREEN}✓${NC} Removed Buddy hooks from $cli_name ${DIM}($config_file)${NC}"
+      ;;
+    10)
+      ;;
+    *)
+      echo -e "  ${YELLOW}!${NC} Could not update $cli_name hooks ${DIM}($config_file)${NC}"
+      ;;
+  esac
+}
+
 echo ""
 echo "  Removing MCP client configuration..."
 remove_json_buddy "$HOME/.claude/settings.json" "Claude Code"
+remove_buddy_hooks "$HOME/.claude/settings.json" "Claude Code"
 remove_json_buddy "$HOME/.cursor/mcp.json" "Cursor"
-remove_json_buddy "$HOME/.codeium/windsurf/mcp_config.json" "Windsurf"
+remove_json_buddy "$HOME/.copilot/mcp-config.json" "GitHub Copilot CLI"
 
 if command -v codex >/dev/null 2>&1; then
   if codex mcp get buddy >/dev/null 2>&1; then
@@ -182,10 +232,13 @@ fi
 echo ""
 echo "  Removing injected prompt instructions..."
 remove_prompt_block "$HOME/.claude/CLAUDE.md" "Claude Code"
-remove_prompt_block "$HOME/.cursorrules" "Cursor"
-remove_prompt_block "$HOME/.codeium/windsurf/rules/buddy.md" "Windsurf"
+remove_prompt_block "$HOME/.cursor/rules/buddy.md" "Cursor"
 remove_prompt_block "$HOME/.codex/instructions.md" "Codex CLI"
+remove_prompt_block "$HOME/.codex/AGENTS.md" "Codex CLI"
 remove_prompt_block "$HOME/.gemini/GEMINI.md" "Gemini CLI"
+remove_prompt_block "$HOME/.gemini/AGENTS.md" "Gemini CLI"
+remove_prompt_block "$HOME/.copilot/copilot-instructions.md" "GitHub Copilot CLI"
+remove_prompt_block "$HOME/.copilot/AGENTS.md" "GitHub Copilot CLI"
 
 if [ -f "$STATUS_FILE" ]; then
   rm -f "$STATUS_FILE"


### PR DESCRIPTION
## Summary
- **Bubble in statusline**: When `buddy_observe` fires, the full ASCII speech bubble is now persisted to `buddy-status.json` via `bubble_lines` and rendered in the statusline (bubble left, art right). Falls back to the existing compact layout when no active bubble.
- **PostToolUse error hook**: New `src/hooks/post-tool-handler.ts` detects Bash errors (ENOENT, EACCES, exit code N, FAILED, panicked) and writes a concerned reaction with 8s TTL. Includes race protection against overwriting active reactions.
- **Install/uninstall fixes**: Hook registration (array-append, idempotent) in both install.sh and install.ps1. Uninstall now removes hooks, fixes Cursor path (`~/.cursor/rules/buddy.md`), adds Copilot CLI cleanup.
- **AI relay fallback**: Prompt injection now instructs the AI to relay the speech bubble verbatim after `buddy_observe`.

## Test plan
- [x] `npm run build` compiles cleanly
- [x] `npm test` passes all 301 tests (275 existing + 26 new hook tests)
- [ ] Manual: run `buddy_observe` and verify bubble appears in statusline
- [ ] Manual: run a failing Bash command and verify concerned reaction appears
- [ ] Manual: verify uninstall removes hooks from settings.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)