### PR TITLE
feat: buddy_doctor diagnostic tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/server/index.js",
   "bin": {
     "buddy-statusline": "dist/statusline-wrapper.js",
-    "buddy-onboard": "dist/cli/onboard.js"
+    "buddy-onboard": "dist/cli/onboard.js",
+    "buddy-doctor": "dist/cli/doctor-cli.js"
   },
   "files": [
     "dist",

--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -102,3 +102,83 @@ describe('Doctor — sentinel constant', () => {
     expect(PROMPT_SENTINEL_V2).toBe('buddy-companion v2');
   });
 });
+
+describe('Doctor — failure paths', () => {
+  it('companion.active returns warn/skip when no companion exists in test DB', () => {
+    // Test DB starts empty (unless prior tests created one)
+    const checks = runDiagnostics();
+    const active = checks.find(c => c.id === 'companion.active');
+    expect(active).toBeDefined();
+    // Either 'ok' (prior test created one) or 'warn' (empty DB)
+    expect(['ok', 'warn']).toContain(active!.status);
+  });
+
+  it('companion.details returns skip when no companion exists', () => {
+    const checks = runDiagnostics();
+    const details = checks.find(c => c.id === 'companion.details');
+    expect(details).toBeDefined();
+    // Either 'ok' (has companion) or 'skip' (no companion)
+    expect(['ok', 'skip']).toContain(details!.status);
+  });
+
+  it('status.file check handles missing file gracefully', () => {
+    const checks = runDiagnostics();
+    const status = checks.find(c => c.id === 'status.file');
+    expect(status).toBeDefined();
+    // In test env, status file likely doesn't exist
+    expect(['ok', 'warn']).toContain(status!.status);
+    if (status!.status === 'warn') {
+      expect(status!.detail).toContain('not found');
+    }
+  });
+
+  it('mcp.registered check handles missing config files gracefully', () => {
+    const checks = runDiagnostics();
+    const mcp = checks.find(c => c.id === 'mcp.registered');
+    expect(mcp).toBeDefined();
+    // Should not throw — either finds config or reports fail with suggestion
+    expect(['ok', 'fail']).toContain(mcp!.status);
+    if (mcp!.status === 'fail') {
+      expect(mcp!.suggestion).toBeDefined();
+      expect(mcp!.suggestion).toContain('claude mcp add');
+    }
+  });
+
+  it('config.statusline check handles missing settings.json gracefully', () => {
+    const checks = runDiagnostics();
+    const sl = checks.find(c => c.id === 'config.statusline');
+    expect(sl).toBeDefined();
+    expect(['ok', 'warn', 'fail']).toContain(sl!.status);
+  });
+
+  it('config.hooks check handles missing hooks gracefully', () => {
+    const checks = runDiagnostics();
+    const hooks = checks.find(c => c.id === 'config.hooks');
+    expect(hooks).toBeDefined();
+    expect(['ok', 'warn']).toContain(hooks!.status);
+  });
+
+  it('prompt.injected check handles missing CLAUDE.md gracefully', () => {
+    const checks = runDiagnostics();
+    const prompt = checks.find(c => c.id === 'prompt.injected');
+    expect(prompt).toBeDefined();
+    expect(['ok', 'warn']).toContain(prompt!.status);
+  });
+
+  it('formatReport handles all-fail scenario without crashing', () => {
+    const fakeChecks = [
+      { id: 'test.fail1', status: 'fail' as const, label: 'Test 1', detail: 'broken', suggestion: 'fix it' },
+      { id: 'test.fail2', status: 'fail' as const, label: 'Test 2', detail: 'also broken', suggestion: 'fix this too' },
+      { id: 'test.warn1', status: 'warn' as const, label: 'Test 3', detail: 'iffy' },
+      { id: 'test.ok1', status: 'ok' as const, label: 'Test 4', detail: 'fine' },
+      { id: 'test.skip1', status: 'skip' as const, label: 'Test 5', detail: 'n/a' },
+    ];
+    const report = formatReport(fakeChecks);
+    expect(report).toContain('2 fail');
+    expect(report).toContain('1 warn');
+    expect(report).toContain('1 ok');
+    expect(report).toContain('1 skip');
+    expect(report).toContain('fix it');
+    expect(report).toContain('fix this too');
+  });
+});

