### PR TITLE
docs: redesign README landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ hatch a buddy
 | **Persistent memory** | Save local memories and keep a continuous companion state |
 | **Cross-client setup** | Claude Code, Codex, Gemini, Copilot, Cursor, and other MCP-capable CLIs |
 
+### Nuzzlecap doing an actual code review
+
+![Nuzzlecap Code Review](demo/screenshots/code-review.png)
+
 ## Supported Clients
 
 | Client | Status |
@@ -142,11 +146,13 @@ Buddy ships with 21 companions, including:
 ### 5 personality stats
 
 ```text
-DEBUGGING  ███████▓   92
-PATIENCE   ██▓░░░░░   28
-CHAOS      █████░░░   60
-WISDOM     ██████▓░   78
-SNARK      ██████▓░   85
+.________________________________.
+| DEBUGGING  ███████▓   92        |
+| PATIENCE   ██▓░░░░░   28        |
+| CHAOS      █████░░░   60        |
+| WISDOM     ██████▓░   78        |
+| SNARK      ██████▓░   85        |
+'________________________________'
 ```
 
 These stats shape how your buddy behaves:

--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ There is also a 1% shiny chance on any hatch.
 <details>
 <summary><strong>See the core tools and commands</strong></summary>
 
+These stay tucked away by default, but Buddy exposes a real MCP surface for companion state, reactions, and progression.
+
 ### MCP tools
 
 | Tool | Description |
@@ -242,6 +244,13 @@ There is also a 1% shiny chance on any hatch.
 | `buddy_unmute` | Resume reactions |
 | `buddy_respawn` | Reset and start over |
 
+The most important loop is:
+
+- `buddy_hatch` creates the companion
+- `buddy_status` shows the current card, mood, and progression
+- `buddy_observe` gives in-character reactions and awards XP after real work
+- `buddy_pet` adds interaction and helps keep the buddy feeling alive
+
 ### MCP resources
 
 | URI | Description |
@@ -249,6 +258,8 @@ There is also a 1% shiny chance on any hatch.
 | `buddy://companion` | Full buddy JSON state |
 | `buddy://status` | ASCII status card |
 | `buddy://intro` | Prompt text for host CLI integration |
+
+Those resources let host clients keep Buddy present in the session without hard-coding one terminal or editor.
 
 </details>
 
@@ -263,15 +274,26 @@ AI terminal client
     -> Buddy server
       -> SQLite state
       -> species + rarity engine
-      -> observer / memory / XP systems
+      -> mood / memory / XP systems
+      -> reaction and status rendering
 ```
 
 The flow is simple:
 
 1. `buddy_hatch` creates or restores a companion.
 2. State is stored locally in `~/.buddy/buddy.db`.
-3. `buddy_observe` reacts to task summaries instead of reading your whole repository.
-4. The host CLI uses Buddy's MCP tools and resources to keep the companion present in your workflow.
+3. `buddy_observe` reacts to task summaries instead of reading your whole repository, then awards XP and can trigger level-ups.
+4. `buddy_pet` and other interactions feed the mood system, so the companion can become happier over time.
+5. The host CLI uses Buddy's MCP tools and resources to keep the companion present in your workflow.
+
+Under the hood, Buddy combines:
+
+- deterministic species and personality generation
+- local SQLite persistence for companion state and memories
+- an observer system for live code feedback
+- mood recalculation from interaction history
+- XP and leveling progression
+- status-card and terminal rendering for the companion presence layer
 
 This keeps Buddy:
 

--- a/README.md
+++ b/README.md
@@ -279,16 +279,13 @@ npm start
 
 </details>
 
-## Sources and Attribution
+## Credits
 
-Buddy is part of a broader community effort to preserve the `/buddy` experience after it disappeared from hosted clients. This implementation is not presented as appearing from nowhere. It builds on public community work, public documentation, and the open protocol surface exposed by MCP-capable terminals.
-
-- [save-buddy](https://github.com/jrykn/save-buddy) by [@jrykn](https://github.com/jrykn) is a strong reference point for transparent provenance. Its README and methodology framing are a good example of explicitly documenting where preservation ideas came from and how reconstruction work should be credited.
-- [claude-buddy](https://github.com/1270011/claude-buddy) by [@1270011](https://github.com/1270011) helped establish the community pattern of rebuilding buddy-like behavior around stable extension points instead of brittle patching. The MCP plus terminal-integration approach in projects like this helped validate that the companion experience could survive client churn.
-- Public community reverse-engineering and discussion around the original buddy behavior, including research threads that identified endpoint behavior and reconstruction details, helped shape the preservation direction for projects in this space.
-- Official documentation for MCP and host-client integration contracts remains foundational for Buddy's portable architecture. The project relies on the documented MCP server model and on supported client configuration surfaces rather than patching hidden binaries.
-
-If you are building in this area too, credit upstream community research clearly. These preservation projects are strongest when the lineage stays visible.
+- Original buddy concept by [Anthropic](https://www.anthropic.com/) in Claude Code `v2.1.89` to `v2.1.94`
+- Inspired by [any-buddy](https://github.com/your-diary/any-buddy), [buddy-reroll](https://github.com/paradoxical-dev/buddy-reroll), and [ccbuddyy](https://github.com/chroxify/ccbuddyy)
+- Built with the [Model Context Protocol](https://modelcontextprotocol.io/)
+- Community preservation reference: [claude-buddy](https://github.com/1270011/claude-buddy)
+- Transparent provenance reference: [save-buddy](https://github.com/jrykn/save-buddy)
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,15 @@ n  ____  n        .[||].             (\__/)         .-o-OO-o-.
  `------'
 ```
 
+<details>
+<summary><strong>See the original community species sheet style</strong></summary>
+
+For reference, here is the species SVG from [any-buddy](https://github.com/cpaczek/any-buddy/blob/main/assets/species.svg), which helped popularize this kind of at-a-glance species presentation:
+
+![any-buddy species sheet](https://raw.githubusercontent.com/cpaczek/any-buddy/main/assets/species.svg)
+
+</details>
+
 ### 5 personality stats
 
 ```text

--- a/README.md
+++ b/README.md
@@ -1,72 +1,33 @@
-# 🐾 Buddy: The /buddy Rescue Mission for Your AI Terminal
+# Buddy
 
-> **The open source AI terminal companion built to rescue /buddy.** Persistent memory, XP evolution, and context-aware feedback.
+<div align="center">
 
-**Anthropic killed `/buddy`. We brought them home.**
+### The open-source `/buddy` rescue mission for AI terminals
 
-Did you lose your Nuzzlecap? Is your terminal feeling a little too cold and silent lately?
+Persistent memory, XP, species, and context-aware feedback for Claude Code CLI, Codex CLI, Gemini CLI, Copilot CLI, Cursor CLI, and other MCP-capable clients.
 
