### PR TITLE
Species-specific deterministic name generation

### DIFF
--- a/src/__tests__/names.test.ts
+++ b/src/__tests__/names.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { generateName, SPECIES_LIST } from '../lib/species.js';
+import { seededIndex } from '../lib/rng.js';
+
+describe('seededIndex', () => {
+  it('returns deterministic index for same seed+namespace', () => {
+    const a = seededIndex('user1', 'name:first', 10);
+    const b = seededIndex('user1', 'name:first', 10);
+    expect(a).toBe(b);
+  });
+
+  it('returns different index for different seed', () => {
+    const a = seededIndex('user1', 'name:first', 100);
+    const b = seededIndex('user2', 'name:first', 100);
+    expect(a).not.toBe(b);
+  });
+
+  it('returns different index for different namespace', () => {
+    const a = seededIndex('user1', 'name:first', 100);
+    const b = seededIndex('user1', 'name:second', 100);
+    expect(a).not.toBe(b);
+  });
+
+  it('returns 0 for length <= 0', () => {
+    expect(seededIndex('user1', 'ns', 0)).toBe(0);
+    expect(seededIndex('user1', 'ns', -5)).toBe(0);
+  });
+
+  it('returns index within bounds', () => {
+    for (let i = 0; i < 50; i++) {
+      const idx = seededIndex(`user-${i}`, 'test', 10);
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(idx).toBeLessThan(10);
+    }
+  });
+});
+
+describe('generateName', () => {
+  it('returns deterministic name for same userId + species', () => {
+    const a = generateName('Mushroom', 'user-abc');
+    const b = generateName('Mushroom', 'user-abc');
+    expect(a).toBe(b);
+  });
+
+  it('returns different name for different userId', () => {
+    const a = generateName('Mushroom', 'user-alpha');
+    const b = generateName('Mushroom', 'user-beta');
+    // Could collide rarely, but with 100 combos it's unlikely for 2 specific users
+    expect(a).not.toBe(b);
+  });
+
+  it('different species can produce different names for same user', () => {
+    const a = generateName('Void Cat', 'user-test');
+    const b = generateName('Robot', 'user-test');
+    expect(a).not.toBe(b);
+  });
+
+  it('returns non-empty name', () => {
+    for (const species of SPECIES_LIST) {
+      const name = generateName(species, 'test-user');
+      expect(name.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('returns name within reasonable length (3-16 chars)', () => {
+    for (const species of SPECIES_LIST) {
+      for (let i = 0; i < 10; i++) {
+        const name = generateName(species, `user-${i}`);
+        expect(name.length).toBeGreaterThanOrEqual(3);
+        expect(name.length).toBeLessThanOrEqual(16);
+      }
+    }
+  });
+
+  it('unknown species uses fallback pools', () => {
+    const name = generateName('Unknown Species', 'user-test');
+    expect(name.length).toBeGreaterThan(0);
+  });
+
+  it('works without userId (random fallback)', () => {
+    const name = generateName('Duck');
+    expect(name.length).toBeGreaterThan(0);
+  });
+
+  it('every species has a name pool', () => {
+    for (const species of SPECIES_LIST) {
+      const name = generateName(species, 'verify-pool');
+      expect(name.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/lib/companion.ts
+++ b/src/lib/companion.ts
@@ -100,7 +100,7 @@ export function createCompanion(opts: {
     ? opts.species
     : bones.species;
 
-  const finalName = sanitizeName(opts.name) || generateName(finalSpecies);
+  const finalName = sanitizeName(opts.name) || generateName(finalSpecies, userId);
   const id = randomUUID();
 
   // Use finalSpecies for bio (bones.species may differ if user overrode species)
@@ -147,7 +147,7 @@ export function rescueCompanion(importResult: {
     ? importResult.species
     : bones.species;
 
-  const finalName = sanitizeName(importResult.name) || generateName(finalSpecies);
+  const finalName = sanitizeName(importResult.name) || generateName(finalSpecies, userId);
   const id = randomUUID();
 
   const bio = generateBio({ ...bones, species: finalSpecies });

--- a/src/lib/rng.ts
+++ b/src/lib/rng.ts
@@ -38,6 +38,17 @@ function hashString(s: string): number {
   return h >>> 0;
 }
 
+/**
+ * Deterministic index selection from a seed string + namespace.
+ * Keeps hashString/mulberry32 private — this is the public API.
+ */
+export function seededIndex(seed: string, namespace: string, length: number): number {
+  if (length <= 0) return 0;
+  const hash = hashString(seed + ':' + namespace);
+  const rng = mulberry32(hash);
+  return Math.floor(rng() * length);
+}
+
 function pick<T>(rng: () => number, arr: readonly T[]): T {
   return arr[Math.floor(rng() * arr.length)]!;
 }

--- a/src/lib/species.ts
+++ b/src/lib/species.ts
@@ -384,14 +384,51 @@ export function calculateMood(xpEvents: any[], recentMemories: number): Mood {
   return 'grumpy';
 }
 
-export function generateName(species: string): string {
-  const prefixes = ['Bit', 'Hex', 'Zip', 'Log', 'Null', 'Void', 'Rust', 'Data', 'Cyber', 'Neo', 'Giga', 'Nano'];
-  const suffixes = ['y', 'o', 'it', 'ox', 'us', 'ix', 'en', 'ly', 'oid', 'bot', 'tron', 'kin'];
-  
-  const prefix = prefixes[Math.floor(Math.random() * prefixes.length)];
-  const suffix = suffixes[Math.floor(Math.random() * suffixes.length)];
-  
-  return prefix + suffix;
+// Species-specific two-pool name system — combine first+second for ~100 unique names per species
+type NamePools = { first: string[]; second: string[] };
+
+const SPECIES_NAMES: Record<string, NamePools> = {
+  'Void Cat':     { first: ['Shadow','Onyx','Ember','Ash','Dusk','Nyx','Luna','Umbra','Vesper','Soot'], second: ['paw','whisker','claw','fang','fur','tail','eye','step','purr','shade'] },
+  'Rust Hound':   { first: ['Iron','Steel','Copper','Bolt','Rivet','Gear','Axle','Chrome','Forge','Titan'], second: ['bark','fang','paw','snout','howl','scout','run','dig','wag','nose'] },
+  'Data Drake':   { first: ['Cipher','Flux','Prism','Vector','Scalar','Delta','Sigma','Byte','Pixel','Qubit'], second: ['wing','fire','scale','claw','tail','fang','spark','flare','blaze','horn'] },
+  'Log Golem':    { first: ['Stone','Slab','Brick','Crag','Flint','Basalt','Cobble','Rune','Quarry','Ore'], second: ['fist','guard','wall','step','core','helm','shard','block','forge','chip'] },
+  'Cache Crow':   { first: ['Jet','Raven','Ink','Coal','Flint','Storm','Gust','Swift','Talon','Plume'], second: ['beak','wing','caw','eye','flight','perch','swoop','call','glide','feather'] },
+  'Shell Turtle': { first: ['Moss','Coral','Tide','Pearl','Shell','Reef','Drift','Kelp','Shore','Wave'], second: ['shell','back','fin','pace','drift','guard','swim','trek','plod','calm'] },
+  'Duck':         { first: ['Quill','Puddle','Waddle','Drake','Splash','Ripple','Reed','Marsh','Brook','Pond'], second: ['bill','wing','flap','float','dip','dive','quack','swim','bob','tuft'] },
+  'Goose':        { first: ['Gale','Storm','Brass','Flint','Thunder','Noble','Baron','Guard','Sentry','Valor'], second: ['honk','wing','step','guard','charge','strut','call','gaze','march','fury'] },
+  'Blob':         { first: ['Goo','Jelly','Slick','Ooze','Wobble','Pudge','Glob','Squish','Bubble','Drop'], second: ['blob','plop','drip','goo','bounce','wiggle','jiggle','slide','stretch','morph'] },
+  'Octopus':      { first: ['Ink','Coral','Deep','Tide','Reef','Abyss','Kraken','Pearl','Drift','Azure'], second: ['arm','ink','jet','swirl','grip','wave','coil','pulse','flow','dash'] },
+  'Owl':          { first: ['Sage','Dusk','Alder','Glen','Hazel','Willow','Aspen','Cedar','Briar','Fern'], second: ['hoot','talon','wing','gaze','perch','swoop','watch','flight','brow','plume'] },
+  'Penguin':      { first: ['Frost','Ice','Snow','Floe','Sleet','Drift','Chill','Polar','Arctic','Glaze'], second: ['flip','slide','waddle','dive','tux','march','chill','splash','glide','beak'] },
+  'Snail':        { first: ['Dew','Moss','Fern','Petal','Leaf','Lichen','Trail','Mist','Glen','Meadow'], second: ['shell','trail','pace','curl','glide','slow','slime','swirl','inch','coil'] },
+  'Ghost':        { first: ['Wisp','Shade','Mist','Echo','Haze','Drift','Vapor','Veil','Gloom','Fade'], second: ['haunt','fade','drift','chill','glow','wail','hover','phase','float','flick'] },
+  'Axolotl':      { first: ['Coral','Bloom','Lily','Petal','Brine','Splash','Ripple','Foam','Fizz','Aqua'], second: ['gill','fin','frill','swim','glow','wave','drift','splash','bloom','frond'] },
+  'Capybara':     { first: ['Marsh','Clover','Sage','Meadow','Willow','Honey','Maple','Birch','Hazel','Reed'], second: ['munch','calm','chill','snooze','loaf','soak','wade','graze','plod','nap'] },
+  'Cactus':       { first: ['Spike','Thorn','Agave','Prickle','Sandy','Mesa','Dune','Arid','Flint','Sage'], second: ['spike','bloom','thorn','poke','sun','grit','sand','root','stem','guard'] },
+  'Robot':        { first: ['Volt','Spark','Circuit','Pixel','Binary','Logic','Chip','Servo','Core','Nano'], second: ['bot','byte','bit','beep','buzz','whir','click','sync','ping','boop'] },
+  'Rabbit':       { first: ['Clover','Thistle','Bramble','Fern','Daisy','Poppy','Hazel','Nutmeg','Basil','Sage'], second: ['hop','ear','paw','nose','thump','dash','leap','fluff','bound','skip'] },
+  'Mushroom':     { first: ['Spore','Morel','Truffle','Cap','Myco','Shroom','Toadly','Fungi','Porcini','Chanty'], second: ['cap','stem','gill','ring','veil','bloom','dew','root','moss','kin'] },
+  'Chonk':        { first: ['Pudge','Chunk','Fluff','Plump','Round','Husky','Beefy','Hefty','Stout','Waddle'], second: ['loaf','roll','nap','plop','sit','purr','snore','flop','lump','chub'] },
+};
+
+const FALLBACK_POOLS: NamePools = {
+  first: ['Bit','Hex','Zip','Log','Null','Void','Rust','Data','Cyber','Neo'],
+  second: ['kin','bot','oid','tron','ix','en','us','ly','ox','it'],
+};
+
+import { seededIndex } from './rng.js';
+
+export function generateName(species: string, userId?: string): string {
+  const pools = SPECIES_NAMES[species] || FALLBACK_POOLS;
+  if (!userId) {
+    const p1 = pools.first[Math.floor(Math.random() * pools.first.length)];
+    const p2 = pools.second[Math.floor(Math.random() * pools.second.length)];
+    return p1 + p2;
+  }
+  const seed = userId + species;
+  const i1 = seededIndex(seed, 'name:first', pools.first.length);
+  const i2 = seededIndex(seed, 'name:second', pools.second.length);
+  return pools.first[i1]! + pools.second[i2]!;
 }
 
 export function getReaction(species: string, event: string, mood: Mood): string {


### PR DESCRIPTION
## Summary
Replace generic random names (Hexbot, Nulltron) with species-themed two-pool combos:
- Each species has 10 first × 10 second names (~100 unique combos)
- Deterministic from userId via seededIndex() — same user = same name
- Void Cat → Shadowpaw, Nyx claw; Robot → Voltbot, Sparkbeep; etc.

## Changes
- `src/lib/rng.ts` — new `seededIndex(seed, namespace, length)` export
- `src/lib/species.ts` — `SPECIES_NAMES` for all 21 species, new `generateName(species, userId?)`
- `src/lib/companion.ts` — pass userId to generateName in create + rescue
- `src/__tests__/names.test.ts` — 13 new tests

## Test plan
- [x] 331 tests pass
- [x] Same userId + species → same name (deterministic)
- [x] Different userId → different name
- [x] All 21 species have themed pools
- [x] Unknown species uses fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)