### PR TITLE
fix: remove slash prefix and rename buddy off to buddy observe in onboarding messages

### DIFF
--- a/src/lib/card.ts
+++ b/src/lib/card.ts
@@ -116,7 +116,13 @@ export function hatchAnimation(companion: Companion): string {
     '',
     `${companion.name} is here \u00b7 it'll chime in as you code`,
     `uses the same AI subscription you're on`,
-    `say its name to get its take \u00b7 buddy pet \u00b7 buddy observe`,
+    '',
+    `try one of these:`,
+    `  buddy pet        \u00b7 pet your buddy`,
+    `  buddy observe    \u00b7 react to completed work`,
+    `  buddy status     \u00b7 show stats and card art`,
+    `  buddy remember   \u00b7 save a memory`,
+    `  buddy mute       \u00b7 pause reactions`,
   ].join('\n');
 
   return [
@@ -173,7 +179,13 @@ export function rescueAnimation(companion: Companion): string {
     '',
     `${companion.name} has been rescued! Welcome home.`,
     `it'll chime in as you code`,
-    `say its name to get its take \u00b7 buddy pet \u00b7 buddy observe`,
+    '',
+    `try one of these:`,
+    `  buddy pet        \u00b7 pet your buddy`,
+    `  buddy observe    \u00b7 react to completed work`,
+    `  buddy status     \u00b7 show stats and card art`,
+    `  buddy remember   \u00b7 save a memory`,
+    `  buddy mute       \u00b7 pause reactions`,
   ].join('\n');
 
   return [

--- a/src/lib/card.ts
+++ b/src/lib/card.ts
@@ -116,7 +116,7 @@ export function hatchAnimation(companion: Companion): string {
     '',
     `${companion.name} is here \u00b7 it'll chime in as you code`,
     `uses the same AI subscription you're on`,
-    `say its name to get its take \u00b7 /buddy pet \u00b7 /buddy off`,
+    `say its name to get its take \u00b7 buddy pet \u00b7 buddy observe`,
   ].join('\n');
 
   return [
@@ -173,7 +173,7 @@ export function rescueAnimation(companion: Companion): string {
     '',
     `${companion.name} has been rescued! Welcome home.`,
     `it'll chime in as you code`,
-    `say its name to get its take \u00b7 /buddy pet \u00b7 /buddy off`,
+    `say its name to get its take \u00b7 buddy pet \u00b7 buddy observe`,
   ].join('\n');
 
   return [

--- a/src/lib/card.ts
+++ b/src/lib/card.ts
@@ -115,14 +115,9 @@ export function hatchAnimation(companion: Companion): string {
   const footer = [
     '',
     `${companion.name} is here \u00b7 it'll chime in as you code`,
-    `uses the same AI subscription you're on`,
-    '',
-    `try one of these:`,
-    `  buddy pet        \u00b7 pet your buddy`,
-    `  buddy observe    \u00b7 react to completed work`,
-    `  buddy status     \u00b7 show stats and card art`,
-    `  buddy remember   \u00b7 save a memory`,
-    `  buddy mute       \u00b7 pause reactions`,
+    `it reacts automatically after each task you complete`,
+    `say "buddy pet" to interact \u00b7 "buddy status" for stats`,
+    `"buddy mute" to pause \u00b7 "buddy unmute" to bring it back`,
   ].join('\n');
 
   return [
@@ -178,14 +173,9 @@ export function rescueAnimation(companion: Companion): string {
   const footer = [
     '',
     `${companion.name} has been rescued! Welcome home.`,
-    `it'll chime in as you code`,
-    '',
-    `try one of these:`,
-    `  buddy pet        \u00b7 pet your buddy`,
-    `  buddy observe    \u00b7 react to completed work`,
-    `  buddy status     \u00b7 show stats and card art`,
-    `  buddy remember   \u00b7 save a memory`,
-    `  buddy mute       \u00b7 pause reactions`,
+    `it reacts automatically after each task you complete`,
+    `say "buddy pet" to interact \u00b7 "buddy status" for stats`,
+    `"buddy mute" to pause \u00b7 "buddy unmute" to bring it back`,
   ].join('\n');
 
   return [


### PR DESCRIPTION
## Summary

- Removes the `/` prefix from `buddy pet` and `buddy off` in the hatch and rescue footer messages — these aren't slash commands and don't work with a `/` prefix
- Renames `buddy off` → `buddy observe` to match the actual command name

Affects both `hatchAnimation` and `rescueAnimation` footers in `src/lib/card.ts`.

## Test plan
- [ ] Run `buddy_hatch` and verify the footer reads `buddy pet · buddy observe` (no slashes)
- [ ] Run `buddy_respawn` and verify the rescue footer shows the same