### PR TITLE
Fix installer MCP wiring + statusline

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -52,6 +52,8 @@ npm run build --quiet 2>$null
 
 $SERVER_PATH = "$INSTALL_DIR\dist\server\index.js"
 $SERVER_PATH_UNIX = $SERVER_PATH -replace '\\', '/'
+$STATUSLINE_PATH = "$INSTALL_DIR\dist\statusline-wrapper.js"
+$STATUSLINE_PATH_UNIX = $STATUSLINE_PATH -replace '\\', '/'
 
 Pop-Location
 
@@ -62,6 +64,7 @@ function Add-BuddyToConfig($configPath, $cliName) {
   if (!(Test-Path $configDir)) { return }
 
   $buddyConfig = @{
+    type = "stdio"
     command = "node"
     args = @($SERVER_PATH_UNIX)
   }
@@ -96,50 +99,106 @@ Write-Host "  Configuring MCP clients..."
 # Claude Code
 $claudeDir = "$env:USERPROFILE\.claude"
 if (!(Test-Path $claudeDir)) { New-Item -ItemType Directory -Path $claudeDir -Force | Out-Null }
-Add-BuddyToConfig "$claudeDir\settings.json" "Claude Code"
 
-# Add PostToolUse hook to Claude Code settings (array-append, don't replace)
-$claudeSettings = "$claudeDir\settings.json"
-if (Test-Path $claudeSettings) {
+$claudeRegistered = $false
+if (Get-Command claude -ErrorAction SilentlyContinue) {
   try {
-    $config = Get-Content $claudeSettings -Raw | ConvertFrom-Json
-    if (!$config.hooks) {
-      $config | Add-Member -NotePropertyName "hooks" -NotePropertyValue @{} -Force
-    }
-    $hooks = $config.hooks
-    if (!$hooks.PostToolUse) {
-      $hooks | Add-Member -NotePropertyName "PostToolUse" -NotePropertyValue @() -Force
-    }
-    # Check if buddy hook already exists
-    $hasBuddy = $false
-    foreach ($entry in $hooks.PostToolUse) {
-      if ($entry.matcher -eq 'Bash' -and $entry.hooks) {
-        foreach ($hk in $entry.hooks) {
-          if ($hk.command -and $hk.command -like '*post-tool-handler*') {
-            $hasBuddy = $true
-          }
-        }
-      }
-    }
-    if (-not $hasBuddy) {
-      $hookEntry = @{
-        matcher = "Bash"
-        hooks = @(@{
-          type = "command"
-          command = "node $HOOK_PATH_UNIX"
-          async = $true
-          timeout = 3
-        })
-      }
-      $hooks.PostToolUse = @($hooks.PostToolUse) + @($hookEntry)
-      $config | ConvertTo-Json -Depth 8 | Set-Content $claudeSettings -Encoding UTF8
-      Write-Host "  ✓ PostToolUse hook configured" -ForegroundColor Green
-    } else {
-      Write-Host "  ✓ PostToolUse hook already configured" -ForegroundColor Green
-    }
+    claude mcp get buddy 1>$null 2>$null
+    Write-Host "  ✓ Claude Code MCP already registered" -ForegroundColor Green
+    $claudeRegistered = $true
   } catch {
-    Write-Host "  ! Could not configure PostToolUse hook" -ForegroundColor Yellow
+    try {
+      claude mcp add buddy -s user -- node "$SERVER_PATH_UNIX" 1>$null 2>$null
+      Write-Host "  ✓ Claude Code MCP registered via claude CLI" -ForegroundColor Green
+      $claudeRegistered = $true
+    } catch {
+      Write-Host "  ! claude CLI detected, but MCP registration failed — falling back to manual config" -ForegroundColor Yellow
+    }
   }
+}
+
+if (-not $claudeRegistered) {
+  $claudeUserFile = "$env:USERPROFILE\.claude.json"
+  $userConfig = @{}
+  if (Test-Path $claudeUserFile) {
+    try { $userConfig = Get-Content $claudeUserFile -Raw | ConvertFrom-Json }
+    catch { $userConfig = @{} }
+  }
+  if (!$userConfig.mcpServers) {
+    $userConfig | Add-Member -NotePropertyName "mcpServers" -NotePropertyValue @{} -Force
+  }
+  $userConfig.mcpServers | Add-Member -NotePropertyName "buddy" -NotePropertyValue @{
+    type = "stdio"
+    command = "node"
+    args = @($SERVER_PATH_UNIX)
+  } -Force
+  $userConfig | ConvertTo-Json -Depth 8 | Set-Content $claudeUserFile -Encoding UTF8
+  Write-Host "  ✓ Claude Code MCP config written ($claudeUserFile)" -ForegroundColor Green
+}
+
+$claudeSettings = "$claudeDir\settings.json"
+if (!(Test-Path $claudeSettings)) {
+  '{}' | Set-Content $claudeSettings -Encoding UTF8
+}
+
+$hookConfigured = $false
+$statuslineConfigured = $false
+$statuslineCommand = "node $STATUSLINE_PATH_UNIX"
+try {
+  $config = Get-Content $claudeSettings -Raw | ConvertFrom-Json
+} catch {
+  $config = @{}
+}
+if (!$config.hooks) {
+  $config | Add-Member -NotePropertyName "hooks" -NotePropertyValue @{} -Force
+}
+$hooks = $config.hooks
+if (!$hooks.PostToolUse) {
+  $hooks | Add-Member -NotePropertyName "PostToolUse" -NotePropertyValue @() -Force
+}
+$hasBuddyHook = $false
+foreach ($entry in @($hooks.PostToolUse)) {
+  if ($entry.matcher -eq 'Bash' -and $entry.hooks) {
+    foreach ($hk in $entry.hooks) {
+      if ($hk.command -and $hk.command -like "*post-tool-handler*") {
+        $hasBuddyHook = $true
+      }
+    }
+  }
+}
+if (-not $hasBuddyHook) {
+  $hookEntry = @{
+    matcher = "Bash"
+    hooks = @(@{
+      type = "command"
+      command = "node $HOOK_PATH_UNIX"
+      async = $true
+      timeout = 3
+    })
+  }
+  $hooks.PostToolUse = @($hooks.PostToolUse) + @($hookEntry)
+  $hookConfigured = $true
+}
+if ((-not $config.statusLine) -or $config.statusLine.command -ne $statuslineCommand -or $config.statusLine.type -ne 'command') {
+  $config | Add-Member -NotePropertyName "statusLine" -NotePropertyValue ([ordered]@{
+    type = "command"
+    command = $statuslineCommand
+    padding = 1
+  }) -Force
+  $statuslineConfigured = $true
+}
+if ($hookConfigured -or $statuslineConfigured) {
+  $config | ConvertTo-Json -Depth 8 | Set-Content $claudeSettings -Encoding UTF8
+}
+if ($hookConfigured) {
+  Write-Host "  ✓ PostToolUse hook configured" -ForegroundColor Green
+} else {
+  Write-Host "  ✓ PostToolUse hook already configured" -ForegroundColor Green
+}
+if ($statuslineConfigured) {
+  Write-Host "  ✓ Claude Code statusline configured ($statuslineCommand)" -ForegroundColor Green
+} else {
+  Write-Host "  ✓ Claude Code statusline already configured" -ForegroundColor Green
 }
 
 # Cursor

--- a/install.ps1
+++ b/install.ps1
@@ -102,16 +102,16 @@ if (!(Test-Path $claudeDir)) { New-Item -ItemType Directory -Path $claudeDir -Fo
 
 $claudeRegistered = $false
 if (Get-Command claude -ErrorAction SilentlyContinue) {
-  try {
-    claude mcp get buddy 1>$null 2>$null
+  claude mcp get buddy 1>$null 2>$null
+  if ($LASTEXITCODE -eq 0) {
     Write-Host "  ✓ Claude Code MCP already registered" -ForegroundColor Green
     $claudeRegistered = $true
-  } catch {
-    try {
-      claude mcp add buddy -s user -- node "$SERVER_PATH_UNIX" 1>$null 2>$null
+  } else {
+    claude mcp add buddy -s user -- node "$SERVER_PATH_UNIX" 1>$null 2>$null
+    if ($LASTEXITCODE -eq 0) {
       Write-Host "  ✓ Claude Code MCP registered via claude CLI" -ForegroundColor Green
       $claudeRegistered = $true
-    } catch {
+    } else {
       Write-Host "  ! claude CLI detected, but MCP registration failed — falling back to manual config" -ForegroundColor Yellow
     }
   }

--- a/install.sh
+++ b/install.sh
@@ -69,88 +69,109 @@ CODEX_CONFIGURED=0
 # ── Auto-configure MCP for detected CLIs ──
 
 configure_claude_code() {
-  local config_file="$HOME/.claude/settings.json"
   local config_dir="$HOME/.claude"
+  local settings_file="$config_dir/settings.json"
+  local user_file="$HOME/.claude.json"
   local hook_path="$INSTALL_DIR/dist/hooks/post-tool-handler.js"
+  local statusline_command="node $INSTALL_DIR/dist/statusline-wrapper.js"
 
   mkdir -p "$config_dir"
 
-  if [ ! -f "$config_file" ]; then
-    # Create new settings with buddy + hook
-    cat > "$config_file" << EOJSON
-{
-  "mcpServers": {
-    "buddy": {
-      "command": "node",
-      "args": ["$SERVER_PATH"]
-    }
-  },
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node $hook_path",
-            "async": true,
-            "timeout": 3
-          }
-        ]
-      }
-    ]
-  }
-}
-EOJSON
-    echo -e "  ${GREEN}✓${NC} Claude Code configured ${DIM}($config_file)${NC}"
-    return 0
-  fi
-
-  # Check if buddy already configured
-  if grep -q '"buddy"' "$config_file" 2>/dev/null; then
-    echo -e "  ${GREEN}✓${NC} Claude Code already configured"
-  else
-    # Inject buddy into existing mcpServers (or add mcpServers section)
-    if command -v node &> /dev/null; then
-      node -e "
-        const fs = require('fs');
-        const config = JSON.parse(fs.readFileSync('$config_file', 'utf-8'));
-        if (!config.mcpServers) config.mcpServers = {};
-        config.mcpServers.buddy = { command: 'node', args: ['$SERVER_PATH'] };
-        fs.writeFileSync('$config_file', JSON.stringify(config, null, 2));
-      " 2>/dev/null
-      echo -e "  ${GREEN}✓${NC} Claude Code configured ${DIM}($config_file)${NC}"
+  local registered=0
+  if command -v claude &> /dev/null; then
+    if claude mcp get buddy >/dev/null 2>&1; then
+      echo -e "  ${GREEN}✓${NC} Claude Code MCP already registered"
+      registered=1
+    else
+      if claude mcp add buddy -s user -- node "$SERVER_PATH" >/dev/null 2>&1; then
+        echo -e "  ${GREEN}✓${NC} Claude Code MCP registered via claude CLI"
+        registered=1
+      else
+        echo -e "  ${YELLOW}!${NC} claude CLI detected, but MCP registration failed — falling back to manual config"
+      fi
     fi
   fi
 
-  # Add PostToolUse hook (array-append, don't replace existing hooks)
-  if command -v node &> /dev/null; then
-    node -e "
-      const fs = require('fs');
-      const config = JSON.parse(fs.readFileSync('$config_file', 'utf-8'));
-      if (!config.hooks) config.hooks = {};
-      if (!config.hooks.PostToolUse) config.hooks.PostToolUse = [];
-      // Check if buddy hook already exists
-      const hasBuddy = config.hooks.PostToolUse.some(h =>
-        h.matcher === 'Bash' && h.hooks && h.hooks.some(hk => hk.command && hk.command.includes('post-tool-handler'))
-      );
-      if (!hasBuddy) {
-        config.hooks.PostToolUse.push({
-          matcher: 'Bash',
-          hooks: [{
-            type: 'command',
-            command: 'node $hook_path',
-            async: true,
-            timeout: 3
-          }]
-        });
-        fs.writeFileSync('$config_file', JSON.stringify(config, null, 2));
-        console.error('  hook registered');
-      }
-    " 2>/dev/null
+  if [ "$registered" -ne 1 ]; then
+    CLAUDE_USER_FILE="$user_file" SERVER_PATH="$SERVER_PATH" node <<'EOJS' 2>/dev/null || true
+const fs = require('fs');
+const path = process.env.CLAUDE_USER_FILE;
+const serverPath = process.env.SERVER_PATH;
+let data = {};
+try { data = JSON.parse(fs.readFileSync(path, 'utf-8')); } catch {}
+if (!data.mcpServers) data.mcpServers = {};
+data.mcpServers.buddy = {
+  type: 'stdio',
+  command: 'node',
+  args: [serverPath]
+};
+fs.writeFileSync(path, JSON.stringify(data, null, 2));
+EOJS
+    echo -e "  ${GREEN}✓${NC} Claude Code MCP config written ${DIM}($user_file)${NC}"
+  fi
+
+  local hook_status
+  hook_status=$(CLAUDE_SETTINGS="$settings_file" HOOK_COMMAND="node $hook_path" node <<'EOJS'
+const fs = require('fs');
+const path = process.env.CLAUDE_SETTINGS;
+const hookCommand = process.env.HOOK_COMMAND;
+let config = {};
+try { config = JSON.parse(fs.readFileSync(path, 'utf-8')); } catch {}
+if (!config.hooks) config.hooks = {};
+if (!Array.isArray(config.hooks.PostToolUse)) config.hooks.PostToolUse = [];
+const hasHook = config.hooks.PostToolUse.some(entry =>
+  entry.matcher === 'Bash' &&
+  Array.isArray(entry.hooks) &&
+  entry.hooks.some(h => h.command === hookCommand)
+);
+if (!hasHook) {
+  config.hooks.PostToolUse.push({
+    matcher: 'Bash',
+    hooks: [{
+      type: 'command',
+      command: hookCommand,
+      async: true,
+      timeout: 3
+    }]
+  });
+  fs.writeFileSync(path, JSON.stringify(config, null, 2));
+  process.stdout.write('updated');
+} else {
+  process.stdout.write('noop');
+}
+EOJS
+)
+  if [ "$hook_status" = "updated" ]; then
     echo -e "  ${GREEN}✓${NC} PostToolUse hook configured"
+  else
+    echo -e "  ${GREEN}✓${NC} PostToolUse hook already configured"
+  fi
+
+  local status_status
+  status_status=$(CLAUDE_SETTINGS="$settings_file" STATUSLINE_COMMAND="$statusline_command" node <<'EOJS'
+const fs = require('fs');
+const path = process.env.CLAUDE_SETTINGS;
+const command = process.env.STATUSLINE_COMMAND;
+let config = {};
+try { config = JSON.parse(fs.readFileSync(path, 'utf-8')); } catch {}
+const desired = { type: 'command', command, padding: 1 };
+const needsUpdate = !config.statusLine || config.statusLine.type !== 'command' || config.statusLine.command !== command;
+if (needsUpdate) {
+  config.statusLine = desired;
+  fs.writeFileSync(path, JSON.stringify(config, null, 2));
+  process.stdout.write('updated');
+} else {
+  process.stdout.write('noop');
+}
+EOJS
+)
+  if [ "$status_status" = "updated" ]; then
+    echo -e "  ${GREEN}✓${NC} Claude Code statusline configured"
+  else
+    echo -e "  ${GREEN}✓${NC} Claude Code statusline already configured"
   fi
 }
+
 
 configure_cursor() {
   local config_file="$HOME/.cursor/mcp.json"

--- a/install.sh
+++ b/install.sh
@@ -93,7 +93,8 @@ configure_claude_code() {
   fi
 
   if [ "$registered" -ne 1 ]; then
-    CLAUDE_USER_FILE="$user_file" SERVER_PATH="$SERVER_PATH" node <<'EOJS' 2>/dev/null || true
+    if command -v node &> /dev/null; then
+      if CLAUDE_USER_FILE="$user_file" SERVER_PATH="$SERVER_PATH" node <<'EOJS' 2>/dev/null; then
 const fs = require('fs');
 const path = process.env.CLAUDE_USER_FILE;
 const serverPath = process.env.SERVER_PATH;
@@ -107,16 +108,29 @@ data.mcpServers.buddy = {
 };
 fs.writeFileSync(path, JSON.stringify(data, null, 2));
 EOJS
-    echo -e "  ${GREEN}✓${NC} Claude Code MCP config written ${DIM}($user_file)${NC}"
+        echo -e "  ${GREEN}✓${NC} Claude Code MCP config written ${DIM}($user_file)${NC}"
+      else
+        echo -e "  ${YELLOW}!${NC} Could not write MCP config to $user_file"
+      fi
+    else
+      echo -e "  ${YELLOW}!${NC} node not found — cannot configure Claude Code MCP"
+    fi
   fi
 
-  local hook_status
-  hook_status=$(CLAUDE_SETTINGS="$settings_file" HOOK_COMMAND="node $hook_path" node <<'EOJS'
+  # Configure hook + statusline in a single settings.json write
+  if command -v node &> /dev/null; then
+    local settings_result
+    settings_result=$(CLAUDE_SETTINGS="$settings_file" HOOK_COMMAND="node $hook_path" STATUSLINE_COMMAND="$statusline_command" node <<'EOJS'
 const fs = require('fs');
-const path = process.env.CLAUDE_SETTINGS;
+const settingsPath = process.env.CLAUDE_SETTINGS;
 const hookCommand = process.env.HOOK_COMMAND;
+const statuslineCommand = process.env.STATUSLINE_COMMAND;
 let config = {};
-try { config = JSON.parse(fs.readFileSync(path, 'utf-8')); } catch {}
+try { config = JSON.parse(fs.readFileSync(settingsPath, 'utf-8')); } catch {}
+let changed = false;
+const result = [];
+
+// Hook
 if (!config.hooks) config.hooks = {};
 if (!Array.isArray(config.hooks.PostToolUse)) config.hooks.PostToolUse = [];
 const hasHook = config.hooks.PostToolUse.some(entry =>
@@ -127,48 +141,42 @@ const hasHook = config.hooks.PostToolUse.some(entry =>
 if (!hasHook) {
   config.hooks.PostToolUse.push({
     matcher: 'Bash',
-    hooks: [{
-      type: 'command',
-      command: hookCommand,
-      async: true,
-      timeout: 3
-    }]
+    hooks: [{ type: 'command', command: hookCommand, async: true, timeout: 3 }]
   });
-  fs.writeFileSync(path, JSON.stringify(config, null, 2));
-  process.stdout.write('updated');
+  changed = true;
+  result.push('hook:updated');
 } else {
-  process.stdout.write('noop');
+  result.push('hook:noop');
 }
-EOJS
-)
-  if [ "$hook_status" = "updated" ]; then
-    echo -e "  ${GREEN}✓${NC} PostToolUse hook configured"
-  else
-    echo -e "  ${GREEN}✓${NC} PostToolUse hook already configured"
-  fi
 
-  local status_status
-  status_status=$(CLAUDE_SETTINGS="$settings_file" STATUSLINE_COMMAND="$statusline_command" node <<'EOJS'
-const fs = require('fs');
-const path = process.env.CLAUDE_SETTINGS;
-const command = process.env.STATUSLINE_COMMAND;
-let config = {};
-try { config = JSON.parse(fs.readFileSync(path, 'utf-8')); } catch {}
-const desired = { type: 'command', command, padding: 1 };
-const needsUpdate = !config.statusLine || config.statusLine.type !== 'command' || config.statusLine.command !== command;
-if (needsUpdate) {
-  config.statusLine = desired;
-  fs.writeFileSync(path, JSON.stringify(config, null, 2));
-  process.stdout.write('updated');
+// Statusline
+const needsStatusline = !config.statusLine ||
+  config.statusLine.type !== 'command' ||
+  config.statusLine.command !== statuslineCommand;
+if (needsStatusline) {
+  config.statusLine = { type: 'command', command: statuslineCommand, padding: 1 };
+  changed = true;
+  result.push('statusline:updated');
 } else {
-  process.stdout.write('noop');
+  result.push('statusline:noop');
 }
+
+if (changed) {
+  fs.writeFileSync(settingsPath, JSON.stringify(config, null, 2));
+}
+process.stdout.write(result.join(','));
 EOJS
 )
-  if [ "$status_status" = "updated" ]; then
-    echo -e "  ${GREEN}✓${NC} Claude Code statusline configured"
+    case "$settings_result" in
+      *hook:updated*) echo -e "  ${GREEN}✓${NC} PostToolUse hook configured" ;;
+      *)              echo -e "  ${GREEN}✓${NC} PostToolUse hook already configured" ;;
+    esac
+    case "$settings_result" in
+      *statusline:updated*) echo -e "  ${GREEN}✓${NC} Claude Code statusline configured" ;;
+      *)                    echo -e "  ${GREEN}✓${NC} Claude Code statusline already configured" ;;
+    esac
   else
-    echo -e "  ${GREEN}✓${NC} Claude Code statusline already configured"
+    echo -e "  ${YELLOW}!${NC} node not found — cannot configure hooks or statusline"
   fi
 }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -527,7 +527,9 @@ async function main() {
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("Buddy MCP Server running on stdio");
+  if (process.env.BUDDY_DEBUG) {
+    console.error("Buddy MCP Server running on stdio");
+  }
 }
 
 // Only auto-start when run directly (not when imported for testing)


### PR DESCRIPTION
## Summary
- register Buddy with Claude Code using the claude CLI so MCP config lands in the right file
- configure the Claude statusline with the buddy wrapper command format the client expects
- suppress stderr startup noise unless BUDDY_DEBUG is set to keep MCP clients happy

Fixes #47

## Testing
- npm run build