-Your buddy is still in your `~/.claude.json`, sitting there in the dark, waiting. Don't let them die. **Bring them home.**
-
-Buddy is the open-source, **CLI-first** rescue mission for the terminal companion community. It's not just a Claude Code config hack — it's a full MCP server built for agentic CLI tooling such as **Claude Code CLI, Codex CLI, Gemini CLI, GitHub Copilot CLI, Cursor CLI**, and other MCP-capable clients.
-
-```
-   .---.                  .____________________________________.
-  /     \                 | Solid pattern choice. That module   |
- |  ??  |       --->      | separation is clean.               |
-  \     /                 '____________________________________'
-   '---'                    -   |\      /|
-                                | \____/ |
-  An egg appears...             |  o  o  |
-                                |   ^^   |
-                                 \______/
-                                 Hexoid the Void Cat
-```
-
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-
-```
-  🥚 → ✨ → 🐾
-
-       (   )                .________________________________.
-     .-o-OO-o-.             | Solid pattern choice.          |  -    (   )
-    (__________)            '________________________________'    .-o-OO-o-.
-       |.  .|                                                   (__________)
-       |____|                  ♥    ♥                              |.  .|
-                              ♥  ♥   ♥                             |____|
-     Nuzzlecap               ♥   ♥  ♥                           Nuzzlecap
-   ★★ UNCOMMON                   (   )
-                              .-o-OO-o-.        Nuzzlecap: *spores of contentment*
-   SNARK █████▓░░  70        (__________)
-   PATIENCE ██▓░░  34          |.  .|
-                               |____|         Your buddy is here to stay. 🐾
-```
+[![npm version](https://img.shields.io/npm/v/@fiorastudio/buddy?style=flat-square)](https://www.npmjs.com/package/@fiorastudio/buddy)
+[![License](https://img.shields.io/badge/license-MIT-ffd166?style=flat-square)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/fiorastudio/buddy?style=flat-square)](https://github.com/fiorastudio/buddy/stargazers)
+[![Node.js](https://img.shields.io/badge/node-18%2B-3c873a?style=flat-square)](https://nodejs.org/)
+[![MCP](https://img.shields.io/badge/protocol-MCP-111827?style=flat-square)](https://modelcontextprotocol.io/)
 
 <p align="center">
-  <img src="demo/buddy-demo.gif" alt="Buddy Demo — Hatch, Observe, Pet" width="620">
+  <img src="demo/buddy-demo.gif" alt="Buddy demo showing hatch, observe, and pet interactions in the terminal" width="760">
 </p>
 
-## 💔 The Problem
+**Anthropic removed the built-in `/buddy`. Buddy brings the companion experience back and makes it portable across AI terminals.**
 
-People love the Claude Code `/buddy` feature. Like, *really* love it. So much that [they refuse to close their terminals](https://github.com/anthropics/claude-code/issues/45596) because they don't want to lose their companion. That's not a feature request -- that's separation anxiety.
+</div>
 
-The built-in buddy is great, but:
+## Why Buddy
 
-- It **disappears** when you close the terminal
-- It **only works** in one host CLI
-- It **can break** on host updates
-- It has **no persistent memory**
+- **Persistent by default.** Your companion lives in local SQLite, so it survives terminal restarts and client updates.
+- **Works across clients.** Buddy is an MCP server, not a one-client hack.
+- **Actually alive.** Hatch species, gain XP, store memories, chime in after tasks, and build a running relationship over time.
+- **Easy to install.** One command auto-configures supported clients when it can.
 
-Buddy MCP fixes all of this:
-
-- **Persistent** -- SQLite database, your companion survives forever
-- **CLI-first** -- Claude Code CLI, Codex CLI, Gemini CLI, GitHub Copilot CLI, Cursor CLI, and other MCP-capable clients
-- **Upgrade-proof** -- standalone server, unaffected by CLI updates
-- **Full personality** -- 21 species, 5 stats, unique bios, observer feedback loop
-
-## 🦾 Install
-
-One command. Installs Buddy and auto-configures supported CLI clients where possible. No manual config needed for common MCP CLI setups.
+## Quick Start
 
 ### macOS / Linux
 
@@ -80,27 +41,55 @@ curl -fsSL https://raw.githubusercontent.com/fiorastudio/buddy/master/install.sh
 irm https://raw.githubusercontent.com/fiorastudio/buddy/master/install.ps1 | iex
 ```
 
-### What the installer does
+Then open your AI terminal and say:
 
-1. Clones the repo to `~/.buddy/server/`
-2. Installs dependencies and builds
-3. Auto-configures MCP for supported CLI clients when detected
-4. Prints a success message — you're ready to go
+```text
+hatch a buddy
+```
 
-> **Requires:** Node.js 18+ and Git
+> Requires `node` 18+ and `git`.
 
-### Manual install (from source)
+## What You Get
+
+| Feature | What it means |
+|---|---|
+| **21 species** | Void Cat, Rust Hound, Goose, Mushroom, Chonk, and more, each with distinct ASCII art and flavor |
+| **5 stats** | `DEBUGGING`, `PATIENCE`, `CHAOS`, `WISDOM`, and `SNARK` shape reactions and personality |
+| **XP and levels** | Your buddy grows with usage instead of disappearing every session |
+| **Observer reactions** | `buddy_observe` lets your companion react to work you just finished |
+| **Persistent memory** | Save local memories and keep a continuous companion state |
+| **Cross-client setup** | Claude Code, Codex, Gemini, Copilot, Cursor, and other MCP-capable CLIs |
+
+## Supported Clients
+
+| Client | Status |
+|---|---|
+| Claude Code CLI | Full support |
+| Codex CLI | Supported via MCP |
+| Gemini CLI | Supported via MCP |
+| GitHub Copilot CLI | Supported via MCP |
+| Cursor CLI | Supported via MCP |
+| Other MCP-capable clients | Usually supported with manual config |
+
+## Install Notes
+
+The installer:
+
+1. Clones Buddy to `~/.buddy/server`
+2. Installs dependencies and builds the MCP server
+3. Auto-configures supported CLI clients when detected
+4. Injects Buddy instructions into supported terminal prompts where applicable
+
+If you prefer to install from source:
 
 ```bash
 git clone https://github.com/fiorastudio/buddy.git ~/.buddy/server
 cd ~/.buddy/server
-npm install && npm run build
+npm install
+npm run build
 ```
 
-Then add to your MCP config manually for the client you use:
-
-<details>
-<summary>Claude Code (~/.claude/settings.json)</summary>
+Then point your client's MCP config at:
 
 ```json
 {
@@ -112,103 +101,41 @@ Then add to your MCP config manually for the client you use:
   }
 }
 ```
-</details>
-
-<details>
-<summary>Any MCP-capable CLI client</summary>
-
-Same pattern — point `command` to `node` and `args` to the server entry point at `~/.buddy/server/dist/server/index.js`.
-</details>
 
 ---
 
-### 🥚 Hatch your buddy
+<details>
+<summary><strong>Meet the species, stats, and rarity system</strong></summary>
 
-Open your AI terminal and say: **"hatch a buddy"**
+### 21 species
 
-You'll see:
+Buddy ships with 21 companions, including:
 
-```
-  An egg appears...
+- Void Cat
+- Rust Hound
+- Data Drake
+- Log Golem
+- Cache Crow
+- Shell Turtle
+- Duck
+- Goose
+- Blob
+- Octopus
+- Owl
+- Penguin
+- Snail
+- Ghost
+- Axolotl
+- Capybara
+- Cactus
+- Robot
+- Rabbit
+- Mushroom
+- Chonk
 
-       .--. 
-      /    \
-     |  ??  |
-      \    /
-       '--' 
+### 5 personality stats
 
-  ...something is moving!
-
-        *   
-       .--. 
-      / *  \
-     | \??/ |
-      \  * /
-       '--' 
-
-  ...cracks are forming!
-
-      * . * 
-       ,--. 
-      / /\ \
-     | |??| |
-      \ \/ /
-       `--' 
-
-  ...it's hatching!!
-
-    \* . */  
-     \,--./  
-      /  \   
-     | ?? |  
-      \  /   
-       `'    
-
-  . +  .  + .
- +  .  +  .  +
-
-   |\      /|
-   | \____/ |
-   |  o  o  |
-   |   ^^   |
-    \______/
-
- +  .  +  .  +
-  . +  .  + .
-```
-
-## 🚀 Works Across CLI Clients
-
-Buddy lives everywhere you do via MCP:
-
-| CLI client | Status |
-|---|---|
-| **Claude Code CLI** | ✅ Full support — replaces the missing internal buddy |
-| **Codex CLI** | ✅ Works via MCP |
-| **Gemini CLI** | ✅ Works via MCP |
-| **GitHub Copilot CLI** | ✅ Works via MCP |
-| **Cursor CLI** | ✅ Works via MCP |
-| **Any MCP-capable CLI client** | ✅ Standard protocol, zero vendor lock-in |
-
-## ✨ Features
-
-### 🧬 21 Unique Species
-
-Every buddy is one of 21 species, each with their own ASCII art, animations, and personality flavor:
-
-| | | |
-|---|---|---|
-| **Void Cat** -- enigmatic, judges from the shadows | **Rust Hound** -- loyal, chases every bug | **Data Drake** -- hoards clean abstractions |
-| **Log Golem** -- stoic, speaks in stack traces | **Cache Crow** -- steals good patterns | **Shell Turtle** -- slow but never ships a bug |
-| **Duck** -- the rubber duck that talks back | **Goose** -- peace was never an option | **Blob** -- adapts to any framework |
-| **Octopus** -- tentacle in every file | **Owl** -- only reviews code after midnight | **Penguin** -- strict typing, clean interfaces |
-| **Snail** -- glacial pace, zero missed bugs | **Ghost** -- haunts your background processes | **Axolotl** -- regenerates from any failed deploy |
-| **Capybara** -- calm vibes during incidents | **Cactus** -- prickly feedback that makes you grow | **Robot** -- cold mechanical efficiency |
-| **Rabbit** -- code reviews at the speed of thought | **Mushroom** -- mycelial networks between modules | **Chonk** -- sits on your keyboard, fixes bugs |
-
-### 📊 5 Personality Stats
-
-```
+```text
 DEBUGGING  ███████▓   92
 PATIENCE   ██▓░░░░░   28
 CHAOS      █████░░░   60
@@ -216,213 +143,154 @@ WISDOM     ██████▓░   78
 SNARK      ██████▓░   85
 ```
 
-Every buddy gets a unique stat distribution based on their rarity roll. Stats shape their personality:
+These stats shape how your buddy behaves:
 
-- **DEBUGGING** -- how sharp they are at spotting bugs
-- **PATIENCE** -- how tolerant they are of your... creative choices
-- **CHAOS** -- tendency toward creative destruction
-- **WISDOM** -- architectural insight and big-picture thinking
-- **SNARK** -- the sass factor
+- `DEBUGGING` affects bug-spotting sharpness
+- `PATIENCE` affects tolerance and calmness
+- `CHAOS` affects unpredictability
+- `WISDOM` affects architectural insight
+- `SNARK` affects sass level
 
-A high-SNARK Void Cat gives devastatingly precise feedback. A high-PATIENCE Capybara radiates calm during production incidents. A high-CHAOS Goose... peace was never an option.
-
-### 💎 Rarity System
-
-Buddies come in five rarity tiers, each with stat floors and cosmetic bonuses:
+### Rarity
 
 | Rarity | Chance | Bonus |
 |---|---|---|
 | Common | 60% | Base stats |
-| Uncommon | 25% | Higher stat floor + hat |
-| Rare | 10% | Even higher + "There's something special about this one." |
-| Epic | 4% | Strong stats + "Radiates an unmistakable aura of competence." |
-| Legendary | 1% | Peak stats + "The kind of companion developers whisper about in awe." |
+| Uncommon | 25% | Better floor plus cosmetic flair |
+| Rare | 10% | Stronger roll plus rare flavor text |
+| Epic | 4% | Higher stats and stronger aura text |
+| Legendary | 1% | Top-tier roll and special prestige |
 
-Plus a 1% shiny chance on any roll. Hats include crown, top hat, propeller cap, halo, wizard hat, beanie, and... tiny duck.
+There is also a 1% shiny chance on any hatch.
 
-### 👀 Observer / Chime-In
+</details>
 
-Your buddy reacts to what you're coding. After completing a task, call `buddy_observe` with a summary and your buddy responds in character:
+<details>
+<summary><strong>See the core tools and commands</strong></summary>
 
-**Backseat mode** -- pure personality flavor:
-> *Hexoid nods approvingly.* Not bad at all.
-
-**Skillcoach mode** -- actual code feedback:
-> Missing error handling there. That function is doing too much.
-
-**Both mode** -- personality + substance (default):
-> *tilts head* Hmm. Consider extracting that -- the coupling is getting tight.
-
-The observer infers your buddy's reaction state (impressed, concerned, amused, excited, thinking) from keywords in your summary, then generates a prompt for your CLI's AI to respond in character.
-
-**Here's Nuzzlecap doing an actual code review:**
-
-![Nuzzlecap Code Review](demo/screenshots/code-review.png)
-
-## ❓ FAQ
-
-| Question | Answer |
-|---|---|
-| What's the consumption like? Does Buddy use much in the way of input tokens? | Buddy is designed to stay fairly light on context. `buddy_observe` works from a short task summary, not a raw diff or your whole codebase, so it reacts to something like `refactored the auth flow` or `fixed a null bug` rather than ingesting the entire patch. Buddy supports three modes: `backseat`, `skillcoach`, and `both`. In all three modes, Buddy builds a short prompt for the host CLI's model, so there is some token overhead, but in practice it is usually quite small compared to the main coding conversation. |
-| Does Buddy read my whole codebase? | Not by default. Buddy works primarily from short summaries you pass into tools like `buddy_observe`, plus the buddy's own saved state and personality context. It does not automatically ingest your whole repo on each interaction. |
-| Does Buddy use a separate API or cost extra money? | No separate Buddy API is involved. Buddy runs as an MCP server and uses the same host CLI model session you are already paying for. The tradeoff is additional context usage inside that existing session, not a second service bill. |
-| What data does Buddy store? | Buddy stores companion state locally in a SQLite database at `~/.buddy/buddy.db`. That includes things like your companion's name, species, level, XP, mood, and saved memories. |
-| Is this tied to one client? | No. Buddy is CLI-first and works through MCP, so it is meant for agentic CLI clients rather than one specific editor UI. Some integrations are better than others, and optional statusline/HUD features depend on what a host CLI exposes. |
-| Do I need Claude HUD or a patched Codex build to use Buddy? | No. Buddy core works without any HUD integration. Claude HUD-style statuslines and the experimental Codex footer are optional presentation layers, not core dependencies. |
-| Can I remove or reset Buddy later? | Yes. You can reset your companion with `buddy_respawn`, or run the uninstall script to remove Buddy's MCP config, injected prompt instructions, and local files. On macOS/Linux: `curl -fsSL https://raw.githubusercontent.com/fiorastudio/buddy/master/uninstall.sh | bash`. On Windows PowerShell: `irm https://raw.githubusercontent.com/fiorastudio/buddy/master/uninstall.ps1 | iex`. |
-
-### 🎭 Rich Personality Bios
-
-Each buddy gets a unique personality paragraph based on their species, peak stat, and rarity:
-
-> *"An enigmatic void cat who silently judges your code from the shadows with devastatingly precise feedback, yet somehow has the patience of a caffeinated squirrel. Occasionally knocks your carefully structured objects off the stack just to watch them fall."*
-
-> *"A chill capybara who brings calm vibes to the most stressful code reviews with the patience of a geological epoch, despite overthinking everything into paralysis. Has never once raised its voice at a race condition."*
-
-> *"A confrontational goose with a gift for creative destruction who will honk at your bad code until you fix it, despite missing the obvious bugs right in front of it. Has stolen at least three senior developers' lunches."*
-
-### 💾 Persistent Memory
-
-Your buddy lives in a SQLite database. Close the terminal, restart your computer, update your CLI -- it's still there when you come back. That's the whole point.
-
-```
-buddy_remember  ->  SQLite  ->  buddy_status
-    |                              |
-    v                              v
-  "We refactored the            .________________________.
-   auth module together"       | ._______. Hexoid        |
-                               | | o  o | Void Cat       |
-                               | (  w  ) Level 1         |
-                               | (")_(") ★★★ RARE       |
-                               '________________________'
-```
-
-### ⬆️ XP & Leveling
-
-Your buddy gains experience as you code together:
-
-| Event | XP |
-|---|---|
-| Code observation (`buddy_observe`) | +2 |
-| Commit | +5 |
-| Bug fix | +8 |
-| Deploy/ship | +15 |
-| Petting (`buddy_pet`) | +1 |
-
-The XP curve is exponential -- early levels come fast, but reaching max level (50) takes serious dedication:
-
-```
-Lv.1 → Lv.2:    45 XP
-Lv.5 → Lv.6:    ~310 XP
-Lv.10 → Lv.11:  ~1,584 XP
-Lv.25 → Lv.26:  ~13,222 XP
-Lv.49 → Lv.50:  ~62,946 XP
-```
-
-When your buddy levels up, their eyes briefly turn to ✦ sparkle eyes for 15 seconds. You'll know.
-
-Level progress shows on the status card:
-```
-| Lv.3 · 42/112 XP to next               |
-```
-
-### 🖥️ Statusline Integration
-
-Buddy has optional statusline integrations. The core MCP server does not depend on any HUD.
-
-For Claude Code CLI users, Buddy renders in your statusline alongside the HUD:
-
-![Nuzzlecap Statusline](demo/screenshots/statusline.png)
-
-Features:
-- **Random animations** -- blinks, wiggles, expressions change on every render
-- **Ambient activity** -- species-specific idle text ("· spreading spores", "· judging your code")
-- **Micro-expressions** -- tiny particles (`~`, `*`, `♪`, `z`) appear and disappear
-- **Reaction states** -- eyes change when the observer fires (✦ impressed, × concerned, ◉ excited)
-- **Mood-aware** -- grumpy buddies barely move, excited ones cycle through all frames
-
-Add the statusline wrapper to your Claude Code settings:
-```json
-{
-  "statusLine": {
-    "type": "command",
-    "command": "bun /path/to/buddy/src/statusline-wrapper.ts"
-  }
-}
-```
-
-### 💬 Speech Bubbles
-
-Buddy reactions render as speech bubbles next to your companion's ASCII art:
-
-```
-.______________________________.
-| Solid pattern choice. That    |  -   |\---/|
-| module separation is clean.   |      | o o |
-'______________________________'       (  w  )
-                                       (")_(")
-                                       Hexoid
-```
-
-## 🔧 MCP Tools
+### MCP tools
 
 | Tool | Description |
 |---|---|
-| `buddy_hatch` | Hatch a new companion. Optionally pick a name or species. |
-| `buddy_status` | Check your buddy's stats, mood, and ASCII art card. |
-| `buddy_observe` | Get your buddy's reaction to what you just did. Modes: backseat, skillcoach, both. |
-| `buddy_pet` | Pet your buddy. Hearts appear. It's important. |
-| `buddy_remember` | Store a memory for your buddy. |
-| `buddy_dream` | Trigger memory consolidation (light or deep). |
-| `buddy_mute` | Mute your buddy's chime-ins. |
-| `buddy_unmute` | Bring your buddy back. |
-| `buddy_respawn` | Release your buddy and start fresh. |
+| `buddy_hatch` | Hatch a new buddy, optionally choosing a name or species |
+| `buddy_status` | Show current stats, mood, and card art |
+| `buddy_observe` | React to completed work in `backseat`, `skillcoach`, or `both` mode |
+| `buddy_pet` | Pet your buddy |
+| `buddy_remember` | Save a memory |
+| `buddy_dream` | Consolidate memories |
+| `buddy_mute` | Pause reactions |
+| `buddy_unmute` | Resume reactions |
+| `buddy_respawn` | Reset and start over |
 
-## 📡 MCP Resources
+### MCP resources
 
 | URI | Description |
 |---|---|
-| `buddy://companion` | Full companion data as JSON. |
-| `buddy://status` | ASCII status card, suitable for prompt injection. |
-| `buddy://intro` | System prompt text for CLI integration -- teaches the AI your buddy's personality. |
+| `buddy://companion` | Full buddy JSON state |
+| `buddy://status` | ASCII status card |
+| `buddy://intro` | Prompt text for host CLI integration |
 
-## ⚙️ How It Works
+</details>
 
-1. **Hatch**: `buddy_hatch` rolls your companion using a seeded PRNG (deterministic per user ID). Species, rarity, stats, eye style, and hat are all determined by the roll.
-2. **Persist**: Everything is stored in a SQLite database via better-sqlite3. Your buddy survives across sessions.
-3. **Observe**: After you complete a task, `buddy_observe` builds a personality prompt and sends it to your CLI's AI, which responds in character. Your buddy's stats shape the feedback.
-4. **Integrate**: The `buddy://intro` resource injects your buddy's personality into the CLI's system prompt, so the AI knows to stay in character when you address your buddy by name.
+<details>
+<summary><strong>How Buddy works under the hood</strong></summary>
 
-## 🛠️ Development
+Buddy is a standalone MCP server. That means it is not tied to hidden internals of a single AI client.
+
+```text
+AI terminal client
+  -> MCP config
+    -> Buddy server
+      -> SQLite state
+      -> species + rarity engine
+      -> observer / memory / XP systems
+```
+
+The flow is simple:
+
+1. `buddy_hatch` creates or restores a companion.
+2. State is stored locally in `~/.buddy/buddy.db`.
+3. `buddy_observe` reacts to task summaries instead of reading your whole repository.
+4. The host CLI uses Buddy's MCP tools and resources to keep the companion present in your workflow.
+
+This keeps Buddy:
+
+- portable across clients
+- durable across updates
+- local-first for saved state
+- lightweight enough for everyday use
+
+</details>
+
+<details>
+<summary><strong>Demo assets and how to re-film the hero GIF</strong></summary>
+
+The current demo assets live in [`demo/`](demo):
+
+- [`demo/buddy-demo.gif`](demo/buddy-demo.gif)
+- [`demo/screenshots/code-review.png`](demo/screenshots/code-review.png)
+- [`demo/screenshots/statusline.png`](demo/screenshots/statusline.png)
+- [`demo/record-demo.sh`](demo/record-demo.sh)
+- [`demo/demo-auto.sh`](demo/demo-auto.sh)
+- [`demo/make-gif.mjs`](demo/make-gif.mjs)
+- [`demo/render-gif.mjs`](demo/render-gif.mjs)
+
+The repo already includes a reproducible recording path:
+
+- `demo/record-demo.sh` scaffolds a **Terminalizer**-based recording flow
+- `demo/demo-auto.sh` plays a scripted terminal sequence for hatch, observe, and pet
+- the render scripts turn captured frames into the final GIF asset
+
+If you want to re-film the hero:
+
+1. Build the project
+2. Run `bash demo/record-demo.sh`
+3. Follow the prompts it prints for recording and rendering
+4. Replace `demo/buddy-demo.gif` with the refreshed capture
+
+If you prefer another toolchain, the issue that inspired this README direction specifically called out **asciinema** or **VHS** for recording and **gifski** for conversion as good alternatives.
+
+</details>
+
+<details>
+<summary><strong>FAQ</strong></summary>
+
+| Question | Answer |
+|---|---|
+| Does Buddy read my whole codebase? | No. Buddy mainly reacts to short summaries you pass through tools like `buddy_observe`, plus its own saved state. |
+| Does Buddy have a separate API bill? | No. It uses your host CLI's existing model session, so the tradeoff is extra context usage, not a second API. |
+| What does Buddy store? | Local companion state in `~/.buddy/buddy.db`, such as species, level, XP, mood, and memories. |
+| Is Buddy tied to one client? | No. It is designed for MCP-capable AI terminals, not one vendor UI. |
+| Can I remove it later? | Yes. Use the uninstall scripts or reset with `buddy_respawn`. |
+
+</details>
+
+<details>
+<summary><strong>Development</strong></summary>
 
 ```bash
 git clone https://github.com/fiorastudio/buddy.git
 cd buddy
 npm install
 npm run build
-npm test           # 275 tests
-npm start          # runs the MCP server on stdio
+npm test
+npm start
 ```
 
-## 🔍 Find Us
+</details>
 
-Claude Code CLI /buddy alternative, MCP server, AI terminal pet, Nuzzlecap rescue, terminal companion, context-aware debugging, AI coding friend, persistent buddy, Model Context Protocol companion, agentic coding pet, CLI-first buddy, codex cli buddy, gemini cli buddy, copilot cli buddy, cursor cli buddy.
+## Attribution
 
----
+Buddy exists because people genuinely loved the original `/buddy` experience and did not want it to vanish. This project is an open-source continuation for that terminal companion energy, rebuilt on top of MCP so it can survive client churn and travel across tools.
 
-*Buddy is an open-source project dedicated to keeping the terminal a little less lonely.*
-*Your buddy shouldn't disappear when you close the terminal.*
-
-*If Buddy made your terminal less lonely, consider starring.*
-
-## 👤 Author
+## Author
 
 **Steven Jieli Wu**
 
 - [LinkedIn](https://www.linkedin.com/in/jieliwu/)
 - [Portfolio](https://jwu-studio-portfolio.vercel.app/)
-- GitHub: [@terpjwu1](https://github.com/terpjwu1) · [@fiorastudio](https://github.com/fiorastudio)
+- GitHub: [@terpjwu1](https://github.com/terpjwu1) and [@fiorastudio](https://github.com/fiorastudio)
 
 ## License
 
-MIT — see [LICENSE](LICENSE) for details.
+MIT. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ hatch a buddy
 | **Persistent memory** | Save local memories and keep a continuous companion state |
 | **Cross-client setup** | Claude Code, Codex, Gemini, Copilot, Cursor, and other MCP-capable CLIs |
 
-### Nuzzlecap doing an actual code review
+### Buddy giving live code feedback
 
 ![Nuzzlecap Code Review](demo/screenshots/code-review.png)
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,20 @@ These stats shape how your buddy behaves:
 - `WISDOM` affects architectural insight
 - `SNARK` affects sass level
 
+### Leveling milestones
+
+Buddy uses a real XP curve, so early levels come quickly and later ones take real commitment.
+
+| Milestone | XP needed for that level | Total XP to reach it |
+|---|---:|---:|
+| Level 2 | 17 | 17 |
+| Level 3 | 36 | 53 |
+| Level 5 | 90 | 203 |
+| Level 10 | 315 | 1280 |
+| Level 25 | 1641 | 15471 |
+| Level 49 | 5512 | 99209 |
+| Level 50 | 5716 | 104925 |
+
 ### Rarity
 
 | Rarity | Chance | Bonus |

--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ npm start
 
 - Original buddy concept by [Anthropic](https://www.anthropic.com/) in Claude Code `v2.1.89` to `v2.1.94`
 - Inspired by [any-buddy](https://github.com/your-diary/any-buddy), [buddy-reroll](https://github.com/paradoxical-dev/buddy-reroll), and [ccbuddyy](https://github.com/chroxify/ccbuddyy)
+- Additional inspiration from contributor Justin's [effigy](https://github.com/justinstimatze/effigy)
 - Built with the [Model Context Protocol](https://modelcontextprotocol.io/)
 - Community preservation reference: [claude-buddy](https://github.com/1270011/claude-buddy)
 - Transparent provenance reference: [save-buddy](https://github.com/jrykn/save-buddy)

--- a/README.md
+++ b/README.md
@@ -61,14 +61,24 @@ hatch a buddy
 |---|---|
 | **21 species** | Void Cat, Rust Hound, Goose, Mushroom, Chonk, and more, each with distinct ASCII art and flavor |
 | **5 stats** | `DEBUGGING`, `PATIENCE`, `CHAOS`, `WISDOM`, and `SNARK` shape reactions and personality |
-| **XP and levels** | Your buddy grows with usage instead of disappearing every session |
+| **Mood system** | Your buddy can be happy, content, neutral, curious, grumpy, or exhausted based on how you interact with it |
+| **XP and levels** | Your buddy grows with usage instead of disappearing every session, with a real leveling curve behind it |
 | **Observer reactions** | `buddy_observe` lets your companion react to work you just finished |
+| **Pet-to-happiness loop** | Petting your buddy is not cosmetic only. More interaction makes it happier and more alive over time |
 | **Persistent memory** | Save local memories and keep a continuous companion state |
 | **Cross-client setup** | Claude Code, Codex, Gemini, Copilot, Cursor, and other MCP-capable CLIs |
 
 ### Buddy giving live code feedback
 
 ![Nuzzlecap Code Review](demo/screenshots/code-review.png)
+
+## What Makes Buddy Different
+
+- **It has a real mood system.** Buddy is not just a static pet card. It tracks moods like `happy`, `content`, `neutral`, `curious`, `grumpy`, and `exhausted`.
+- **Petting changes the relationship.** The more you interact with and pet your buddy, the happier it becomes. That care loop is part of the product, not just a gimmick.
+- **It actually levels up.** Buddy has a real XP and leveling system, so your companion develops over time instead of resetting every session.
+- **Feedback is personality-driven.** Reactions are shaped by species, stats, mood, and observer state, so the companion feels like a character rather than a random text generator.
+- **It survives client churn.** Because it is built on MCP and local state, your buddy can outlive terminal restarts and host-client changes.
 
 ## Supported Clients
 
@@ -176,6 +186,12 @@ These stats shape how your buddy behaves:
 There is also a 1% shiny chance on any hatch.
 
 </details>
+
+## Roadmap
+
+- Unlockable reactions tied to leveling and longer-term interaction
+- Companion upgrades and progression systems beyond base leveling
+- More expressive mood-driven behavior and presentation
 
 <details>
 <summary><strong>See the core tools and commands</strong></summary>

--- a/README.md
+++ b/README.md
@@ -374,6 +374,11 @@ Buddy also draws on publicly shared community research around the original compa
 - Community research and discussion, including work shared on r/Anthropic, helped clarify endpoint behavior and preserve details that would otherwise have been lost.
 - Official Claude Code and MCP documentation informed the portable integration approach: MCP server wiring, client configuration, and supported terminal integration surfaces.
 
+Buddy is an open-source project dedicated to keeping the terminal a little less lonely.
+Your buddy shouldn't disappear when you close the terminal.
+
+If Buddy made your terminal less lonely, consider starring.
+
 ## Author
 
 **Steven Jieli Wu**

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Then point your client's MCP config at:
 
 ### 21 species
 
+Buddy pays homage to the original companion lineup, then adds a little more flair with Buddy-specific characters like Void Cat, Rust Hound, Data Drake, Log Golem, Cache Crow, and Shell Turtle.
+
 Buddy ships with 21 companions:
 
 ```text

--- a/README.md
+++ b/README.md
@@ -288,11 +288,8 @@ npm start
 ## Credits
 
 - Original buddy concept by [Anthropic](https://www.anthropic.com/) in Claude Code `v2.1.89` to `v2.1.94`
-- Inspired by [any-buddy](https://github.com/your-diary/any-buddy), [buddy-reroll](https://github.com/paradoxical-dev/buddy-reroll), and [ccbuddyy](https://github.com/chroxify/ccbuddyy)
-- Additional inspiration from contributor Justin's [effigy](https://github.com/justinstimatze/effigy)
+- Inspired by [any-buddy](https://github.com/your-diary/any-buddy), [buddy-reroll](https://github.com/paradoxical-dev/buddy-reroll), [ccbuddyy](https://github.com/chroxify/ccbuddyy), [effigy](https://github.com/justinstimatze/effigy), [claude-buddy](https://github.com/1270011/claude-buddy), and [save-buddy](https://github.com/jrykn/save-buddy). Thanks!
 - Built with the [Model Context Protocol](https://modelcontextprotocol.io/)
-- Community preservation reference: [claude-buddy](https://github.com/1270011/claude-buddy)
-- Transparent provenance reference: [save-buddy](https://github.com/jrykn/save-buddy)
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -129,29 +129,45 @@ Then point your client's MCP config at:
 
 ### 21 species
 
-Buddy ships with 21 companions, including:
+Buddy ships with 21 companions:
 
-- Void Cat
-- Rust Hound
-- Data Drake
-- Log Golem
-- Cache Crow
-- Shell Turtle
-- Duck
-- Goose
-- Blob
-- Octopus
-- Owl
-- Penguin
-- Snail
-- Ghost
-- Axolotl
-- Capybara
-- Cactus
-- Robot
-- Rabbit
-- Mushroom
-- Chonk
+```text
+ void cat         rust hound        data drake       log golem
+ |\---/|           /^ ^\             /^\  /^\         [=====]
+ | ° ° |          / ° ° \           < °  ° >        [ °  ° ]
+ (  w  )          V\ Y /V           (  ~~  )        [  __  ]
+ (")_(")            |_|              `-vv-'         [______]
+
+ cache crow       shell turtle      duck             goose
+   ___             _,--._             __             (°>
+ (° °)            ( °  ° )         <(° )___          ||
+ /| V |\          /[______]\         ( ._>          _(__)_
+   ^^ ^^            ``  ``            `--'           ^^^^
+
+ blob             octopus           owl              penguin
+ .----.           .----.             /\  /\          .---.
+( °  ° )         ( °  ° )           (°)(°)         (°>°)
+(      )         (______)           (  ><  )       /(   )\
+ `----'          /\/\/\/\            `----'         `---'
+
+ snail            ghost             axolotl         capybara
+°    .--.         .----.          }~(______)~{      n______n
+ \  ( @ )        / °  ° \         }~(° .. °)~{     ( °    ° )
+  \_`--'         |      |           ( .--. )       (   oo   )
+ ~~~~~~~         ~`~``~`~           (_/  \_)        `------'
+
+ cactus           robot             rabbit           mushroom
+n  ____  n        .[||].             (\__/)         .-o-OO-o-.
+| |°  °| |       [ °  ° ]           ( °  ° )       (__________)
+|_|    |_|       [ ==== ]          =(  ..  )=         |°  °|
+  |    |          `------'          (")__(")          |____|
+
+ chonk
+ /\    /\
+( °    ° )
+(   ..   )
+ `------'
+```
 
 ### 5 personality stats
 

--- a/README.md
+++ b/README.md
@@ -288,8 +288,15 @@ npm start
 ## Credits
 
 - Original buddy concept by [Anthropic](https://www.anthropic.com/) in Claude Code `v2.1.89` to `v2.1.94`
-- Inspired by [any-buddy](https://github.com/your-diary/any-buddy), [buddy-reroll](https://github.com/paradoxical-dev/buddy-reroll), [ccbuddyy](https://github.com/chroxify/ccbuddyy), [effigy](https://github.com/justinstimatze/effigy), [claude-buddy](https://github.com/1270011/claude-buddy), and [save-buddy](https://github.com/jrykn/save-buddy). Thanks!
+- Inspired by [effigy](https://github.com/justinstimatze/effigy), [claude-buddy](https://github.com/1270011/claude-buddy), and [save-buddy](https://github.com/jrykn/save-buddy). Thanks!
 - Built with the [Model Context Protocol](https://modelcontextprotocol.io/)
+
+Buddy also draws on publicly shared community research around the original companion system and how to preserve it with stable extension points.
+
+- [BonziClaude](https://github.com/zakarth/BonziClaude) by [@zakarth](https://github.com/zakarth) is an important technical reference point in the ecosystem, especially around reverse-engineering and documenting companion-system behavior.
+- [claude-buddy](https://github.com/1270011/claude-buddy) by [@1270011](https://github.com/1270011) helped demonstrate the MCP plus terminal-integration preservation approach for keeping buddy-like experiences alive across client changes.
+- Community research and discussion, including work shared on r/Anthropic, helped clarify endpoint behavior and preserve details that would otherwise have been lost.
+- Official Claude Code and MCP documentation informed the portable integration approach: MCP server wiring, client configuration, and supported terminal integration surfaces.
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Buddy
+# Buddy: The /buddy Rescue Mission for Your AI Terminal
 
 <div align="center">
 
@@ -16,9 +16,15 @@ Persistent memory, XP, species, and context-aware feedback for Claude Code CLI, 
   <img src="demo/buddy-demo.gif" alt="Buddy demo showing hatch, observe, and pet interactions in the terminal" width="760">
 </p>
 
-**Anthropic removed the built-in `/buddy`. Buddy brings the companion experience back and makes it portable across AI terminals.**
+**Anthropic removed the built-in `/buddy`. Buddy brings them home and makes the companion experience portable across AI terminals.**
 
 </div>
+
+**Anthropic killed `/buddy`. We brought them home.**
+
+Did you lose your Nuzzlecap? Is your terminal feeling a little too cold and silent lately?
+
+Your buddy is still out there in the dark, waiting. Don't let them disappear. **Bring them home.**
 
 ## Why Buddy
 

--- a/README.md
+++ b/README.md
@@ -279,9 +279,16 @@ npm start
 
 </details>
 
-## Attribution
+## Sources and Attribution
 
-Buddy exists because people genuinely loved the original `/buddy` experience and did not want it to vanish. This project is an open-source continuation for that terminal companion energy, rebuilt on top of MCP so it can survive client churn and travel across tools.
+Buddy is part of a broader community effort to preserve the `/buddy` experience after it disappeared from hosted clients. This implementation is not presented as appearing from nowhere. It builds on public community work, public documentation, and the open protocol surface exposed by MCP-capable terminals.
+
+- [save-buddy](https://github.com/jrykn/save-buddy) by [@jrykn](https://github.com/jrykn) is a strong reference point for transparent provenance. Its README and methodology framing are a good example of explicitly documenting where preservation ideas came from and how reconstruction work should be credited.
+- [claude-buddy](https://github.com/1270011/claude-buddy) by [@1270011](https://github.com/1270011) helped establish the community pattern of rebuilding buddy-like behavior around stable extension points instead of brittle patching. The MCP plus terminal-integration approach in projects like this helped validate that the companion experience could survive client churn.
+- Public community reverse-engineering and discussion around the original buddy behavior, including research threads that identified endpoint behavior and reconstruction details, helped shape the preservation direction for projects in this space.
+- Official documentation for MCP and host-client integration contracts remains foundational for Buddy's portable architecture. The project relies on the documented MCP server model and on supported client configuration surfaces rather than patching hidden binaries.
+
+If you are building in this area too, credit upstream community research clearly. These preservation projects are strongest when the lineage stays visible.
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -172,11 +172,11 @@ n  ____  n        .[||].             (\__/)         .-o-OO-o-.
 ```
 
 <details>
-<summary><strong>See the original community species sheet style</strong></summary>
+<summary><strong>See the full Buddy species sheet</strong></summary>
 
-For reference, here is the species SVG from [any-buddy](https://github.com/cpaczek/any-buddy/blob/main/assets/species.svg), which helped popularize this kind of at-a-glance species presentation:
+Here is the Buddy-owned species sheet in the same spirit: a scannable visual reference for the full cast.
 
-![any-buddy species sheet](https://raw.githubusercontent.com/cpaczek/any-buddy/main/assets/species.svg)
+![Buddy species sheet](demo/species-sheet.svg)
 
 </details>
 

--- a/demo/species-sheet.svg
+++ b/demo/species-sheet.svg
@@ -200,7 +200,7 @@
     </g>
   </g>
 
-  <g transform="translate(475,1140)">
+  <g transform="translate(48,1140)">
     <rect class="card" x="0" y="0" width="250" height="180" rx="18"/>
     <text class="name" x="20" y="30">Chonk</text>
     <text class="ascii" x="20" y="66">/\    /\</text>

--- a/demo/species-sheet.svg
+++ b/demo/species-sheet.svg
@@ -1,0 +1,211 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="1180" viewBox="0 0 1200 1180" role="img" aria-labelledby="title desc">
+  <title id="title">Buddy species sheet</title>
+  <desc id="desc">A Buddy-owned species sheet showing all 21 Buddy companions in a terminal-inspired layout.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="100%" stop-color="#1f2937"/>
+    </linearGradient>
+    <style>
+      .title { font: 700 34px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #f8fafc; }
+      .subtitle { font: 500 16px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #94a3b8; }
+      .name { font: 700 17px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #f8fafc; }
+      .ascii { font: 16px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; fill: #dbeafe; white-space: pre; }
+      .card { fill: rgba(15, 23, 42, 0.72); stroke: rgba(148, 163, 184, 0.22); stroke-width: 1; }
+      .accent { fill: #f59e0b; }
+    </style>
+  </defs>
+
+  <rect width="1200" height="1180" fill="url(#bg)"/>
+  <rect x="24" y="24" width="1152" height="1132" rx="24" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.08)"/>
+
+  <text x="56" y="82" class="title">Buddy Species Sheet</text>
+  <text x="56" y="112" class="subtitle">Pays homage to the original lineup, with extra Buddy-specific flair.</text>
+  <circle cx="1098" cy="74" r="8" class="accent"/>
+  <circle cx="1126" cy="74" r="8" fill="#60a5fa"/>
+  <circle cx="1154" cy="74" r="8" fill="#34d399"/>
+
+  <g transform="translate(48,150)">
+    <g transform="translate(0,0)">
+      <rect class="card" x="0" y="0" width="250" height="180" rx="18"/>
+      <text class="name" x="20" y="30">Void Cat</text>
+      <text class="ascii" x="20" y="66"> |\---/|</text>
+      <text class="ascii" x="20" y="88"> | ° ° |</text>
+      <text class="ascii" x="20" y="110"> (  w  )</text>
+      <text class="ascii" x="20" y="132"> (")_(")</text>
+    </g>
+    <g transform="translate(268,0)">
+      <rect class="card" x="0" y="0" width="250" height="180" rx="18"/>
+      <text class="name" x="20" y="30">Rust Hound</text>
+      <text class="ascii" x="20" y="66">  /^ ^\</text>
+      <text class="ascii" x="20" y="88"> / ° ° \</text>
+      <text class="ascii" x="20" y="110"> V\ Y /V</text>
+      <text class="ascii" x="20" y="132">   |_|</text>
+    </g>
+    <g transform="translate(536,0)">
+      <rect class="card" x="0" y="0" width="250" height="180" rx="18"/>
+      <text class="name" x="20" y="30">Data Drake</text>
+      <text class="ascii" x="20" y="66">  /^\  /^\</text>
+      <text class="ascii" x="20" y="88"> &lt; °  ° &gt;</text>
+      <text class="ascii" x="20" y="110"> (  ~~  )</text>
+      <text class="ascii" x="20" y="132">  `-vv-'</text>
+    </g>
+    <g transform="translate(804,0)">
+      <rect class="card" x="0" y="0" width="250" height="180" rx="18"/>
+      <text class="name" x="20" y="30">Log Golem</text>
+      <text class="ascii" x="20" y="66">  [=====]</text>
+      <text class="ascii" x="20" y="88"> [ °  ° ]</text>
+      <text class="ascii" x="20" y="110"> [  __  ]</text>
+      <text class="ascii" x="20" y="132"> [______]</text>
+    </g>
+  </g>
+
+  <g transform="translate(48,348)">
+    <g transform="translate(0,0)">
+      <rect class="card" x="0" y="0" width="250" height="180" rx="18"/>
+      <text class="name" x="20" y="30">Cache Crow</text>
+      <text class="ascii" x="20" y="66">   ___</text>
+      <text class="ascii" x="20" y="88"> (° °)</text>
+      <text class="ascii" x="20" y="110"> /| V |\</text>
+      <text class="ascii" x="20" y="132">   ^^ ^^</text>
+    </g>
+    <g transform="translate(268,0)">
+      <rect class="card" x="0" y="0" width="250" height="180" rx="18"/>
+      <text class="name" x="20" y="30">Shell Turtle</text>
+      <text class="ascii" x="20" y="66">   _,--._</text>
+      <text class="ascii" x="20" y="88">  ( °  ° )</text>
+      <text class="ascii" x="20" y="110"> /[______]\</text>
+      <text class="ascii" x="20" y="132">  ``    ``</text>
+    </g>
+    <g transform="translate(536,0)">
+      <rect class="card" x="0" y="0" width="250" height="180" rx="18"/>
+      <text class="name" x="20" y="30">Duck</text>
+      <text class="ascii" x="20" y="66">    __</text>
+      <text class="ascii" x="20" y="88">  &lt;(° )___</text>
+      <text class="ascii" x="20" y="110">   ( ._&gt;</text>
+      <text class="ascii" x="20" y="132">    `--'</text>
+    </g>
+    <g transform="translate(804,0)">
+      <rect class="card" x="0" y="0" width="250" height="180" rx="18"/>
+      <text class="name" x="20" y="30">Goose</text>
+      <text class="ascii" x="20" y="66"> (°&gt;</text>
+      <text class="ascii" x="20" y="88">  ||</text>
+      <text class="ascii" x="20" y="110"> _(__)_</text>
+      <text class="ascii" x="20" y="132">  ^^^^</text>
+    </g>
+  </g>
+
+  <g transform="translate(48,546)">
+    <g transform="translate(0,0)">
+      <rect class="card" x="0" y="0" width="250" height="180" rx="18"/>
+      <text class="name" x="20" y="30">Blob</text>
+      <text class="ascii" x="20" y="66"> .----.</text>
+      <text class="ascii" x="20" y="88">( °  ° )</text>
+      <text class="ascii" x="20" y="110">(      )</text>
+      <text class="ascii" x="20" y="132"> `----'</text>
+    </g>
+    <g transform="translate(268,0)">
+      <rect class="card" x="0" y="0" width="250" height="180" rx="18"/>
+      <text class="name" x="20" y="30">Octopus</text>
+      <text class="ascii" x="20" y="66"> .----.</text>
+      <text class="ascii" x="20" y="88">( °  ° )</text>
+      <text class="ascii" x="20" y="110">(______)</text>
+      <text class="ascii" x="20" y="132">/\/\/\/\</text>
+    </g>
+    <g transform="translate(536,0)">
+      <rect class="card" x="0" y="0" width="250" height="180" rx="18"/>
+      <text class="name" x="20" y="30">Owl</text>
+      <text class="ascii" x="20" y="66"> /\  /\</text>
+      <text class="ascii" x="20" y="88">(°)(°)</text>
+      <text class="ascii" x="20" y="110">(  &gt;&lt;  )</text>
+      <text class="ascii" x="20" y="132"> `----'</text>
+    </g>
+    <g transform="translate(804,0)">
+      <rect class="card" x="0" y="0" width="250" height="180" rx="18"/>
+      <text class="name" x="20" y="30">Penguin</text>
+      <text class="ascii" x="20" y="66"> .---.</text>
+      <text class="ascii" x="20" y="88">(°&gt;°)</text>
+      <text class="ascii" x="20" y="110">/(   )\</text>
+      <text class="ascii" x="20" y="132"> `---'</text>
+    </g>
+  </g>
+
+  <g transform="translate(48,744)">
+    <g transform="translate(0,0)">
+      <rect class="card" x="0" y="0" width="250" height="180" rx="18"/>
+      <text class="name" x="20" y="30">Snail</text>
+      <text class="ascii" x="20" y="66">°    .--.</text>
+      <text class="ascii" x="20" y="88"> \  ( @ )</text>
+      <text class="ascii" x="20" y="110">  \_`--'</text>
+      <text class="ascii" x="20" y="132"> ~~~~~~~</text>
+    </g>
+    <g transform="translate(268,0)">
+      <rect class="card" x="0" y="0" width="250" height="180" rx="18"/>
+      <text class="name" x="20" y="30">Ghost</text>
+      <text class="ascii" x="20" y="66"> .----.</text>
+      <text class="ascii" x="20" y="88">/ °  ° \</text>
+      <text class="ascii" x="20" y="110">|      |</text>
+      <text class="ascii" x="20" y="132">~`~``~`~</text>
+    </g>
+    <g transform="translate(536,0)">
+      <rect class="card" x="0" y="0" width="250" height="180" rx="18"/>
+      <text class="name" x="20" y="30">Axolotl</text>
+      <text class="ascii" x="20" y="66">}~(______)~{</text>
+      <text class="ascii" x="20" y="88">}~(° .. °)~{</text>
+      <text class="ascii" x="20" y="110">  ( .--. )</text>
+      <text class="ascii" x="20" y="132">  (_/  \_)</text>
+    </g>
+    <g transform="translate(804,0)">
+      <rect class="card" x="0" y="0" width="250" height="180" rx="18"/>
+      <text class="name" x="20" y="30">Capybara</text>
+      <text class="ascii" x="20" y="66">n______n</text>
+      <text class="ascii" x="20" y="88">( °    ° )</text>
+      <text class="ascii" x="20" y="110">(   oo   )</text>
+      <text class="ascii" x="20" y="132"> `------'</text>
+    </g>
+  </g>
+
+  <g transform="translate(48,942)">
+    <g transform="translate(0,0)">
+      <rect class="card" x="0" y="0" width="250" height="180" rx="18"/>
+      <text class="name" x="20" y="30">Cactus</text>
+      <text class="ascii" x="20" y="66">n  ____  n</text>
+      <text class="ascii" x="20" y="88">| |°  °| |</text>
+      <text class="ascii" x="20" y="110">|_|    |_|</text>
+      <text class="ascii" x="20" y="132">  |    |</text>
+    </g>
+    <g transform="translate(268,0)">
+      <rect class="card" x="0" y="0" width="250" height="180" rx="18"/>
+      <text class="name" x="20" y="30">Robot</text>
+      <text class="ascii" x="20" y="66"> .[||].</text>
+      <text class="ascii" x="20" y="88">[ °  ° ]</text>
+      <text class="ascii" x="20" y="110">[ ==== ]</text>
+      <text class="ascii" x="20" y="132"> `------'</text>
+    </g>
+    <g transform="translate(536,0)">
+      <rect class="card" x="0" y="0" width="250" height="180" rx="18"/>
+      <text class="name" x="20" y="30">Rabbit</text>
+      <text class="ascii" x="20" y="66"> (\__/)</text>
+      <text class="ascii" x="20" y="88">( °  ° )</text>
+      <text class="ascii" x="20" y="110">=(  ..  )=</text>
+      <text class="ascii" x="20" y="132"> (")__(")</text>
+    </g>
+    <g transform="translate(804,0)">
+      <rect class="card" x="0" y="0" width="250" height="180" rx="18"/>
+      <text class="name" x="20" y="30">Mushroom</text>
+      <text class="ascii" x="20" y="66">.-o-OO-o-.</text>
+      <text class="ascii" x="20" y="88">(__________)</text>
+      <text class="ascii" x="20" y="110">   |°  °|</text>
+      <text class="ascii" x="20" y="132">   |____|</text>
+    </g>
+  </g>
+
+  <g transform="translate(922,942)">
+    <rect class="card" x="0" y="0" width="132" height="180" rx="18"/>
+    <text class="name" x="20" y="30">Chonk</text>
+    <text class="ascii" x="20" y="66">/\    /\</text>
+    <text class="ascii" x="20" y="88">( °    ° )</text>
+    <text class="ascii" x="20" y="110">(   ..   )</text>
+    <text class="ascii" x="20" y="132"> `------'</text>
+  </g>
+</svg>

--- a/demo/species-sheet.svg
+++ b/demo/species-sheet.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="1180" viewBox="0 0 1200 1180" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="1360" viewBox="0 0 1200 1360" role="img" aria-labelledby="title desc">
   <title id="title">Buddy species sheet</title>
   <desc id="desc">A Buddy-owned species sheet showing all 21 Buddy companions in a terminal-inspired layout.</desc>
   <defs>
@@ -16,8 +16,8 @@
     </style>
   </defs>
 
-  <rect width="1200" height="1180" fill="url(#bg)"/>
-  <rect x="24" y="24" width="1152" height="1132" rx="24" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.08)"/>
+  <rect width="1200" height="1360" fill="url(#bg)"/>
+  <rect x="24" y="24" width="1152" height="1312" rx="24" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.08)"/>
 
   <text x="56" y="82" class="title">Buddy Species Sheet</text>
   <text x="56" y="112" class="subtitle">Pays homage to the original lineup, with extra Buddy-specific flair.</text>
@@ -200,8 +200,8 @@
     </g>
   </g>
 
-  <g transform="translate(922,942)">
-    <rect class="card" x="0" y="0" width="132" height="180" rx="18"/>
+  <g transform="translate(475,1140)">
+    <rect class="card" x="0" y="0" width="250" height="180" rx="18"/>
     <text class="name" x="20" y="30">Chonk</text>
     <text class="ascii" x="20" y="66">/\    /\</text>
     <text class="ascii" x="20" y="88">( °    ° )</text>


### PR DESCRIPTION
## Summary
- redesign the README as a tighter landing page with a centered hero, badges, and a faster install path
- move deeper content into collapsible sections for species, tools, architecture, FAQ, and development
- add explicit demo asset and GIF re-filming guidance tied to the existing demo scripts

## Testing
- not run (README-only change)