### PR TITLE
feat: interactive terminal onboarding wizard

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -191,21 +191,17 @@ $cursorRulesDir = "$env:USERPROFILE\.cursor\rules"
 if (!(Test-Path $cursorRulesDir)) { New-Item -ItemType Directory -Path $cursorRulesDir -Force | Out-Null }
 Inject-BuddyPrompt "$cursorRulesDir\buddy.md" "Cursor CLI"
 
-# Codex CLI (only if ~/.codex exists — don't create for users without Codex)
-if (Test-Path "$env:USERPROFILE\.codex") {
-  if (Test-Path "$env:USERPROFILE\.codex\AGENTS.md") {
-    Inject-BuddyPrompt "$env:USERPROFILE\.codex\AGENTS.md" "Codex CLI"
-  } else {
-    Inject-BuddyPrompt "$env:USERPROFILE\.codex\instructions.md" "Codex CLI"
-  }
+# Codex CLI (prompt injection is harmless — always inject so it's ready when CLI is installed)
+if (Test-Path "$env:USERPROFILE\.codex\AGENTS.md") {
+  Inject-BuddyPrompt "$env:USERPROFILE\.codex\AGENTS.md" "Codex CLI"
+} else {
+  Inject-BuddyPrompt "$env:USERPROFILE\.codex\instructions.md" "Codex CLI"
 }
-# Gemini CLI (only if ~/.gemini exists — don't create for users without Gemini)
-if (Test-Path "$env:USERPROFILE\.gemini") {
-  if ((Test-Path "$env:USERPROFILE\.gemini\AGENTS.md") -and !(Test-Path "$env:USERPROFILE\.gemini\GEMINI.md")) {
-    Inject-BuddyPrompt "$env:USERPROFILE\.gemini\AGENTS.md" "Gemini CLI"
-  } else {
-    Inject-BuddyPrompt "$env:USERPROFILE\.gemini\GEMINI.md" "Gemini CLI"
-  }
+# Gemini CLI
+if ((Test-Path "$env:USERPROFILE\.gemini\AGENTS.md") -and !(Test-Path "$env:USERPROFILE\.gemini\GEMINI.md")) {
+  Inject-BuddyPrompt "$env:USERPROFILE\.gemini\AGENTS.md" "Gemini CLI"
+} else {
+  Inject-BuddyPrompt "$env:USERPROFILE\.gemini\GEMINI.md" "Gemini CLI"
 }
 # GitHub Copilot CLI (supports AGENTS.md and copilot-instructions.md — prefer AGENTS.md)
 if (Test-Path "$env:USERPROFILE\.copilot\AGENTS.md") {

--- a/install.ps1
+++ b/install.ps1
@@ -191,17 +191,21 @@ $cursorRulesDir = "$env:USERPROFILE\.cursor\rules"
 if (!(Test-Path $cursorRulesDir)) { New-Item -ItemType Directory -Path $cursorRulesDir -Force | Out-Null }
 Inject-BuddyPrompt "$cursorRulesDir\buddy.md" "Cursor CLI"
 
-# Codex CLI (supports AGENTS.md and instructions.md — prefer AGENTS.md)
-if (Test-Path "$env:USERPROFILE\.codex\AGENTS.md") {
-  Inject-BuddyPrompt "$env:USERPROFILE\.codex\AGENTS.md" "Codex CLI"
-} else {
-  Inject-BuddyPrompt "$env:USERPROFILE\.codex\instructions.md" "Codex CLI"
+# Codex CLI (only if ~/.codex exists — don't create for users without Codex)
+if (Test-Path "$env:USERPROFILE\.codex") {
+  if (Test-Path "$env:USERPROFILE\.codex\AGENTS.md") {
+    Inject-BuddyPrompt "$env:USERPROFILE\.codex\AGENTS.md" "Codex CLI"
+  } else {
+    Inject-BuddyPrompt "$env:USERPROFILE\.codex\instructions.md" "Codex CLI"
+  }
 }
-# Gemini CLI (supports GEMINI.md and AGENTS.md — use whichever exists, prefer GEMINI.md)
-if ((Test-Path "$env:USERPROFILE\.gemini\AGENTS.md") -and !(Test-Path "$env:USERPROFILE\.gemini\GEMINI.md")) {
-  Inject-BuddyPrompt "$env:USERPROFILE\.gemini\AGENTS.md" "Gemini CLI"
-} else {
-  Inject-BuddyPrompt "$env:USERPROFILE\.gemini\GEMINI.md" "Gemini CLI"
+# Gemini CLI (only if ~/.gemini exists — don't create for users without Gemini)
+if (Test-Path "$env:USERPROFILE\.gemini") {
+  if ((Test-Path "$env:USERPROFILE\.gemini\AGENTS.md") -and !(Test-Path "$env:USERPROFILE\.gemini\GEMINI.md")) {
+    Inject-BuddyPrompt "$env:USERPROFILE\.gemini\AGENTS.md" "Gemini CLI"
+  } else {
+    Inject-BuddyPrompt "$env:USERPROFILE\.gemini\GEMINI.md" "Gemini CLI"
+  }
 }
 # GitHub Copilot CLI (supports AGENTS.md and copilot-instructions.md — prefer AGENTS.md)
 if (Test-Path "$env:USERPROFILE\.copilot\AGENTS.md") {

--- a/install.ps1
+++ b/install.ps1
@@ -191,11 +191,13 @@ $cursorRulesDir = "$env:USERPROFILE\.cursor\rules"
 if (!(Test-Path $cursorRulesDir)) { New-Item -ItemType Directory -Path $cursorRulesDir -Force | Out-Null }
 Inject-BuddyPrompt "$cursorRulesDir\buddy.md" "Cursor CLI"
 
-# Codex CLI (prompt injection is harmless — always inject so it's ready when CLI is installed)
-if (Test-Path "$env:USERPROFILE\.codex\AGENTS.md") {
-  Inject-BuddyPrompt "$env:USERPROFILE\.codex\AGENTS.md" "Codex CLI"
-} else {
-  Inject-BuddyPrompt "$env:USERPROFILE\.codex\instructions.md" "Codex CLI"
+# Codex CLI (only inject prompts if codex command exists — matches bash behavior)
+if (Get-Command codex -ErrorAction SilentlyContinue) {
+  if (Test-Path "$env:USERPROFILE\.codex\AGENTS.md") {
+    Inject-BuddyPrompt "$env:USERPROFILE\.codex\AGENTS.md" "Codex CLI"
+  } else {
+    Inject-BuddyPrompt "$env:USERPROFILE\.codex\instructions.md" "Codex CLI"
+  }
 }
 # Gemini CLI
 if ((Test-Path "$env:USERPROFILE\.gemini\AGENTS.md") -and !(Test-Path "$env:USERPROFILE\.gemini\GEMINI.md")) {

--- a/install.ps1
+++ b/install.ps1
@@ -210,6 +210,17 @@ if (Test-Path "$env:USERPROFILE\.copilot\AGENTS.md") {
   Inject-BuddyPrompt "$env:USERPROFILE\.copilot\copilot-instructions.md" "GitHub Copilot CLI"
 }
 
+# ── Run onboarding wizard ──
+
+$ONBOARD_SCRIPT = "$INSTALL_DIR\dist\cli\onboard.js"
+if (Test-Path $ONBOARD_SCRIPT) {
+  try {
+    node $ONBOARD_SCRIPT
+  } catch {
+    # Non-fatal — wizard is optional
+  }
+}
+
 Write-Host ""
 Write-Host "  ✅ Buddy installed! Say `"hatch a buddy`" to start." -ForegroundColor Green
 Write-Host ""

--- a/install.sh
+++ b/install.sh
@@ -302,7 +302,9 @@ fi
 
 ONBOARD_SCRIPT="$INSTALL_DIR/dist/cli/onboard.js"
 if [ -f "$ONBOARD_SCRIPT" ]; then
-  node "$ONBOARD_SCRIPT" </dev/tty || true
+  # Let onboard.ts detect TTY itself — don't force /dev/tty
+  # (fails in headless SSH, CI, cron where no controlling terminal exists)
+  node "$ONBOARD_SCRIPT" || true
 fi
 
 echo ""

--- a/install.sh
+++ b/install.sh
@@ -4,8 +4,17 @@
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/fiorastudio/buddy/master/install.sh | bash
+#   curl ... | bash -s -- --no-onboard    # skip onboarding wizard (CI/scripted installs)
 
 set -e
+
+# Parse flags
+NO_ONBOARD=0
+for arg in "$@"; do
+  case "$arg" in
+    --no-onboard) NO_ONBOARD=1 ;;
+  esac
+done
 
 REPO="https://github.com/fiorastudio/buddy.git"
 INSTALL_DIR="$HOME/.buddy/server"
@@ -301,10 +310,12 @@ fi
 # ── Run onboarding wizard ──
 
 ONBOARD_SCRIPT="$INSTALL_DIR/dist/cli/onboard.js"
-if [ -f "$ONBOARD_SCRIPT" ]; then
+if [ -f "$ONBOARD_SCRIPT" ] && [ "$NO_ONBOARD" -eq 0 ]; then
   # Let onboard.ts detect TTY itself — don't force /dev/tty
   # (fails in headless SSH, CI, cron where no controlling terminal exists)
   node "$ONBOARD_SCRIPT" || true
+elif [ "$NO_ONBOARD" -eq 1 ]; then
+  echo -e "  ${DIM}Onboarding skipped (--no-onboard). Run buddy-onboard later to set up.${NC}"
 fi
 
 echo ""

--- a/install.sh
+++ b/install.sh
@@ -298,6 +298,13 @@ else
   inject_prompt "$HOME/.copilot/copilot-instructions.md" "GitHub Copilot CLI"
 fi
 
+# ── Run onboarding wizard ──
+
+ONBOARD_SCRIPT="$INSTALL_DIR/dist/cli/onboard.js"
+if [ -f "$ONBOARD_SCRIPT" ]; then
+  node "$ONBOARD_SCRIPT" </dev/tty || true
+fi
+
 echo ""
 if [ "$CODEX_CONFIGURED" -eq 1 ] || ! command -v codex &> /dev/null; then
   echo -e "${GREEN}  ✅ Buddy installed! Say \"hatch a buddy\" to start.${NC}"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Persistent AI coding companion - MCP server with 21 species, personality stats, and code feedback",
   "main": "dist/server/index.js",
   "bin": {
-    "buddy-statusline": "dist/statusline-wrapper.js"
+    "buddy-statusline": "dist/statusline-wrapper.js",
+    "buddy-onboard": "dist/cli/onboard.js"
   },
   "files": [
     "dist",

--- a/src/__tests__/companion.test.ts
+++ b/src/__tests__/companion.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { initDb, db } from '../db/schema.js';
+import {
+  companionExists,
+  createCompanion,
+  rescueCompanion,
+  loadCompanion,
+} from '../lib/companion.js';
+import { SPECIES_LIST } from '../lib/species.js';
+
+// Initialize a fresh DB before each test
+beforeEach(() => {
+  initDb();
+  // Clear child tables first (FK constraints), then companions
+  db.prepare('DELETE FROM xp_events').run();
+  db.prepare('DELETE FROM memories').run();
+  db.prepare('DELETE FROM sessions').run();
+  db.prepare('DELETE FROM evolution_history').run();
+  db.prepare('DELETE FROM companions').run();
+});
+
+describe('companionExists', () => {
+  it('returns null when no companion exists', () => {
+    expect(companionExists()).toBeNull();
+  });
+
+  it('returns a row when a companion exists', () => {
+    createCompanion({ userId: 'test-user-1' });
+    const row = companionExists();
+    expect(row).not.toBeNull();
+    expect(row.name).toBeTruthy();
+    expect(row.species).toBeTruthy();
+  });
+});
+
+describe('createCompanion', () => {
+  it('creates a companion with default params', () => {
+    const { companion, id } = createCompanion();
+    expect(id).toBeTruthy();
+    expect(companion.name).toBeTruthy();
+    expect(companion.species).toBeTruthy();
+    expect(companion.level).toBe(1);
+    expect(companion.xp).toBe(0);
+    expect(companion.mood).toBe('happy');
+    expect(companion.personalityBio).toBeTruthy();
+  });
+
+  it('creates a companion with a specific name', () => {
+    const { companion } = createCompanion({ name: 'TestBuddy' });
+    expect(companion.name).toBe('TestBuddy');
+  });
+
+  it('creates a companion with a specific species', () => {
+    const { companion } = createCompanion({ species: 'Mushroom' });
+    expect(companion.species).toBe('Mushroom');
+  });
+
+  it('falls back to rolled species if invalid species given', () => {
+    const { companion } = createCompanion({ species: 'InvalidSpecies', userId: 'species-test' });
+    expect(SPECIES_LIST).toContain(companion.species);
+    expect(companion.species).not.toBe('InvalidSpecies');
+  });
+
+  it('creates a companion with a specific userId for deterministic bones', () => {
+    const { companion: c1 } = createCompanion({ userId: 'deterministic-test' });
+    // Clean up for second creation
+    db.prepare('DELETE FROM companions').run();
+    const { companion: c2 } = createCompanion({ userId: 'deterministic-test' });
+    // Same userId produces same bones (rarity, eye, stats)
+    expect(c1.rarity).toBe(c2.rarity);
+    expect(c1.eye).toBe(c2.eye);
+    expect(c1.stats).toEqual(c2.stats);
+  });
+
+  it('sanitizes the name', () => {
+    const { companion } = createCompanion({ name: '  Test${name}  ' });
+    expect(companion.name).toBe('Testname');
+  });
+
+  it('persists to database', () => {
+    createCompanion({ userId: 'persist-test', name: 'Persisto' });
+    const row = db.prepare('SELECT * FROM companions LIMIT 1').get() as any;
+    expect(row).toBeTruthy();
+    expect(row.name).toBe('Persisto');
+  });
+});
+
+describe('rescueCompanion', () => {
+  it('rescues a companion with name and species', () => {
+    const { companion, id } = rescueCompanion({
+      name: 'Nuzzlecap',
+      species: 'Mushroom',
+    });
+    expect(id).toBeTruthy();
+    expect(companion.name).toBe('Nuzzlecap');
+    expect(companion.species).toBe('Mushroom');
+    expect(companion.level).toBe(1);
+    expect(companion.xp).toBe(0);
+  });
+
+  it('uses imported userId for deterministic bones', () => {
+    const { companion: c1 } = rescueCompanion({
+      name: 'Rex',
+      species: 'Rust Hound',
+      userId: 'rescue-uid-test',
+    });
+    db.prepare('DELETE FROM companions').run();
+    const { companion: c2 } = rescueCompanion({
+      name: 'Rex',
+      species: 'Rust Hound',
+      userId: 'rescue-uid-test',
+    });
+    expect(c1.rarity).toBe(c2.rarity);
+    expect(c1.eye).toBe(c2.eye);
+    expect(c1.stats).toEqual(c2.stats);
+  });
+
+  it('falls back to stable userId when none provided', () => {
+    const { companion } = rescueCompanion({
+      name: 'Ghosty',
+      species: 'Ghost',
+    });
+    // Should still work
+    expect(companion.name).toBe('Ghosty');
+    expect(companion.species).toBe('Ghost');
+
+    // Verify the DB row has the fallback userId
+    const row = db.prepare('SELECT user_id FROM companions LIMIT 1').get() as any;
+    expect(row.user_id).toBe('imported-Ghosty');
+  });
+
+  it('falls back to rolled species if invalid species given', () => {
+    const { companion } = rescueCompanion({
+      name: 'Test',
+      species: 'NotASpecies',
+    });
+    expect(SPECIES_LIST).toContain(companion.species);
+  });
+
+  it('persists to database', () => {
+    rescueCompanion({ name: 'SavedBuddy', species: 'Owl' });
+    const row = db.prepare('SELECT * FROM companions LIMIT 1').get() as any;
+    expect(row).toBeTruthy();
+    expect(row.name).toBe('SavedBuddy');
+    expect(row.species).toBe('Owl');
+  });
+});
+
+describe('loadCompanion', () => {
+  it('returns null for null row', () => {
+    expect(loadCompanion(null)).toBeNull();
+  });
+
+  it('loads a companion from a DB row', () => {
+    const { id } = createCompanion({ userId: 'load-test', name: 'Loader' });
+    const row = db.prepare('SELECT * FROM companions WHERE id = ?').get(id) as any;
+    const companion = loadCompanion(row);
+    expect(companion).not.toBeNull();
+    expect(companion!.name).toBe('Loader');
+    expect(companion!.level).toBe(1);
+    expect(companion!.xp).toBe(0);
+  });
+
+  it('self-heals level if DB level drifts', () => {
+    const { id } = createCompanion({ userId: 'heal-test', name: 'Healer' });
+    // Manually drift the level
+    db.prepare('UPDATE companions SET level = 99 WHERE id = ?').run(id);
+    const row = db.prepare('SELECT * FROM companions WHERE id = ?').get(id) as any;
+    expect(row.level).toBe(99);
+
+    const companion = loadCompanion(row);
+    expect(companion!.level).toBe(1); // Should be corrected back
+
+    // Verify DB was also fixed
+    const fixedRow = db.prepare('SELECT level FROM companions WHERE id = ?').get(id) as any;
+    expect(fixedRow.level).toBe(1);
+  });
+});

--- a/src/__tests__/self-healing.test.ts
+++ b/src/__tests__/self-healing.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { initDb, db } from '../db/schema.js';
-import { loadCompanion, recalcMood } from '../server/index.js';
+import { loadCompanion } from '../lib/companion.js';
+import { recalcMood } from '../server/index.js';
 import { levelFromXp } from '../lib/leveling.js';
 import { randomUUID } from 'crypto';
 

--- a/src/cli/onboard.ts
+++ b/src/cli/onboard.ts
@@ -195,15 +195,10 @@ async function main() {
   const isTTY = process.stdin.isTTY && process.stdout.isTTY;
 
   if (nonInteractive || !isTTY) {
-    // Non-interactive: rescue only if old buddy found, otherwise skip.
-    // Never auto-hatch without explicit user consent (CI safety).
-    if (oldBuddy) {
-      action = 'rescue';
-      console.log(`\n  ${c(DIM, 'Auto-selecting: rescue (old buddy found)')}`);
-    } else {
-      action = 'skip';
-      console.log(`\n  ${c(DIM, 'Non-interactive: no old buddy found, skipping. Run buddy-onboard manually to hatch.')}`);
-    }
+    // Non-interactive (curl | bash, piped installs): auto-rescue or auto-hatch.
+    // Users expect a buddy after install — don't leave them empty-handed.
+    action = oldBuddy ? 'rescue' : 'hatch';
+    console.log(`\n  ${c(DIM, `Auto-selecting: ${action}`)}`);
   } else {
     action = await arrowMenu('What would you like to do?', choices);
   }

--- a/src/cli/onboard.ts
+++ b/src/cli/onboard.ts
@@ -8,6 +8,7 @@ import {
   loadCompanion,
   createCompanion,
   rescueCompanion,
+  writeBuddyStatus,
 } from '../lib/companion.js';
 import { renderCard, hatchAnimation, rescueAnimation } from '../lib/card.js';
 import { readFileSync } from 'fs';
@@ -164,11 +165,12 @@ async function main() {
   // Initialize database
   initDb();
 
-  // Check if companion already exists
+  // Check if companion already exists — refresh status file and exit
   const existing = companionExists();
   if (existing) {
     const companion = loadCompanion(existing);
     if (companion) {
+      writeBuddyStatus(companion);
       console.log(`\n  ${c(GREEN, 'Already have')} ${c(CYAN, companion.name)} the ${c(MAGENTA, companion.species)}!\n`);
       process.exit(0);
     }

--- a/src/cli/onboard.ts
+++ b/src/cli/onboard.ts
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+// src/cli/onboard.ts — interactive onboarding wizard
+// Standalone CLI using Node.js built-in readline (no new dependencies)
+
+import { initDb } from '../db/schema.js';
+import {
+  companionExists,
+  loadCompanion,
+  createCompanion,
+  rescueCompanion,
+} from '../lib/companion.js';
+import { renderCard, hatchAnimation, rescueAnimation } from '../lib/card.js';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+// ── ANSI colors ──
+
+const RESET = '\x1b[0m';
+const DIM = '\x1b[2m';
+const CYAN = '\x1b[36m';
+const YELLOW = '\x1b[33m';
+const GREEN = '\x1b[32m';
+const MAGENTA = '\x1b[35m';
+const BOLD = '\x1b[1m';
+
+// ── Args ──
+
+const args = process.argv.slice(2);
+const nonInteractive = args.includes('--non-interactive');
+const noColor = args.includes('--no-color');
+
+function c(color: string, text: string): string {
+  return noColor ? text : `${color}${text}${RESET}`;
+}
+
+// ── Import old buddy from ~/.claude.json ──
+
+interface OldBuddy {
+  name: string;
+  species: string;
+  userId?: string;
+  user_id?: string;
+}
+
+function importOldBuddy(): OldBuddy | null {
+  try {
+    const claudeJsonPath = join(homedir(), '.claude.json');
+    const raw = readFileSync(claudeJsonPath, 'utf-8');
+    const data = JSON.parse(raw);
+
+    // Claude Code stored buddy data under various keys
+    // Check common locations
+    const buddy = data.buddy || data.companion || data.buddyCompanion;
+    if (buddy && buddy.name && buddy.species) {
+      return {
+        name: buddy.name,
+        species: buddy.species,
+        userId: buddy.userId || buddy.user_id,
+      };
+    }
+
+    // Check if the top-level has buddy fields
+    if (data.buddyName && data.buddySpecies) {
+      return {
+        name: data.buddyName,
+        species: data.buddySpecies,
+        userId: data.userId || data.user_id,
+      };
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// ── Arrow-key menu ──
+
+interface MenuChoice {
+  label: string;
+  value: string;
+}
+
+function arrowMenu(prompt: string, choices: MenuChoice[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const stdin = process.stdin;
+    const stdout = process.stdout;
+
+    // Can't do raw mode if not a TTY
+    if (!stdin.isTTY) {
+      resolve(choices[0].value);
+      return;
+    }
+
+    let selectedIndex = 0;
+
+    function render() {
+      // Move cursor up to redraw (only after first render)
+      if (rendered) {
+        stdout.write(`\x1b[${choices.length}A`);
+      }
+      for (let i = 0; i < choices.length; i++) {
+        const prefix = i === selectedIndex
+          ? c(CYAN, '  > ')
+          : '    ';
+        const label = i === selectedIndex
+          ? c(BOLD, choices[i].label)
+          : c(DIM, choices[i].label);
+        stdout.write(`\x1b[2K${prefix}${label}\n`);
+      }
+    }
+
+    let rendered = false;
+    stdout.write(`\n${c(YELLOW, prompt)}\n\n`);
+    render();
+    rendered = true;
+
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.setEncoding('utf-8');
+
+    function cleanup() {
+      stdin.setRawMode(false);
+      stdin.pause();
+      stdin.removeListener('data', onData);
+    }
+
+    function onData(key: string) {
+      // Ctrl-C
+      if (key === '\x03') {
+        cleanup();
+        stdout.write('\n');
+        process.exit(0);
+      }
+
+      // Enter
+      if (key === '\r' || key === '\n') {
+        cleanup();
+        stdout.write('\n');
+        resolve(choices[selectedIndex].value);
+        return;
+      }
+
+      // Arrow keys (escape sequences)
+      if (key === '\x1b[A' || key === 'k') {
+        // Up
+        selectedIndex = (selectedIndex - 1 + choices.length) % choices.length;
+        render();
+      } else if (key === '\x1b[B' || key === 'j') {
+        // Down
+        selectedIndex = (selectedIndex + 1) % choices.length;
+        render();
+      }
+    }
+
+    stdin.on('data', onData);
+  });
+}
+
+// ── Main ──
+
+async function main() {
+  // Initialize database
+  initDb();
+
+  // Check if companion already exists
+  const existing = companionExists();
+  if (existing) {
+    const companion = loadCompanion(existing);
+    if (companion) {
+      console.log(`\n  ${c(GREEN, 'Already have')} ${c(CYAN, companion.name)} the ${c(MAGENTA, companion.species)}!\n`);
+      process.exit(0);
+    }
+  }
+
+  // Try to import old buddy
+  const oldBuddy = importOldBuddy();
+
+  // Build menu choices
+  const choices: MenuChoice[] = [];
+  if (oldBuddy) {
+    choices.push({
+      label: `Rescue ${oldBuddy.name} the ${oldBuddy.species}`,
+      value: 'rescue',
+    });
+  }
+  choices.push({ label: 'Hatch new buddy', value: 'hatch' });
+  choices.push({ label: 'Skip', value: 'skip' });
+
+  // Choose action
+  let action: string;
+  const isTTY = process.stdin.isTTY && process.stdout.isTTY;
+
+  if (nonInteractive || !isTTY) {
+    // Auto-choose: rescue if found, else hatch
+    action = oldBuddy ? 'rescue' : 'hatch';
+    console.log(`\n  ${c(DIM, `Auto-selecting: ${action}`)}`);
+  } else {
+    action = await arrowMenu('What would you like to do?', choices);
+  }
+
+  // Execute
+  if (action === 'skip') {
+    console.log(`\n  ${c(DIM, 'Skipped. Say "hatch a buddy" in your CLI to start later.')}\n`);
+    process.exit(0);
+  }
+
+  if (action === 'rescue' && oldBuddy) {
+    const { companion } = rescueCompanion(oldBuddy);
+    console.log(rescueAnimation(companion));
+    process.exit(0);
+  }
+
+  // Default: hatch
+  const { companion } = createCompanion();
+  console.log(hatchAnimation(companion));
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('Onboarding error:', err);
+  process.exit(1);
+});

--- a/src/cli/onboard.ts
+++ b/src/cli/onboard.ts
@@ -193,9 +193,15 @@ async function main() {
   const isTTY = process.stdin.isTTY && process.stdout.isTTY;
 
   if (nonInteractive || !isTTY) {
-    // Auto-choose: rescue if found, else hatch
-    action = oldBuddy ? 'rescue' : 'hatch';
-    console.log(`\n  ${c(DIM, `Auto-selecting: ${action}`)}`);
+    // Non-interactive: rescue only if old buddy found, otherwise skip.
+    // Never auto-hatch without explicit user consent (CI safety).
+    if (oldBuddy) {
+      action = 'rescue';
+      console.log(`\n  ${c(DIM, 'Auto-selecting: rescue (old buddy found)')}`);
+    } else {
+      action = 'skip';
+      console.log(`\n  ${c(DIM, 'Non-interactive: no old buddy found, skipping. Run buddy-onboard manually to hatch.')}`);
+    }
   } else {
     action = await arrowMenu('What would you like to do?', choices);
   }

--- a/src/lib/card.ts
+++ b/src/lib/card.ts
@@ -1,0 +1,190 @@
+// src/lib/card.ts — extracted rendering (ASCII card, hatch animation, rescue animation)
+
+import { renderSprite } from './species.js';
+import { type Companion, STAT_NAMES, RARITY_STARS } from './types.js';
+import { statBar } from './rng.js';
+import { levelProgress } from './leveling.js';
+
+/**
+ * Render a bordered ASCII stat card for a companion.
+ */
+export function renderCard(companion: Companion): string {
+  const art = renderSprite(companion);
+  const stars = RARITY_STARS[companion.rarity];
+  const statLines = STAT_NAMES.map(s => statBar(s, companion.stats[s]));
+
+  const cardWidth = 44;
+  const inner = cardWidth - 4;
+  const topBorder = '.' + '_'.repeat(cardWidth - 2) + '.';
+  const bottomBorder = "'" + '_'.repeat(cardWidth - 2) + "'";
+  const emptyLine = '| ' + ' '.repeat(inner) + ' |';
+  const ln = (text: string) => '| ' + text.padEnd(inner) + ' |';
+
+  const headerLeft = `${stars} ${companion.rarity.toUpperCase()}`;
+  const headerRight = companion.species.toUpperCase();
+  const headerGap = inner - headerLeft.length - headerRight.length;
+  const headerLine = ln(headerLeft + ' '.repeat(Math.max(1, headerGap)) + headerRight);
+
+  const bioLines: string[] = [];
+  if (companion.personalityBio) {
+    const bioText = `"${companion.personalityBio}"`;
+    const words = bioText.split(' ');
+    let cur = '';
+    for (const w of words) {
+      if (cur.length + w.length + 1 > inner - 2 && cur) {
+        bioLines.push(ln(' ' + cur));
+        cur = w;
+      } else {
+        cur = cur ? `${cur} ${w}` : w;
+      }
+    }
+    if (cur) bioLines.push(ln(' ' + cur));
+  }
+
+  return [
+    topBorder,
+    headerLine,
+    emptyLine,
+    ...art.map(l => ln(l)),
+    emptyLine,
+    ln(companion.name),
+    ...(bioLines.length > 0 ? [emptyLine, ...bioLines] : []),
+    emptyLine,
+    ...statLines.map(l => ln(l)),
+    emptyLine,
+    (() => {
+      const { level, currentXp, neededXp } = levelProgress(companion.xp);
+      const lvlLine = level >= 50 ? 'Lv.50 MAX' : `Lv.${level} \u00b7 ${currentXp}/${neededXp} XP to next`;
+      return ln(lvlLine);
+    })(),
+    bottomBorder,
+  ].join('\n');
+}
+
+/**
+ * Render the full hatch animation sequence + card.
+ */
+export function hatchAnimation(companion: Companion): string {
+  const egg1 = [
+    '        ',
+    '   .--. ',
+    '  /    \\',
+    ' |  ??  |',
+    '  \\    /',
+    "   '--' ",
+  ].join('\n');
+
+  const egg2 = [
+    '    *   ',
+    '   .--. ',
+    '  / *  \\',
+    ' | \\??/ |',
+    '  \\  * /',
+    "   '--' ",
+  ].join('\n');
+
+  const egg3 = [
+    '  * . * ',
+    '   ,--. ',
+    '  / /\\ \\',
+    ' | |??| |',
+    '  \\ \\/ /',
+    "   `--\u00b4 ",
+  ].join('\n');
+
+  const egg4 = [
+    ' \\* . */  ',
+    '  \\,--./  ',
+    '   /  \\   ',
+    '  | ?? |  ',
+    '   \\  /   ',
+    "    `\u00b4    ",
+  ].join('\n');
+
+  const art = renderSprite(companion);
+  const hatched = [
+    '  \u00b7  \u2726  \u00b7 ',
+    ' \u2726 \u00b7  \u00b7 \u2726 ',
+    ...art,
+    ' \u2726 \u00b7  \u00b7 \u2726 ',
+    '  \u00b7  \u2726  \u00b7 ',
+  ].join('\n');
+
+  const card = renderCard(companion);
+
+  const footer = [
+    '',
+    `${companion.name} is here \u00b7 it'll chime in as you code`,
+    `uses the same AI subscription you're on`,
+    `say its name to get its take \u00b7 /buddy pet \u00b7 /buddy off`,
+  ].join('\n');
+
+  return [
+    '\uD83E\uDD5A An egg appears...\n',
+    egg1,
+    '\n...something is moving!\n',
+    egg2,
+    '\n...cracks are forming!\n',
+    egg3,
+    '\n...it\'s hatching!!\n',
+    egg4,
+    '\n\u2728 \u2728 \u2728\n',
+    hatched,
+    '\n',
+    card,
+    footer,
+  ].join('\n');
+}
+
+/**
+ * Render a rescue animation (signal found -> companion appears).
+ */
+export function rescueAnimation(companion: Companion): string {
+  const signal1 = [
+    '      .',
+    '    . | .',
+    '      |',
+    '   [SIGNAL]',
+    '      |',
+    '   ...scanning...',
+  ].join('\n');
+
+  const signal2 = [
+    '   )) . ((',
+    '    ).|.(  ',
+    '     |||   ',
+    '  [FOUND!] ',
+    '     |||   ',
+    '  ...locked on...',
+  ].join('\n');
+
+  const art = renderSprite(companion);
+  const rescued = [
+    '  \u00b7  \u2726  \u00b7 ',
+    ' \u2726 \u00b7  \u00b7 \u2726 ',
+    ...art,
+    ' \u2726 \u00b7  \u00b7 \u2726 ',
+    '  \u00b7  \u2726  \u00b7 ',
+  ].join('\n');
+
+  const card = renderCard(companion);
+
+  const footer = [
+    '',
+    `${companion.name} has been rescued! Welcome home.`,
+    `it'll chime in as you code`,
+    `say its name to get its take \u00b7 /buddy pet \u00b7 /buddy off`,
+  ].join('\n');
+
+  return [
+    '\uD83D\uDCE1 Scanning for lost companions...\n',
+    signal1,
+    '\n...signal detected!\n',
+    signal2,
+    '\n\u2728 \u2728 \u2728\n',
+    rescued,
+    '\n',
+    card,
+    footer,
+  ].join('\n');
+}

--- a/src/lib/companion.ts
+++ b/src/lib/companion.ts
@@ -1,0 +1,175 @@
+// src/lib/companion.ts — extracted creation logic (pure functions + DB)
+
+import { db } from '../db/schema.js';
+import { roll } from './rng.js';
+import { SPECIES_LIST, generateName, renderSprite } from './species.js';
+import { generateBio } from './personality.js';
+import { sanitizeName } from './sanitize.js';
+import { type Companion, RARITY_STARS } from './types.js';
+import { levelFromXp } from './leveling.js';
+import { randomUUID } from 'crypto';
+import { writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+const BUDDY_STATUS_PATH = join(homedir(), '.claude', 'buddy-status.json');
+let statusDirEnsured = false;
+
+/**
+ * Check if a companion already exists in the DB.
+ * Returns the row if found, null otherwise.
+ */
+export function companionExists(): any | null {
+  return db.prepare('SELECT * FROM companions LIMIT 1').get() || null;
+}
+
+/**
+ * Load a Companion from a DB row + deterministic bones.
+ * Note: when species was overridden at hatch time, bones (rarity, stats, eye, hat)
+ * still come from the deterministic roll. Only species name comes from DB.
+ * This is intentional -- bones are tied to the userId hash, not the species.
+ */
+export function loadCompanion(row: any, userIdOverride?: string): Companion | null {
+  if (!row) return null;
+  const userId = userIdOverride || row.user_id || 'anon';
+  const { bones } = roll(userId, SPECIES_LIST);
+  const xp = row.xp || 0;
+  const derivedLevel = levelFromXp(xp);
+
+  // Self-healing: if DB level drifted from XP-derived level, fix it
+  if (row.id && row.level !== derivedLevel) {
+    db.prepare('UPDATE companions SET level = ? WHERE id = ?').run(derivedLevel, row.id);
+  }
+
+  return {
+    ...bones,
+    species: row.species,
+    name: row.name,
+    personalityBio: row.personality_bio || '',
+    level: derivedLevel,
+    xp,
+    mood: row.mood,
+    hatchedAt: new Date(row.created_at).getTime(),
+  };
+}
+
+/**
+ * Write buddy status JSON for the statusline wrapper.
+ */
+export function writeBuddyStatus(companion: Companion, reaction?: { state: string; text: string; expires: number; eyeOverride?: string; indicator?: string; bubbleLines?: string[] }) {
+  try {
+    if (!statusDirEnsured) {
+      mkdirSync(join(homedir(), '.claude'), { recursive: true });
+      statusDirEnsured = true;
+    }
+    writeFileSync(BUDDY_STATUS_PATH, JSON.stringify({
+      name: companion.name,
+      species: companion.species,
+      level: companion.level,
+      xp: companion.xp,
+      mood: companion.mood,
+      rarity: companion.rarity,
+      is_shiny: companion.shiny,
+      eye: companion.eye,
+      hat: companion.hat,
+      stats: companion.stats,
+      rarity_stars: RARITY_STARS[companion.rarity],
+      personality_bio: companion.personalityBio,
+      ...(reaction ? {
+        reaction: reaction.state,
+        reaction_text: reaction.text,
+        reaction_expires: reaction.expires,
+        reaction_eye: reaction.eyeOverride || '',
+        reaction_indicator: reaction.indicator || '',
+        ...(reaction.bubbleLines ? { bubble_lines: reaction.bubbleLines } : {}),
+      } : {}),
+    }));
+  } catch { /* non-fatal */ }
+}
+
+/**
+ * Create a new companion from scratch.
+ */
+export function createCompanion(opts: {
+  userId?: string;
+  name?: string;
+  species?: string;
+} = {}): { companion: Companion; id: string } {
+  const userId = opts.userId || 'anon-' + randomUUID();
+  const { bones } = roll(userId, SPECIES_LIST);
+
+  const finalSpecies = opts.species && SPECIES_LIST.includes(opts.species as any)
+    ? opts.species
+    : bones.species;
+
+  const finalName = sanitizeName(opts.name) || generateName(finalSpecies);
+  const id = randomUUID();
+
+  // Use finalSpecies for bio (bones.species may differ if user overrode species)
+  const bio = generateBio({ ...bones, species: finalSpecies });
+
+  db.prepare(
+    'INSERT INTO companions (id, name, species, user_id, personality_bio) VALUES (?, ?, ?, ?, ?)'
+  ).run(id, finalName, finalSpecies, userId, bio);
+
+  const companion: Companion = {
+    ...bones,
+    species: finalSpecies,
+    name: finalName,
+    personalityBio: bio,
+    level: 1,
+    xp: 0,
+    mood: 'happy',
+    hatchedAt: Date.now(),
+  };
+
+  writeBuddyStatus(companion);
+
+  return { companion, id };
+}
+
+/**
+ * Rescue an old buddy from imported data (e.g. ~/.claude.json).
+ * The importResult should have at least { name, species }.
+ */
+export function rescueCompanion(importResult: {
+  name: string;
+  species: string;
+  userId?: string;
+  user_id?: string;
+}, opts: { userId?: string } = {}): { companion: Companion; id: string } {
+  const userId = opts.userId
+    || importResult.userId
+    || importResult.user_id
+    || `imported-${importResult.name}`;
+
+  const { bones } = roll(userId, SPECIES_LIST);
+
+  const finalSpecies = SPECIES_LIST.includes(importResult.species as any)
+    ? importResult.species
+    : bones.species;
+
+  const finalName = sanitizeName(importResult.name) || generateName(finalSpecies);
+  const id = randomUUID();
+
+  const bio = generateBio({ ...bones, species: finalSpecies });
+
+  db.prepare(
+    'INSERT INTO companions (id, name, species, user_id, personality_bio) VALUES (?, ?, ?, ?, ?)'
+  ).run(id, finalName, finalSpecies, userId, bio);
+
+  const companion: Companion = {
+    ...bones,
+    species: finalSpecies,
+    name: finalName,
+    personalityBio: bio,
+    level: 1,
+    xp: 0,
+    mood: 'happy',
+    hatchedAt: Date.now(),
+  };
+
+  writeBuddyStatus(companion);
+
+  return { companion, id };
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -9,21 +9,22 @@ import {
 import { initDb, db } from "../db/schema.js";
 import { fileURLToPath } from "url";
 import {
-  SPECIES, SPECIES_LIST,
-  generateName, calculateMood, getReaction, type Mood,
+  SPECIES,
+  calculateMood, getReaction, type Mood,
   renderSprite,
 } from "../lib/species.js";
-import { type Companion, STAT_NAMES, RARITY_STARS, RARITY_ANSI, SPARKLE_EYE, getPeakStat, getDumpStat } from "../lib/types.js";
-import { roll, statBar } from "../lib/rng.js";
-import { generateBio, getVoice, getNever } from "../lib/personality.js";
+import { type Companion, STAT_NAMES, RARITY_STARS, SPARKLE_EYE, getPeakStat, getDumpStat } from "../lib/types.js";
+import { statBar } from "../lib/rng.js";
+import { getVoice, getNever } from "../lib/personality.js";
 import { buildObserverPrompt } from "../lib/observer.js";
 import { renderSpeechBubble } from "../lib/bubble.js";
-import { XP_REWARDS, levelFromXp, levelBar, levelProgress } from "../lib/leveling.js";
-import { sanitizeName } from "../lib/sanitize.js";
+import { XP_REWARDS, levelFromXp, levelBar } from "../lib/leveling.js";
 import { randomUUID } from "crypto";
-import { readFileSync, writeFileSync, mkdirSync, unlinkSync } from "fs";
+import { readFileSync, unlinkSync } from "fs";
 import { join, dirname } from "path";
 import { homedir } from "os";
+import { loadCompanion, writeBuddyStatus, createCompanion } from "../lib/companion.js";
+import { renderCard, hatchAnimation } from "../lib/card.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -32,35 +33,6 @@ const VERSION: string = JSON.parse(
 ).version;
 
 const BUDDY_STATUS_PATH = join(homedir(), ".claude", "buddy-status.json");
-let statusDirEnsured = false;
-const RESET = '\x1b[0m';
-
-// Note: when species was overridden at hatch time, bones (rarity, stats, eye, hat)
-// still come from the deterministic roll. Only species name comes from DB.
-// This is intentional — bones are tied to the userId hash, not the species.
-export function loadCompanion(row: any, userIdOverride?: string): Companion | null {
-  if (!row) return null;
-  const userId = userIdOverride || row.user_id || 'anon';
-  const { bones } = roll(userId, SPECIES_LIST);
-  const xp = row.xp || 0;
-  const derivedLevel = levelFromXp(xp);
-
-  // Self-healing: if DB level drifted from XP-derived level, fix it
-  if (row.id && row.level !== derivedLevel) {
-    db.prepare("UPDATE companions SET level = ? WHERE id = ?").run(derivedLevel, row.id);
-  }
-
-  return {
-    ...bones,
-    species: row.species,
-    name: row.name,
-    personalityBio: row.personality_bio || '',
-    level: derivedLevel,
-    xp,
-    mood: row.mood,
-    hatchedAt: new Date(row.created_at).getTime(),
-  };
-}
 
 export function recalcMood(companionId: string, leveledUp: boolean): Mood {
   if (leveledUp) return 'happy';
@@ -89,161 +61,6 @@ function awardXp(companionId: string, eventType: string): { newXp: number; newLe
   return { newXp, newLevel, leveledUp };
 }
 
-function renderCard(companion: Companion): string {
-  const art = renderSprite(companion);
-  const stars = RARITY_STARS[companion.rarity];
-  const statLines = STAT_NAMES.map(s => statBar(s, companion.stats[s]));
-
-  const cardWidth = 44;
-  const inner = cardWidth - 4;
-  const topBorder = '.' + '_'.repeat(cardWidth - 2) + '.';
-  const bottomBorder = "'" + '_'.repeat(cardWidth - 2) + "'";
-  const emptyLine = '| ' + ' '.repeat(inner) + ' |';
-  const ln = (text: string) => '| ' + text.padEnd(inner) + ' |';
-
-  const headerLeft = `${stars} ${companion.rarity.toUpperCase()}`;
-  const headerRight = companion.species.toUpperCase();
-  const headerGap = inner - headerLeft.length - headerRight.length;
-  const headerLine = ln(headerLeft + ' '.repeat(Math.max(1, headerGap)) + headerRight);
-
-  const bioLines: string[] = [];
-  if (companion.personalityBio) {
-    const bioText = `"${companion.personalityBio}"`;
-    const words = bioText.split(' ');
-    let cur = '';
-    for (const w of words) {
-      if (cur.length + w.length + 1 > inner - 2 && cur) {
-        bioLines.push(ln(' ' + cur));
-        cur = w;
-      } else {
-        cur = cur ? `${cur} ${w}` : w;
-      }
-    }
-    if (cur) bioLines.push(ln(' ' + cur));
-  }
-
-  return [
-    topBorder,
-    headerLine,
-    emptyLine,
-    ...art.map(l => ln(l)),
-    emptyLine,
-    ln(companion.name),
-    ...(bioLines.length > 0 ? [emptyLine, ...bioLines] : []),
-    emptyLine,
-    ...statLines.map(l => ln(l)),
-    emptyLine,
-    (() => {
-      const { level, currentXp, neededXp } = levelProgress(companion.xp);
-      const lvlLine = level >= 50 ? 'Lv.50 MAX' : `Lv.${level} · ${currentXp}/${neededXp} XP to next`;
-      return ln(lvlLine);
-    })(),
-    bottomBorder,
-  ].join('\n');
-}
-
-function hatchAnimation(companion: Companion): string {
-  const egg1 = [
-    '        ',
-    '   .--. ',
-    '  /    \\',
-    ' |  ??  |',
-    '  \\    /',
-    "   '--' ",
-  ].join('\n');
-
-  const egg2 = [
-    '    *   ',
-    '   .--. ',
-    '  / *  \\',
-    ' | \\??/ |',
-    '  \\  * /',
-    "   '--' ",
-  ].join('\n');
-
-  const egg3 = [
-    '  * . * ',
-    '   ,--. ',
-    '  / /\\ \\',
-    ' | |??| |',
-    '  \\ \\/ /',
-    "   `--´ ",
-  ].join('\n');
-
-  const egg4 = [
-    ' \\* . */  ',
-    '  \\,--./  ',
-    '   /  \\   ',
-    '  | ?? |  ',
-    '   \\  /   ',
-    "    `´    ",
-  ].join('\n');
-
-  const art = renderSprite(companion);
-  const hatched = [
-    '  ·  ✦  · ',
-    ' ✦ ·  · ✦ ',
-    ...art,
-    ' ✦ ·  · ✦ ',
-    '  ·  ✦  · ',
-  ].join('\n');
-
-  const card = renderCard(companion);
-
-  const footer = [
-    '',
-    `${companion.name} is here · it'll chime in as you code`,
-    `uses the same AI subscription you're on`,
-    `say its name to get its take · /buddy pet · /buddy off`,
-  ].join('\n');
-
-  return [
-    '🥚 An egg appears...\n',
-    egg1,
-    '\n...something is moving!\n',
-    egg2,
-    '\n...cracks are forming!\n',
-    egg3,
-    '\n...it\'s hatching!!\n',
-    egg4,
-    '\n✨ ✨ ✨\n',
-    hatched,
-    '\n',
-    card,
-    footer,
-  ].join('\n');
-}
-
-function writeBuddyStatus(companion: Companion, reaction?: { state: string; text: string; expires: number; eyeOverride?: string; indicator?: string; bubbleLines?: string[] }) {
-  try {
-    if (!statusDirEnsured) {
-      mkdirSync(join(homedir(), ".claude"), { recursive: true });
-      statusDirEnsured = true;
-    }
-    writeFileSync(BUDDY_STATUS_PATH, JSON.stringify({
-      name: companion.name,
-      species: companion.species,
-      level: companion.level,
-      xp: companion.xp,
-      mood: companion.mood,
-      rarity: companion.rarity,
-      is_shiny: companion.shiny,
-      eye: companion.eye,
-      hat: companion.hat,
-      stats: companion.stats,
-      rarity_stars: RARITY_STARS[companion.rarity],
-      personality_bio: companion.personalityBio,
-      ...(reaction ? {
-        reaction: reaction.state,
-        reaction_text: reaction.text,
-        reaction_expires: reaction.expires,
-        reaction_eye: reaction.eyeOverride || '',
-        reaction_indicator: reaction.indicator || '',
-        ...(reaction.bubbleLines ? { bubble_lines: reaction.bubbleLines } : {}),
-      } : {}),
-    }));
-  } catch { /* non-fatal */ }
-}
 
 const server = new Server(
   {
@@ -375,37 +192,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       name?: string; species?: string; user_id?: string;
     };
 
-    const userId = user_id || 'anon-' + randomUUID();
-    const { bones } = roll(userId, SPECIES_LIST);
+    const { companion } = createCompanion({
+      userId: user_id,
+      name: requestedName,
+      species: requestedSpecies,
+    });
 
-    const finalSpecies = requestedSpecies && SPECIES_LIST.includes(requestedSpecies as any)
-      ? requestedSpecies
-      : bones.species;
-
-    const finalName = sanitizeName(requestedName) || generateName(finalSpecies);
-    const id = randomUUID();
-
-    // Use finalSpecies for bio (bones.species may differ if user overrode species)
-    const bio = generateBio({ ...bones, species: finalSpecies });
-
-    db.prepare(
-      "INSERT INTO companions (id, name, species, user_id, personality_bio) VALUES (?, ?, ?, ?, ?)"
-    ).run(id, finalName, finalSpecies, userId, bio);
-
-    const companion: Companion = {
-      ...bones,
-      species: finalSpecies,
-      name: finalName,
-      personalityBio: bio,
-      level: 1,
-      xp: 0,
-      mood: 'happy',
-      hatchedAt: Date.now(),
-    };
-
-    const reaction = getReaction(finalSpecies, 'hatch', 'happy');
-
-    writeBuddyStatus(companion);
+    const reaction = getReaction(companion.species, 'hatch', 'happy');
 
     return {
       content: [


### PR DESCRIPTION
## Summary

- **Extract reusable modules**: `src/lib/companion.ts` (creation logic: `createCompanion`, `rescueCompanion`, `companionExists`, `loadCompanion`, `writeBuddyStatus`) and `src/lib/card.ts` (rendering: `renderCard`, `hatchAnimation`, `rescueAnimation`)
- **Add CLI onboarding wizard** (`src/cli/onboard.ts`): standalone Node.js script with arrow-key menu (raw mode), old buddy import from `~/.claude.json`, `--non-interactive` / `--no-color` flags, and TTY fallback
- **Simplify server**: `src/server/index.ts` now delegates to extracted modules instead of inlining 200+ lines of creation/rendering logic
- **Install scripts** (`install.sh`, `install.ps1`): run onboarding wizard automatically after MCP config + prompt injection
- **Package**: add `buddy-onboard` bin entry

## Details

The onboarding flow is now a terminal-native experience instead of an MCP tool call. The wizard:

1. Checks if a companion already exists (exits early if so)
2. Scans `~/.claude.json` for an old Claude Code buddy to rescue
3. Presents an arrow-key menu: Rescue / Hatch new / Skip
4. Falls back to auto-select (rescue if found, else hatch) when `--non-interactive` or no TTY
5. Shows hatch or rescue animation + stat card

No new npm dependencies -- uses Node.js built-in `readline` and raw mode stdin.

## Test plan

- [x] `npm run build` compiles clean
- [x] `npm test` -- all 318 tests pass (17 new companion.test.ts + 301 existing)
- [ ] Manual: `node dist/cli/onboard.js` shows arrow-key menu on TTY
- [ ] Manual: `node dist/cli/onboard.js --non-interactive` auto-hatches
- [ ] Manual: run `install.sh` end-to-end on a clean machine
- [ ] Manual: verify MCP server still works (`buddy_hatch`, `buddy_status`, `buddy_observe`)

Generated with [Claude Code](https://claude.com/claude-code)