### PR TITLE
Fix: isolate test DB from production

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -3,9 +3,10 @@ import path from 'path';
 import { mkdirSync } from 'fs';
 import { homedir } from 'os';
 
-const buddyDir = path.join(homedir(), '.buddy');
-mkdirSync(buddyDir, { recursive: true });
-const dbPath = path.join(buddyDir, 'buddy.db');
+// BUDDY_DB_PATH env var allows tests to use an isolated DB
+// instead of the production ~/.buddy/buddy.db
+const dbPath = process.env.BUDDY_DB_PATH || path.join(homedir(), '.buddy', 'buddy.db');
+mkdirSync(path.dirname(dbPath), { recursive: true });
 
 export const db = new Database(dbPath);
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vitest/config';
+import { join } from 'path';
+import { tmpdir } from 'os';
 
 export default defineConfig({
   test: {
     include: ['src/__tests__/**/*.test.ts'],
+    env: {
+      // Tests use an isolated DB so they never touch ~/.buddy/buddy.db
+      BUDDY_DB_PATH: join(tmpdir(), 'buddy-test.db'),
+    },
   },
 });


### PR DESCRIPTION
## Summary

Tests were using the production DB at `~/.buddy/buddy.db`, causing test companions to overwrite the user's real companion. This happened repeatedly during this session (Healer kept replacing Nuzzlecap).

### Changes
- `src/db/schema.ts`: respects `BUDDY_DB_PATH` env var for DB location
- `vitest.config.ts`: sets `BUDDY_DB_PATH` to OS temp dir for all tests

### Result
- Tests run against `/tmp/buddy-test.db` (or OS equivalent)
- Production DB at `~/.buddy/buddy.db` is never touched by tests
- 318 tests still pass

## Test plan
- [x] 318 tests pass
- [x] Verified production DB untouched after test run (Nuzzlecap safe)
- [x] Verified test DB created in temp dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)