### PR TITLE
docs: link Claude Code attribution to official repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,10 @@ All notable changes to this project will follow [Semantic Versioning](https://se
 - Rich personality bios (21 species x 3 templates)
 - Species voice kernels and NEVER constraints for AI roleplay (per-species voice + 2 behavioral guardrails)
 - Pokemon-style hatch animation + rescue animation for imported companions
-- Interactive terminal onboarding wizard during install (arrow-key menu, old buddy rescue or fresh hatch)
-- Old buddy import from ~/.claude.json — uses original CC userID for deterministic restoration (same name, species, stats)
+- Two-path onboarding wizard during install:
+  - **Rescue mode**: imports your old Claude Code buddy from `~/.claude.json` — uses original CC userID for deterministic restoration (same name, species, stats, eye, rarity)
+  - **Hatch mode**: fresh companion with random species, stats, and personality
+  - Interactive arrow-key menu with `--non-interactive` and `--no-onboard` flags for CI
 - Choreographed animation sequences (15-frame idle cycle, 500ms ticks, mood-aware: idle/grumpy/happy patterns)
 - Statusline integration (side-by-side with claude-hud, full speech bubble rendering)
 - Mood recalibration on every interaction (observe, pet, status) + happy on level-up

--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ npm start
 
 ## Credits
 
-- Original buddy concept by [Anthropic](https://www.anthropic.com/) in Claude Code `v2.1.89` to `v2.1.94`
+- Original buddy concept by [Anthropic](https://www.anthropic.com/) in [Claude Code](https://github.com/anthropics/claude-code) `v2.1.89` to `v2.1.94`
 - Inspired by [effigy](https://github.com/justinstimatze/effigy), [claude-buddy](https://github.com/1270011/claude-buddy), and [save-buddy](https://github.com/jrykn/save-buddy). Thanks!
 - Built with the [Model Context Protocol](https://modelcontextprotocol.io/)
 
@@ -381,7 +381,7 @@ Buddy also draws on publicly shared community research around the original compa
 - [BonziClaude](https://github.com/zakarth/BonziClaude) by [@zakarth](https://github.com/zakarth) is an important technical reference point in the ecosystem, especially around reverse-engineering and documenting companion-system behavior.
 - [claude-buddy](https://github.com/1270011/claude-buddy) by [@1270011](https://github.com/1270011) helped demonstrate the MCP plus terminal-integration preservation approach for keeping buddy-like experiences alive across client changes.
 - Community research and discussion, including work shared on r/Anthropic, helped clarify endpoint behavior and preserve details that would otherwise have been lost.
-- Official Claude Code and MCP documentation informed the portable integration approach: MCP server wiring, client configuration, and supported terminal integration surfaces.
+- Official [Claude Code](https://github.com/anthropics/claude-code) and [MCP](https://modelcontextprotocol.io/) documentation informed the portable integration approach: MCP server wiring, client configuration, and supported terminal integration surfaces.
 
 Buddy is an open-source project dedicated to keeping the terminal a little less lonely.
 Your buddy shouldn't disappear when you close the terminal.

--- a/README.md
+++ b/README.md
@@ -47,13 +47,12 @@ curl -fsSL https://raw.githubusercontent.com/fiorastudio/buddy/master/install.sh
 irm https://raw.githubusercontent.com/fiorastudio/buddy/master/install.ps1 | iex
 ```
 
-Then open your AI terminal and say:
+The installer will guide you through onboarding:
 
-```text
-hatch a buddy
-```
+- **Rescue your old buddy** — if you had a `/buddy` in Claude Code, the wizard finds it in `~/.claude.json` and brings it home with the same name, species, and stats, now with leveling + XP
+- **Hatch a new buddy** — get a fresh companion with random species, stats, and personality
 
-> Requires `node` 18+ and `git`.
+> Requires `node` 18+ and `git`. Use `--no-onboard` to skip the wizard in CI.
 
 ## What You Get
 


### PR DESCRIPTION
Links Claude Code mentions in the credits section to https://github.com/anthropics/claude-code. Supersedes #42 (which had conflicts).