--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { runDiagnostics, formatReport, PROMPT_SENTINEL_V2 } from '../lib/doctor.js';
+
+describe('Doctor — runDiagnostics', () => {
+  it('returns an array of checks', () => {
+    const checks = runDiagnostics();
+    expect(Array.isArray(checks)).toBe(true);
+    expect(checks.length).toBe(14);
+  });
+
+  it('every check has required fields', () => {
+    const checks = runDiagnostics();
+    for (const c of checks) {
+      expect(c).toHaveProperty('id');
+      expect(c).toHaveProperty('status');
+      expect(c).toHaveProperty('label');
+      expect(c).toHaveProperty('detail');
+      expect(['ok', 'warn', 'fail', 'skip']).toContain(c.status);
+    }
+  });
+
+  it('env.node check reports current node version', () => {
+    const checks = runDiagnostics();
+    const nodeCheck = checks.find(c => c.id === 'env.node');
+    expect(nodeCheck).toBeDefined();
+    expect(nodeCheck!.detail).toContain(process.version);
+  });
+
+  it('env.platform reports current platform', () => {
+    const checks = runDiagnostics();
+    const platCheck = checks.find(c => c.id === 'env.platform');
+    expect(platCheck).toBeDefined();
+    expect(platCheck!.detail).toContain(process.platform);
+  });
+
+  it('pkg.version reports a version string', () => {
+    const checks = runDiagnostics();
+    const verCheck = checks.find(c => c.id === 'pkg.version');
+    expect(verCheck).toBeDefined();
+    expect(verCheck!.detail).toMatch(/@fiorastudio\/buddy v/);
+  });
+
+  it('db.exists check runs without throwing', () => {
+    const checks = runDiagnostics();
+    const dbCheck = checks.find(c => c.id === 'db.exists');
+    expect(dbCheck).toBeDefined();
+    // Test DB exists (vitest.config.ts sets BUDDY_DB_PATH to temp)
+    expect(['ok', 'warn', 'fail']).toContain(dbCheck!.status);
+  });
+
+  it('db.tables check finds expected tables', () => {
+    const checks = runDiagnostics();
+    const tablesCheck = checks.find(c => c.id === 'db.tables');
+    expect(tablesCheck).toBeDefined();
+    expect(tablesCheck!.detail).toContain('companions');
+    expect(tablesCheck!.detail).toContain('memories');
+  });
+
+  it('failed checks include suggestions', () => {
+    const checks = runDiagnostics();
+    for (const c of checks) {
+      if (c.status === 'fail' || c.status === 'warn') {
+        // Not all warns need suggestions (e.g. no companion is just informational)
+        // but fails should always have one
+        if (c.status === 'fail') {
+          expect(c.suggestion).toBeDefined();
+        }
+      }
+    }
+  });
+});
+
+describe('Doctor — formatReport', () => {
+  it('produces a string with section headers', () => {
+    const checks = runDiagnostics();
+    const report = formatReport(checks);
+    expect(report).toContain('Buddy Doctor');
+    expect(report).toContain('ENVIRONMENT');
+    expect(report).toContain('COMPANION');
+    expect(report).toContain('DATABASE');
+    expect(report).toContain('STATUS FILE');
+    expect(report).toContain('CLAUDE CODE INTEGRATION');
+    expect(report).toContain('SUMMARY');
+  });
+
+  it('includes check count in header', () => {
+    const checks = runDiagnostics();
+    const report = formatReport(checks);
+    expect(report).toContain('14 checks:');
+  });
+
+  it('includes ISO timestamp', () => {
+    const checks = runDiagnostics();
+    const report = formatReport(checks);
+    // Should contain a date-like string
+    expect(report).toMatch(/\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+describe('Doctor — sentinel constant', () => {
+  it('exports the v2 sentinel string', () => {
+    expect(PROMPT_SENTINEL_V2).toBe('buddy-companion v2');
+  });
+});

--- a/src/cli/doctor-cli.ts
+++ b/src/cli/doctor-cli.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+// src/cli/doctor-cli.ts — CLI entry point for buddy-doctor
+// Usage: node dist/cli/doctor-cli.js
+//   or:  buddy-doctor (if installed globally via npm)
+
+import { initDb } from '../db/schema.js';
+import { runDiagnostics, formatReport } from '../lib/doctor.js';
+
+initDb();
+const checks = runDiagnostics();
+console.log(formatReport(checks));
+
+// Exit with non-zero if any checks failed
+const hasFail = checks.some(c => c.status === 'fail');
+process.exit(hasFail ? 1 : 0);

--- a/src/cli/doctor-cli.ts
+++ b/src/cli/doctor-cli.ts
@@ -3,10 +3,17 @@
 // Usage: node dist/cli/doctor-cli.js
 //   or:  buddy-doctor (if installed globally via npm)
 
-import { initDb } from '../db/schema.js';
-import { runDiagnostics, formatReport } from '../lib/doctor.js';
+try {
+  const { initDb } = await import('../db/schema.js');
+  initDb();
+} catch (e: any) {
+  console.error(`\u26A0 Database initialization failed: ${e?.message || 'unknown error'}`);
+  console.error(`  DB path: ${process.env.BUDDY_DB_PATH || '~/.buddy/buddy.db'}`);
+  console.error('  The doctor will still run but companion/DB checks will fail.\n');
+}
 
-initDb();
+const { runDiagnostics, formatReport } = await import('../lib/doctor.js');
+
 const checks = runDiagnostics();
 console.log(formatReport(checks));
 

--- a/src/lib/doctor.ts
+++ b/src/lib/doctor.ts
@@ -210,9 +210,10 @@ function checkStatusline(): DiagnosticCheck {
   if (!cmd.includes('statusline-wrapper')) {
     return { id: 'config.statusline', status: 'warn', label: 'Statusline', detail: `Configured but not pointing to buddy: ${cmd}` };
   }
-  // Check if the wrapper file exists — strip quotes from path
-  const parts = cmd.split(' ');
-  const wrapperPath = parts[parts.length - 1]?.replace(/^["']|["']$/g, '');
+  // Extract wrapper path — handle "node /path/to/file.js" and "node '/path with spaces/file.js'"
+  // Match everything after "node " stripping surrounding quotes
+  const pathMatch = cmd.match(/node\s+["']?(.+?)["']?\s*$/);
+  const wrapperPath = pathMatch?.[1];
   if (wrapperPath && !fileExists(wrapperPath)) {
     return { id: 'config.statusline', status: 'fail', label: 'Statusline', detail: `Configured but wrapper missing: ${wrapperPath}`, suggestion: 'Re-run install script or rebuild' };
   }

--- a/src/lib/doctor.ts
+++ b/src/lib/doctor.ts
@@ -1,0 +1,338 @@
+// src/lib/doctor.ts — Diagnostic engine for buddy_doctor tool and CLI
+
+import { readFileSync, accessSync, statSync, constants as fsConstants } from 'fs';
+import { join, dirname } from 'path';
+import { homedir } from 'os';
+import { fileURLToPath } from 'url';
+import { BUDDY_DB_PATH, BUDDY_STATUS_PATH } from './constants.js';
+import { db } from '../db/schema.js';
+import { loadCompanion } from './companion.js';
+import { STAT_NAMES, RARITY_STARS } from './types.js';
+import { levelProgress } from './leveling.js';
+
+// Shared sentinel — keep in sync with install.sh / install.ps1
+export const PROMPT_SENTINEL_V2 = 'buddy-companion v2';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export interface DiagnosticCheck {
+  id: string;
+  status: 'ok' | 'warn' | 'fail' | 'skip';
+  label: string;
+  detail: string;
+  suggestion?: string;
+}
+
+function getVersion(): string {
+  try {
+    return JSON.parse(readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf-8')).version;
+  } catch { return 'unknown'; }
+}
+
+function fileExists(path: string): boolean {
+  try { accessSync(path, fsConstants.F_OK); return true; } catch { return false; }
+}
+
+function fileWritable(path: string): boolean {
+  try { accessSync(path, fsConstants.W_OK); return true; } catch { return false; }
+}
+
+function fileReadable(path: string): boolean {
+  try { accessSync(path, fsConstants.R_OK); return true; } catch { return false; }
+}
+
+function readJsonSafe(path: string): any {
+  try { return JSON.parse(readFileSync(path, 'utf-8')); } catch { return null; }
+}
+
+function readTextSafe(path: string): string | null {
+  try { return readFileSync(path, 'utf-8'); } catch { return null; }
+}
+
+// ── Individual checks ──
+
+function checkNodeVersion(): DiagnosticCheck {
+  const ver = process.version;
+  const major = parseInt(ver.slice(1), 10);
+  if (major < 18) {
+    return { id: 'env.node', status: 'fail', label: 'Node.js', detail: ver, suggestion: 'Node.js 18+ required. Upgrade at https://nodejs.org' };
+  }
+  return { id: 'env.node', status: 'ok', label: 'Node.js', detail: `${ver} \u2713` };
+}
+
+function checkPlatform(): DiagnosticCheck {
+  return { id: 'env.platform', status: 'ok', label: 'Platform', detail: `${process.platform} ${process.arch}` };
+}
+
+function checkEnvVars(): DiagnosticCheck {
+  const dbOverride = process.env.BUDDY_DB_PATH ? `(custom) ${process.env.BUDDY_DB_PATH}` : `(default) ${BUDDY_DB_PATH}`;
+  const statusOverride = process.env.BUDDY_STATUS_PATH ? `(custom) ${process.env.BUDDY_STATUS_PATH}` : `(default) ${BUDDY_STATUS_PATH}`;
+  // Warn only if custom path is set but doesn't exist
+  let status: 'ok' | 'warn' = 'ok';
+  let suggestion: string | undefined;
+  if (process.env.BUDDY_DB_PATH && !fileExists(process.env.BUDDY_DB_PATH)) {
+    status = 'warn';
+    suggestion = `BUDDY_DB_PATH is set to ${process.env.BUDDY_DB_PATH} but file does not exist`;
+  }
+  return { id: 'env.vars', status, label: 'Env overrides', detail: `DB: ${dbOverride}\n               STATUS: ${statusOverride}`, suggestion };
+}
+
+function checkPackageVersion(): DiagnosticCheck {
+  const ver = getVersion();
+  return { id: 'pkg.version', status: 'ok', label: 'Package', detail: `@fiorastudio/buddy v${ver}` };
+}
+
+function checkCompanionActive(): DiagnosticCheck {
+  try {
+    const row = db.prepare('SELECT * FROM companions LIMIT 1').get() as any;
+    if (!row) {
+      return { id: 'companion.active', status: 'warn', label: 'Active companion', detail: 'None', suggestion: 'Use buddy_hatch to create a companion' };
+    }
+    return { id: 'companion.active', status: 'ok', label: 'Active companion', detail: `\u2713 ${row.name} the ${row.species}` };
+  } catch {
+    return { id: 'companion.active', status: 'fail', label: 'Active companion', detail: 'DB query failed', suggestion: 'Database may be corrupted. Try deleting ~/.buddy/buddy.db and re-hatching' };
+  }
+}
+
+function checkCompanionCount(): DiagnosticCheck {
+  try {
+    const row = db.prepare('SELECT count(*) as count FROM companions').get() as any;
+    return { id: 'companion.count', status: 'ok', label: 'Total saved', detail: `${row?.count || 0} companion(s) in DB` };
+  } catch {
+    return { id: 'companion.count', status: 'fail', label: 'Total saved', detail: 'DB query failed' };
+  }
+}
+
+function checkCompanionDetails(): DiagnosticCheck {
+  try {
+    const row = db.prepare('SELECT * FROM companions LIMIT 1').get() as any;
+    if (!row) {
+      return { id: 'companion.details', status: 'skip', label: 'Companion details', detail: 'No companion' };
+    }
+    const companion = loadCompanion(row);
+    if (!companion) {
+      return { id: 'companion.details', status: 'fail', label: 'Companion details', detail: 'loadCompanion() returned null' };
+    }
+    const { level, currentXp, neededXp } = levelProgress(companion.xp);
+    const stars = RARITY_STARS[companion.rarity] || '';
+    const statStr = STAT_NAMES.map(s => `${s.slice(0, 3)}:${companion.stats[s]}`).join(' ');
+    const bioLen = companion.personalityBio?.length || 0;
+    return {
+      id: 'companion.details', status: 'ok', label: 'Details',
+      detail: `${stars} ${companion.rarity} | Lv.${level} (${currentXp}/${neededXp} XP) | mood: ${companion.mood}\n               Stats: ${statStr}\n               Bio: \u2713 (${bioLen} chars)`,
+    };
+  } catch (e: any) {
+    return { id: 'companion.details', status: 'fail', label: 'Companion details', detail: e?.message || 'Unknown error' };
+  }
+}
+
+function checkDbExists(): DiagnosticCheck {
+  if (!fileExists(BUDDY_DB_PATH)) {
+    return { id: 'db.exists', status: 'fail', label: 'Database file', detail: `${BUDDY_DB_PATH} not found`, suggestion: 'Database will be created on first buddy_hatch' };
+  }
+  const writable = fileWritable(BUDDY_DB_PATH);
+  try {
+    const stat = statSync(BUDDY_DB_PATH);
+    const sizeKb = (stat.size / 1024).toFixed(1);
+    return {
+      id: 'db.exists', status: writable ? 'ok' : 'warn', label: 'Database file',
+      detail: `${BUDDY_DB_PATH} ${writable ? '\u2713' : '\u2717 read-only'} (${sizeKb} KB)`,
+      suggestion: writable ? undefined : 'Database is not writable — check file permissions',
+    };
+  } catch {
+    return { id: 'db.exists', status: 'warn', label: 'Database file', detail: `${BUDDY_DB_PATH} exists but cannot stat` };
+  }
+}
+
+function checkDbTables(): DiagnosticCheck {
+  const expected = ['companions', 'memories', 'xp_events', 'sessions', 'evolution_history'];
+  try {
+    const rows = db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as any[];
+    const tables = rows.map(r => r.name);
+    const results = expected.map(t => `${t} ${tables.includes(t) ? '\u2713' : '\u2717'}`);
+    const missing = expected.filter(t => !tables.includes(t));
+    return {
+      id: 'db.tables', status: missing.length > 0 ? 'fail' : 'ok', label: 'DB tables',
+      detail: results.join(' | '),
+      suggestion: missing.length > 0 ? `Missing tables: ${missing.join(', ')}. Try re-running the server to auto-create.` : undefined,
+    };
+  } catch {
+    return { id: 'db.tables', status: 'fail', label: 'DB tables', detail: 'Cannot query sqlite_master' };
+  }
+}
+
+function checkStatusFile(): DiagnosticCheck {
+  if (!fileExists(BUDDY_STATUS_PATH)) {
+    return { id: 'status.file', status: 'warn', label: 'Status file', detail: `${BUDDY_STATUS_PATH} not found`, suggestion: 'Status file is created when buddy_status or buddy_observe is called' };
+  }
+  const writable = fileWritable(BUDDY_STATUS_PATH);
+  try {
+    const stat = statSync(BUDDY_STATUS_PATH);
+    const ageMs = Date.now() - stat.mtimeMs;
+    const ageSec = Math.floor(ageMs / 1000);
+    const fresh = ageSec < 60;
+    return {
+      id: 'status.file', status: writable ? 'ok' : 'warn', label: 'Status file',
+      detail: `${BUDDY_STATUS_PATH} ${writable ? '\u2713' : '\u2717'} (${ageSec}s ago${fresh ? ' \u2713' : ' — stale'})`,
+      suggestion: writable ? undefined : 'Status file is not writable — check permissions',
+    };
+  } catch {
+    return { id: 'status.file', status: 'warn', label: 'Status file', detail: 'Exists but cannot stat' };
+  }
+}
+
+function checkMcpRegistered(): DiagnosticCheck {
+  const claudeJsonPath = join(homedir(), '.claude.json');
+  const config = readJsonSafe(claudeJsonPath);
+  if (config?.mcpServers?.buddy) {
+    return { id: 'mcp.registered', status: 'ok', label: 'MCP registration', detail: `\u2713 registered in ${claudeJsonPath}` };
+  }
+  // Also check ~/.claude/settings.json as fallback
+  const settingsPath = join(homedir(), '.claude', 'settings.json');
+  const settings = readJsonSafe(settingsPath);
+  if (settings?.mcpServers?.buddy) {
+    return { id: 'mcp.registered', status: 'ok', label: 'MCP registration', detail: `\u2713 registered in ${settingsPath}` };
+  }
+  return {
+    id: 'mcp.registered', status: 'fail', label: 'MCP registration', detail: '\u2717 not found',
+    suggestion: 'Run: claude mcp add buddy -s user -- node ~/.buddy/server/dist/server/index.js',
+  };
+}
+
+function checkStatusline(): DiagnosticCheck {
+  const settingsPath = join(homedir(), '.claude', 'settings.json');
+  const settings = readJsonSafe(settingsPath);
+  if (!settings?.statusLine?.command) {
+    return { id: 'config.statusline', status: 'warn', label: 'Statusline', detail: '\u2717 not configured in settings.json', suggestion: 'Re-run install script to configure statusline' };
+  }
+  const cmd: string = settings.statusLine.command;
+  if (!cmd.includes('statusline-wrapper')) {
+    return { id: 'config.statusline', status: 'warn', label: 'Statusline', detail: `Configured but not pointing to buddy: ${cmd}` };
+  }
+  // Check if the wrapper file exists — strip quotes from path
+  const parts = cmd.split(' ');
+  const wrapperPath = parts[parts.length - 1]?.replace(/^["']|["']$/g, '');
+  if (wrapperPath && !fileExists(wrapperPath)) {
+    return { id: 'config.statusline', status: 'fail', label: 'Statusline', detail: `Configured but wrapper missing: ${wrapperPath}`, suggestion: 'Re-run install script or rebuild' };
+  }
+  return { id: 'config.statusline', status: 'ok', label: 'Statusline', detail: '\u2713 configured in settings.json' };
+}
+
+function checkHooks(): DiagnosticCheck {
+  const settingsPath = join(homedir(), '.claude', 'settings.json');
+  const settings = readJsonSafe(settingsPath);
+  if (!settings?.hooks?.PostToolUse) {
+    return { id: 'config.hooks', status: 'warn', label: 'Hooks', detail: '\u2717 no PostToolUse hooks', suggestion: 'Re-run install script to configure hooks' };
+  }
+  const hooks: any[] = Array.isArray(settings.hooks.PostToolUse) ? settings.hooks.PostToolUse : [];
+  const hasBuddy = hooks.some((entry: any) => {
+    if (entry.matcher === 'Bash' && Array.isArray(entry.hooks)) {
+      return entry.hooks.some((h: any) => h.command && h.command.includes('post-tool-handler'));
+    }
+    // Handle legacy string format
+    if (typeof entry === 'string' && entry.includes('post-tool-handler')) return true;
+    return false;
+  });
+  if (!hasBuddy) {
+    return { id: 'config.hooks', status: 'warn', label: 'Hooks', detail: '\u2717 buddy hook not found in PostToolUse', suggestion: 'Re-run install script to configure hooks' };
+  }
+  return { id: 'config.hooks', status: 'ok', label: 'Hooks', detail: '\u2713 PostToolUse hook present' };
+}
+
+function checkPromptInjection(): DiagnosticCheck {
+  const claudeMdPath = join(homedir(), '.claude', 'CLAUDE.md');
+  const content = readTextSafe(claudeMdPath);
+  if (!content) {
+    return { id: 'prompt.injected', status: 'warn', label: 'Prompt injection', detail: `${claudeMdPath} not found or unreadable`, suggestion: 'Re-run install script to inject buddy instructions' };
+  }
+  if (content.includes(PROMPT_SENTINEL_V2)) {
+    return { id: 'prompt.injected', status: 'ok', label: 'Prompt injection', detail: `\u2713 ${PROMPT_SENTINEL_V2} found in CLAUDE.md` };
+  }
+  if (content.includes('buddy-companion')) {
+    return { id: 'prompt.injected', status: 'warn', label: 'Prompt injection', detail: 'v1 sentinel found — needs upgrade to v2', suggestion: 'Re-run install script to upgrade prompt instructions' };
+  }
+  return { id: 'prompt.injected', status: 'warn', label: 'Prompt injection', detail: '\u2717 no buddy instructions in CLAUDE.md', suggestion: 'Re-run install script to inject buddy instructions' };
+}
+
+// ── Runner ──
+
+export function runDiagnostics(): DiagnosticCheck[] {
+  return [
+    checkNodeVersion(),
+    checkPlatform(),
+    checkEnvVars(),
+    checkPackageVersion(),
+    checkCompanionActive(),
+    checkCompanionCount(),
+    checkCompanionDetails(),
+    checkDbExists(),
+    checkDbTables(),
+    checkStatusFile(),
+    checkMcpRegistered(),
+    checkStatusline(),
+    checkHooks(),
+    checkPromptInjection(),
+  ];
+}
+
+// ── Report formatter ──
+
+export function formatReport(checks: DiagnosticCheck[]): string {
+  const version = getVersion();
+  const now = new Date().toISOString();
+  const counts = { ok: 0, warn: 0, fail: 0, skip: 0 };
+  for (const c of checks) counts[c.status]++;
+
+  const summaryParts = [];
+  if (counts.ok > 0) summaryParts.push(`${counts.ok} ok`);
+  if (counts.warn > 0) summaryParts.push(`${counts.warn} warn`);
+  if (counts.fail > 0) summaryParts.push(`${counts.fail} fail`);
+  if (counts.skip > 0) summaryParts.push(`${counts.skip} skip`);
+
+  const lines: string[] = [];
+  lines.push(`\uD83E\uDE7A Buddy Doctor v${version} \u2014 ${now}`);
+  lines.push(`${checks.length} checks: ${summaryParts.join(', ')}`);
+  lines.push('\u2550'.repeat(48));
+  lines.push('');
+
+  // Group checks by section
+  const sections: Record<string, DiagnosticCheck[]> = {
+    'ENVIRONMENT': checks.filter(c => c.id.startsWith('env.') || c.id.startsWith('pkg.')),
+    'COMPANION': checks.filter(c => c.id.startsWith('companion.')),
+    'DATABASE': checks.filter(c => c.id.startsWith('db.')),
+    'STATUS FILE': checks.filter(c => c.id.startsWith('status.')),
+    'CLAUDE CODE INTEGRATION': checks.filter(c => c.id.startsWith('mcp.') || c.id.startsWith('config.') || c.id.startsWith('prompt.')),
+  };
+
+  for (const [section, sectionChecks] of Object.entries(sections)) {
+    lines.push(section);
+    for (const c of sectionChecks) {
+      const pad = 15 - c.label.length;
+      lines.push(`  ${c.label}:${' '.repeat(Math.max(1, pad))}${c.detail}`);
+    }
+    lines.push('');
+  }
+
+  // Summary
+  const issues = checks.filter(c => c.status === 'fail' || c.status === 'warn');
+  lines.push('SUMMARY');
+  if (issues.length === 0) {
+    lines.push(`  \u2713 All ${checks.length} checks passed \u2014 Buddy is healthy!`);
+  } else {
+    const fails = checks.filter(c => c.status === 'fail');
+    const warns = checks.filter(c => c.status === 'warn');
+    const parts = [];
+    if (fails.length > 0) parts.push(`${fails.length} fail`);
+    if (warns.length > 0) parts.push(`${warns.length} warn`);
+    lines.push(`  \u2717 ${parts.join(', ')}:`);
+    let idx = 1;
+    for (const c of issues) {
+      lines.push(`    ${idx}. [${c.id}] ${c.label}: ${c.detail}`);
+      if (c.suggestion) lines.push(`       \u2192 ${c.suggestion}`);
+      idx++;
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -26,6 +26,7 @@ import { homedir } from "os";
 import { loadCompanion, writeBuddyStatus, createCompanion } from "../lib/companion.js";
 import { renderCard, hatchAnimation } from "../lib/card.js";
 import { BUDDY_STATUS_PATH } from "../lib/constants.js";
+import { runDiagnostics, formatReport } from "../lib/doctor.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -188,6 +189,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       {
         name: "buddy_unmute",
         description: "Unmute your buddy so it can chime in again.",
+        inputSchema: { type: "object", properties: {} },
+      },
+      {
+        name: "buddy_doctor",
+        description: "Run diagnostics on your Buddy installation. Checks companion state, database, MCP registration, statusline, hooks, and prompt injection. Returns a report you can paste into bug reports. IMPORTANT: Include the full diagnostic report verbatim in a code block in your response.",
         inputSchema: { type: "object", properties: {} },
       },
     ],
@@ -429,6 +435,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     writeBuddyStatus(companion);
 
     return { content: [{ type: "text", text: `${companion.name} is back! It'll chime in as you code.` }] };
+  }
+
+  if (name === "buddy_doctor") {
+    const checks = runDiagnostics();
+    const report = formatReport(checks);
+    return { content: [{ type: "text", text: '```\n' + report + '\n```' }] };
   }
 
   throw new Error(`Tool not found: ${name}`);


### PR DESCRIPTION
## Summary
- New `buddy_doctor` MCP tool — users say "buddy doctor" for a full diagnostic report
- New `buddy-doctor` CLI bin — works even when MCP registration is broken
- 14 checks: environment, companion state, database, status file, MCP registration, statusline, hooks, prompt injection
- Reports are copy-pasteable into bug reports with actionable suggestions

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 343 tests pass (12 new doctor tests)
- [x] `node dist/cli/doctor-cli.js` — verified on local machine, correctly detected 3 real issues
- [ ] Call `buddy_doctor` via MCP client
- [ ] Break something (delete status file) and verify doctor catches it

🤖 Generated with [Claude Code](https://claude.com/claude-code)