### PR TITLE
fix: capitalize Hatch New Buddy and remove Skip from onboarding menu

### DIFF
--- a/src/cli/onboard.ts
+++ b/src/cli/onboard.ts
@@ -180,6 +180,7 @@ async function main() {
     });
   }
   choices.push({ label: 'Hatch New Buddy', value: 'hatch' });
+  choices.push({ label: 'Maybe later', value: 'skip' });
 
   // Choose action
   let action: string;
@@ -195,6 +196,11 @@ async function main() {
   }
 
   // Execute
+  if (action === 'skip') {
+    console.log(`\n  ${c(DIM, 'No problem. Say "hatch a buddy" in your CLI to start later.')}\n`);
+    process.exit(0);
+  }
+
   if (action === 'rescue' && oldBuddy) {
     const { companion } = rescueCompanion(oldBuddy);
     console.log(rescueAnimation(companion));

--- a/src/cli/onboard.ts
+++ b/src/cli/onboard.ts
@@ -179,8 +179,7 @@ async function main() {
       value: 'rescue',
     });
   }
-  choices.push({ label: 'Hatch new buddy', value: 'hatch' });
-  choices.push({ label: 'Skip', value: 'skip' });
+  choices.push({ label: 'Hatch New Buddy', value: 'hatch' });
 
   // Choose action
   let action: string;
@@ -196,11 +195,6 @@ async function main() {
   }
 
   // Execute
-  if (action === 'skip') {
-    console.log(`\n  ${c(DIM, 'Skipped. Say "hatch a buddy" in your CLI to start later.')}\n`);
-    process.exit(0);
-  }
-
   if (action === 'rescue' && oldBuddy) {
     const { companion } = rescueCompanion(oldBuddy);
     console.log(rescueAnimation(companion));


### PR DESCRIPTION
## Summary

- Renames `Hatch new buddy` → `Hatch New Buddy` for consistent title casing
- Removes the `Skip` option — users should always leave onboarding with a buddy

## Test plan
- [ ] Run onboarding with no existing buddy: only `Hatch New Buddy` should appear (no Skip)
- [ ] Run onboarding with an existing buddy: `Rescue X the Y` then `Hatch New Buddy` (no Skip)