### PR TITLE
Fix Issue #60: Rescue mode species derivation

### DIFF
--- a/src/__tests__/companion.test.ts
+++ b/src/__tests__/companion.test.ts
@@ -144,6 +144,115 @@ describe('rescueCompanion', () => {
     expect(row.name).toBe('SavedBuddy');
     expect(row.species).toBe('Owl');
   });
+
+  it('preserves imported personality when provided (issue #60 — Fernsquire)', () => {
+    const personality =
+      'A philosophically unflappable turtle who responds to your bugs with measured skepticism...';
+    const { companion } = rescueCompanion({
+      name: 'Fernsquire',
+      species: 'Shell Turtle',
+      personality,
+    });
+    expect(companion.personalityBio).toBe(personality);
+    const row = db.prepare('SELECT personality_bio FROM companions LIMIT 1').get() as any;
+    expect(row.personality_bio).toBe(personality);
+  });
+
+  it('generates a fresh bio when no personality is imported', () => {
+    const { companion } = rescueCompanion({ name: 'NoBio', species: 'Owl' });
+    expect(companion.personalityBio).toBeTruthy();
+    expect(companion.personalityBio.length).toBeGreaterThan(0);
+  });
+
+  it('preserves imported hatchedAt (issue #60 — original hatch date survives rescue)', () => {
+    const originalHatchedAt = 1775074927992; // from issue #60 sample
+    const { companion, id } = rescueCompanion({
+      name: 'Fernsquire',
+      species: 'Shell Turtle',
+      hatchedAt: originalHatchedAt,
+    });
+    expect(companion.hatchedAt).toBe(originalHatchedAt);
+    // Round-trips cleanly through loadCompanion via ISO 8601 serialization.
+    const row = db.prepare('SELECT * FROM companions WHERE id = ?').get(id) as any;
+    const reloaded = loadCompanion(row);
+    expect(reloaded!.hatchedAt).toBe(originalHatchedAt);
+  });
+
+  it('defaults hatchedAt to now when not imported', () => {
+    const before = Date.now();
+    const { companion } = rescueCompanion({ name: 'Fresh', species: 'Duck' });
+    const after = Date.now();
+    expect(companion.hatchedAt).toBeGreaterThanOrEqual(before);
+    expect(companion.hatchedAt).toBeLessThanOrEqual(after);
+  });
+
+  it('uses accountUuid as userId fallback when no explicit userId is provided', () => {
+    rescueCompanion({
+      name: 'UuidBuddy',
+      species: 'Ghost',
+      accountUuid: 'user-uuid-abc-123',
+    });
+    const row = db.prepare('SELECT user_id FROM companions LIMIT 1').get() as any;
+    expect(row.user_id).toBe('user-uuid-abc-123');
+  });
+
+  it('prefers explicit opts.userId over accountUuid', () => {
+    rescueCompanion(
+      { name: 'Override', species: 'Ghost', accountUuid: 'uuid-lose' },
+      { userId: 'override-win' }
+    );
+    const row = db.prepare('SELECT user_id FROM companions LIMIT 1').get() as any;
+    expect(row.user_id).toBe('override-win');
+  });
+
+  it('rescues a buddy with no species (rolls one from bones)', () => {
+    const { companion } = rescueCompanion({ name: 'Speciesless' });
+    expect(SPECIES_LIST).toContain(companion.species);
+  });
+
+  it('produces deterministic species across rescues for the same accountUuid', () => {
+    const { companion: c1 } = rescueCompanion({
+      name: 'Det1',
+      accountUuid: 'same-uuid',
+    });
+    db.prepare('DELETE FROM companions').run();
+    const { companion: c2 } = rescueCompanion({
+      name: 'Det1',
+      accountUuid: 'same-uuid',
+    });
+    expect(c1.species).toBe(c2.species);
+    expect(c1.rarity).toBe(c2.rarity);
+    expect(c1.stats).toEqual(c2.stats);
+  });
+
+  it('normalizes legacy short species names ("turtle" → "Shell Turtle")', () => {
+    // The legacy Claude Code config stored bare animal nouns. If a user has
+    // that in ~/.claude.json, the rescue path should write the canonical name
+    // to the DB rather than the short form.
+    const { companion } = rescueCompanion({
+      name: 'Fern',
+      species: 'turtle',
+      accountUuid: 'legacy-short-uuid',
+    });
+    expect(companion.species).toBe('Shell Turtle');
+    const row = db.prepare('SELECT species FROM companions LIMIT 1').get() as any;
+    expect(row.species).toBe('Shell Turtle');
+  });
+
+  it('infers species from personality when none is given (Fernsquire → Shell Turtle)', () => {
+    // End-to-end: this is exactly the shape Josh (issue #60) has in ~/.claude.json.
+    const { companion } = rescueCompanion({
+      name: 'Fernsquire',
+      personality:
+        'A philosophically unflappable turtle who responds to your bugs with measured skepticism and the occasional cutting remark about your variable names, as if waiting 80 years to hatch has given them an exceptionally low tolerance for sloppy thinking.',
+      hatchedAt: 1775074927992,
+      accountUuid: 'josh-account-uuid',
+    });
+    expect(companion.species).toBe('Shell Turtle');
+    expect(companion.name).toBe('Fernsquire');
+    expect(companion.hatchedAt).toBe(1775074927992);
+    expect(companion.personalityBio).toMatch(/turtle/i);
+  });
 });
 
 describe('loadCompanion', () => {

--- a/src/__tests__/oldBuddy.test.ts
+++ b/src/__tests__/oldBuddy.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseOldBuddy,
+  inferSpeciesFromPersonality,
+  deriveSpecies,
+  SPECIES_KEYWORDS,
+} from '../lib/oldBuddy.js';
+import { SPECIES_LIST } from '../lib/species.js';
+
+describe('parseOldBuddy', () => {
+  it('parses the Fernsquire shape from issue #60 (companion, personality, hatchedAt, no species)', () => {
+    const data = {
+      oauthAccount: { accountUuid: 'acc-123' },
+      companion: {
+        name: 'Fernsquire',
+        personality:
+          'A philosophically unflappable turtle who responds to your bugs with measured skepticism and the occasional cutting remark about your variable names, as if waiting 80 years to hatch has given them an exceptionally low tolerance for sloppy thinking.',
+        hatchedAt: 1775074927992,
+      },
+    };
+    const result = parseOldBuddy(data);
+    expect(result).toEqual({
+      name: 'Fernsquire',
+      species: undefined,
+      personality: data.companion.personality,
+      hatchedAt: 1775074927992,
+      accountUuid: 'acc-123',
+      userId: undefined,
+    });
+  });
+
+  it('accepts data.buddy as an alternative nested key', () => {
+    const data = {
+      buddy: { name: 'Nested', species: 'Owl' },
+      oauthAccount: { accountUuid: 'acc-x' },
+    };
+    const result = parseOldBuddy(data);
+    expect(result?.name).toBe('Nested');
+    expect(result?.species).toBe('Owl');
+    expect(result?.accountUuid).toBe('acc-x');
+  });
+
+  it('accepts data.buddyCompanion as an alternative nested key', () => {
+    const data = { buddyCompanion: { name: 'Third', species: 'Ghost' } };
+    const result = parseOldBuddy(data);
+    expect(result?.name).toBe('Third');
+    expect(result?.species).toBe('Ghost');
+  });
+
+  it('parses the flat shape: data.buddyName / data.buddySpecies', () => {
+    const data = {
+      buddyName: 'Flat',
+      buddySpecies: 'Rust Hound',
+      userId: 'flat-uid',
+    };
+    const result = parseOldBuddy(data);
+    expect(result?.name).toBe('Flat');
+    expect(result?.species).toBe('Rust Hound');
+    expect(result?.userId).toBe('flat-uid');
+  });
+
+  it('captures accountUuid on the flat shape too', () => {
+    const data = {
+      buddyName: 'FlatWithUuid',
+      oauthAccount: { accountUuid: 'flat-uuid' },
+    };
+    const result = parseOldBuddy(data);
+    expect(result?.accountUuid).toBe('flat-uuid');
+  });
+
+  it('returns null for null input', () => {
+    expect(parseOldBuddy(null)).toBeNull();
+  });
+
+  it('returns null for non-object input', () => {
+    expect(parseOldBuddy('string' as any)).toBeNull();
+    expect(parseOldBuddy(42 as any)).toBeNull();
+  });
+
+  it('returns null for empty object', () => {
+    expect(parseOldBuddy({})).toBeNull();
+  });
+
+  it('returns null when the nested buddy object exists but has no name', () => {
+    expect(parseOldBuddy({ companion: { species: 'Owl' } })).toBeNull();
+  });
+
+  it('prefers companion.userId over companion.user_id', () => {
+    const data = {
+      companion: { name: 'X', userId: 'primary', user_id: 'fallback' },
+    };
+    expect(parseOldBuddy(data)?.userId).toBe('primary');
+  });
+
+  it('falls back to companion.user_id when userId is absent', () => {
+    const data = { companion: { name: 'X', user_id: 'snake' } };
+    expect(parseOldBuddy(data)?.userId).toBe('snake');
+  });
+
+  it('does not require oauthAccount to parse', () => {
+    const data = { companion: { name: 'NoOauth', species: 'Duck' } };
+    const result = parseOldBuddy(data);
+    expect(result?.name).toBe('NoOauth');
+    expect(result?.accountUuid).toBeUndefined();
+  });
+
+  it('prefers data.buddy over data.companion when both are present', () => {
+    // Explicit precedence check: .buddy is tried first.
+    const data = {
+      buddy: { name: 'BuddyWins', species: 'Owl' },
+      companion: { name: 'CompanionLoses', species: 'Duck' },
+    };
+    const result = parseOldBuddy(data);
+    expect(result?.name).toBe('BuddyWins');
+    expect(result?.species).toBe('Owl');
+  });
+});
+
+describe('inferSpeciesFromPersonality', () => {
+  it('pins Fernsquire to Shell Turtle via the word "turtle"', () => {
+    const text =
+      'A philosophically unflappable turtle who responds to your bugs with measured skepticism and the occasional cutting remark about your variable names, as if waiting 80 years to hatch has given them an exceptionally low tolerance for sloppy thinking.';
+    expect(inferSpeciesFromPersonality(text)).toBe('Shell Turtle');
+  });
+
+  it('matches multi-word species names with higher priority than generic nouns', () => {
+    // "shell turtle" (multi-word) appears once AND "turtle" (generic) appears twice.
+    // Multi-word weight (100) should dominate.
+    const text = 'A shell turtle. A turtle. Another turtle.';
+    expect(inferSpeciesFromPersonality(text)).toBe('Shell Turtle');
+  });
+
+  it('recognizes all default bio species names', () => {
+    // These are verbatim phrases lifted from src/lib/personality.ts bios, one
+    // per species, so the inference covers the canonical output Claude would
+    // have written.
+    const canonical: Record<string, string> = {
+      'Void Cat': 'An enigmatic void cat who judges from the shadows.',
+      'Rust Hound': 'A loyal, relentless rust hound that chases every bug.',
+      'Data Drake': 'An analytical data drake that hoards abstractions.',
+      'Log Golem': 'A stoic log golem built from a thousand debug sessions.',
+      'Cache Crow': 'A quick-witted cache crow that steals good patterns.',
+      'Shell Turtle': 'A patient shell turtle that prefers stability.',
+      'Duck': 'A scatterbrained duck who waddles through your code.',
+      'Goose': 'A territorial goose that honks at every breakpoint.',
+      'Blob': 'An adaptable blob that absorbs any framework.',
+      'Octopus': 'A multitasking octopus with a tentacle in every module.',
+      'Owl': 'A wise, nocturnal owl that sees patterns others miss.',
+      'Penguin': 'A formal penguin that believes in strict typing.',
+      'Snail': 'A thoughtful snail that leaves trails of wisdom.',
+      'Ghost': 'An elusive ghost that appears with spectral insights.',
+      'Axolotl': 'A regenerative axolotl that recovers from any deploy.',
+      'Capybara': 'A chill capybara that brings calm to reviews.',
+      'Cactus': 'A prickly cactus that thrives on minimal resources.',
+      'Robot': 'A logical robot that processes code mechanically.',
+      'Rabbit': 'A quick-witted rabbit that roasts your naming.',
+      'Mushroom': 'A mysterious mushroom spreading a mycelial network.',
+      'Chonk': 'A hefty chonk that takes up space unapologetically.',
+    };
+    for (const [species, text] of Object.entries(canonical)) {
+      expect(inferSpeciesFromPersonality(text), `should infer ${species}`).toBe(species);
+    }
+  });
+
+  it('uses case-insensitive matching', () => {
+    expect(inferSpeciesFromPersonality('A TURTLE in the shell.')).toBe('Shell Turtle');
+    expect(inferSpeciesFromPersonality('A Turtle.')).toBe('Shell Turtle');
+  });
+
+  it('uses word boundaries — "cat" does not match "category" or "catalog"', () => {
+    expect(inferSpeciesFromPersonality('Handles every category of bug')).toBeNull();
+    expect(inferSpeciesFromPersonality('An archivist with a deep catalog')).toBeNull();
+  });
+
+  it('returns null for empty / nullish / unrelated input', () => {
+    expect(inferSpeciesFromPersonality('')).toBeNull();
+    expect(inferSpeciesFromPersonality(undefined)).toBeNull();
+    expect(inferSpeciesFromPersonality(null)).toBeNull();
+    expect(inferSpeciesFromPersonality('Just a vibe.')).toBeNull();
+  });
+
+  it('picks the species with the most matches when multiple species-keywords appear', () => {
+    // Hound is mentioned twice, cat once — Rust Hound wins on count.
+    const text = 'A loyal hound chasing a cat, a real hound at heart.';
+    expect(inferSpeciesFromPersonality(text)).toBe('Rust Hound');
+  });
+
+  it('every species in SPECIES_LIST has a keyword entry', () => {
+    // Guard against adding a new species but forgetting to register its keywords.
+    for (const species of SPECIES_LIST) {
+      expect(SPECIES_KEYWORDS[species], `missing keywords for ${species}`).toBeDefined();
+      expect(SPECIES_KEYWORDS[species].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every keyword entry maps to a valid species in SPECIES_LIST', () => {
+    for (const species of Object.keys(SPECIES_KEYWORDS)) {
+      expect(SPECIES_LIST as readonly string[]).toContain(species);
+    }
+  });
+});
+
+describe('deriveSpecies', () => {
+  it('returns an explicit valid species as-is', () => {
+    expect(deriveSpecies({ species: 'Owl' })).toBe('Owl');
+  });
+
+  it('ignores an explicit invalid species and falls through to inference', () => {
+    expect(
+      deriveSpecies({ species: 'NotReal', personality: 'A patient shell turtle.' })
+    ).toBe('Shell Turtle');
+  });
+
+  it('infers species from personality when species is missing (Fernsquire case)', () => {
+    const result = deriveSpecies({
+      personality:
+        'A philosophically unflappable turtle who responds to your bugs with measured skepticism.',
+      accountUuid: 'acc-xyz', // present but should not be consulted — inference wins
+    });
+    expect(result).toBe('Shell Turtle');
+  });
+
+  it('falls back to accountUuid-derived species when personality yields no match', () => {
+    const result = deriveSpecies({
+      personality: 'Just a vibe.',
+      accountUuid: 'stable-uuid-abc',
+    });
+    expect(SPECIES_LIST as readonly string[]).toContain(result!);
+  });
+
+  it('is deterministic on accountUuid — same uuid → same species', () => {
+    const a = deriveSpecies({ accountUuid: 'repeat-uuid' });
+    const b = deriveSpecies({ accountUuid: 'repeat-uuid' });
+    expect(a).toBe(b);
+  });
+
+  it('returns null when nothing is resolvable (no species, no personality match, no uuid)', () => {
+    expect(deriveSpecies({})).toBeNull();
+    expect(deriveSpecies({ personality: 'undefinable entity' })).toBeNull();
+  });
+
+  describe('loose-match for legacy short species names', () => {
+    // The legacy Claude Code config stored bare animal nouns — "turtle", "cat"
+    // — where the current SPECIES_LIST has compound names. These are the cases
+    // Josh's actual ~/.claude.json would look like if it did have a species field.
+    it('maps "turtle" to Shell Turtle', () => {
+      expect(deriveSpecies({ species: 'turtle' })).toBe('Shell Turtle');
+    });
+
+    it('maps "cat" to Void Cat', () => {
+      expect(deriveSpecies({ species: 'cat' })).toBe('Void Cat');
+    });
+
+    it('maps "hound" and "dog" to Rust Hound', () => {
+      expect(deriveSpecies({ species: 'hound' })).toBe('Rust Hound');
+      expect(deriveSpecies({ species: 'dog' })).toBe('Rust Hound');
+    });
+
+    it('maps "drake" and "dragon" to Data Drake', () => {
+      expect(deriveSpecies({ species: 'drake' })).toBe('Data Drake');
+      expect(deriveSpecies({ species: 'dragon' })).toBe('Data Drake');
+    });
+
+    it('maps "golem" to Log Golem', () => {
+      expect(deriveSpecies({ species: 'golem' })).toBe('Log Golem');
+    });
+
+    it('maps "crow" and "raven" to Cache Crow', () => {
+      expect(deriveSpecies({ species: 'crow' })).toBe('Cache Crow');
+      expect(deriveSpecies({ species: 'raven' })).toBe('Cache Crow');
+    });
+
+    it('normalizes lowercase single-word species ("owl" → "Owl")', () => {
+      expect(deriveSpecies({ species: 'owl' })).toBe('Owl');
+      expect(deriveSpecies({ species: 'duck' })).toBe('Duck');
+      expect(deriveSpecies({ species: 'mushroom' })).toBe('Mushroom');
+    });
+
+    it('is case-insensitive ("TURTLE", "Turtle" → Shell Turtle)', () => {
+      expect(deriveSpecies({ species: 'TURTLE' })).toBe('Shell Turtle');
+      expect(deriveSpecies({ species: 'Turtle' })).toBe('Shell Turtle');
+    });
+
+    it('prefers explicit species over personality inference (even when personality disagrees)', () => {
+      // User's stored species field is authoritative — if they say "turtle",
+      // the goose-flavored bio text must not override it.
+      const result = deriveSpecies({
+        species: 'turtle',
+        personality: 'A territorial goose that honks at everything.',
+      });
+      expect(result).toBe('Shell Turtle');
+    });
+
+    it('falls through to personality inference when species is non-mappable', () => {
+      const result = deriveSpecies({
+        species: 'xyzzy', // not a match for anything
+        personality: 'A patient shell turtle that prefers stability.',
+      });
+      expect(result).toBe('Shell Turtle');
+    });
+
+    it('maps every legacy Claude Code species to its canonical form', () => {
+      // The original 18-species list as shipped in Claude Code's ~/.claude.json.
+      // Three of them (cat / dragon / turtle) have since been renamed to
+      // compound forms (Void Cat / Data Drake / Shell Turtle) — the rest
+      // survive as single-word species with only case to normalize.
+      const LEGACY_TO_CANONICAL: Record<string, string> = {
+        duck: 'Duck',
+        goose: 'Goose',
+        blob: 'Blob',
+        cat: 'Void Cat',
+        dragon: 'Data Drake',
+        octopus: 'Octopus',
+        owl: 'Owl',
+        penguin: 'Penguin',
+        turtle: 'Shell Turtle',
+        snail: 'Snail',
+        ghost: 'Ghost',
+        axolotl: 'Axolotl',
+        capybara: 'Capybara',
+        cactus: 'Cactus',
+        robot: 'Robot',
+        rabbit: 'Rabbit',
+        mushroom: 'Mushroom',
+        chonk: 'Chonk',
+      };
+      for (const [legacy, canonical] of Object.entries(LEGACY_TO_CANONICAL)) {
+        expect(deriveSpecies({ species: legacy }), `legacy "${legacy}" should map to "${canonical}"`).toBe(canonical);
+      }
+    });
+  });
+});

--- a/src/cli/onboard.ts
+++ b/src/cli/onboard.ts
@@ -14,6 +14,7 @@ import { renderCard, hatchAnimation, rescueAnimation } from '../lib/card.js';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
+import { SPECIES_LIST, seededIndex } from '../lib/species.js';
 
 import { RESET, DIM, CYAN, YELLOW, GREEN, MAGENTA, BOLD } from '../lib/ansi.js';
 
@@ -31,7 +32,10 @@ function c(color: string, text: string): string {
 
 interface OldBuddy {
   name: string;
-  species: string;
+  species?: string;
+  personality?: string;
+  hatchedAt?: number;
+  accountUuid?: string;
   userId?: string;
   user_id?: string;
 }
@@ -45,19 +49,23 @@ function importOldBuddy(): OldBuddy | null {
     // Claude Code stored buddy data under various keys
     // Check common locations
     const buddy = data.buddy || data.companion || data.buddyCompanion;
-    if (buddy && buddy.name && buddy.species) {
+    if (buddy && buddy.name) {
       return {
         name: buddy.name,
         species: buddy.species,
+        personality: buddy.personality,
+        hatchedAt: buddy.hatchedAt,
+        accountUuid: data.oauthAccount?.accountUuid,
         userId: buddy.userId || buddy.user_id,
       };
     }
 
     // Check if the top-level has buddy fields
-    if (data.buddyName && data.buddySpecies) {
+    if (data.buddyName) {
       return {
         name: data.buddyName,
         species: data.buddySpecies,
+        accountUuid: data.oauthAccount?.accountUuid,
         userId: data.userId || data.user_id,
       };
     }
@@ -171,11 +179,20 @@ async function main() {
   // Try to import old buddy
   const oldBuddy = importOldBuddy();
 
+  // If species is missing but accountUuid exists, derive it deterministically
+  if (oldBuddy && !oldBuddy.species && oldBuddy.accountUuid) {
+    const speciesIndex = seededIndex(oldBuddy.accountUuid, 'friend-2026-401', SPECIES_LIST.length);
+    oldBuddy.species = SPECIES_LIST[speciesIndex];
+  }
+
   // Build menu choices
   const choices: MenuChoice[] = [];
   if (oldBuddy) {
+    const label = oldBuddy.species 
+      ? `Rescue ${oldBuddy.name} the ${oldBuddy.species}`
+      : `Rescue ${oldBuddy.name}`;
     choices.push({
-      label: `Rescue ${oldBuddy.name} the ${oldBuddy.species}`,
+      label,
       value: 'rescue',
     });
   }

--- a/src/cli/onboard.ts
+++ b/src/cli/onboard.ts
@@ -14,7 +14,7 @@ import { renderCard, hatchAnimation, rescueAnimation } from '../lib/card.js';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
-import { SPECIES_LIST, seededIndex } from '../lib/species.js';
+import { type OldBuddy, parseOldBuddy, deriveSpecies } from '../lib/oldBuddy.js';
 
 import { RESET, DIM, CYAN, YELLOW, GREEN, MAGENTA, BOLD } from '../lib/ansi.js';
 
@@ -30,47 +30,11 @@ function c(color: string, text: string): string {
 
 // ── Import old buddy from ~/.claude.json ──
 
-interface OldBuddy {
-  name: string;
-  species?: string;
-  personality?: string;
-  hatchedAt?: number;
-  accountUuid?: string;
-  userId?: string;
-  user_id?: string;
-}
-
 function importOldBuddy(): OldBuddy | null {
   try {
     const claudeJsonPath = join(homedir(), '.claude.json');
     const raw = readFileSync(claudeJsonPath, 'utf-8');
-    const data = JSON.parse(raw);
-
-    // Claude Code stored buddy data under various keys
-    // Check common locations
-    const buddy = data.buddy || data.companion || data.buddyCompanion;
-    if (buddy && buddy.name) {
-      return {
-        name: buddy.name,
-        species: buddy.species,
-        personality: buddy.personality,
-        hatchedAt: buddy.hatchedAt,
-        accountUuid: data.oauthAccount?.accountUuid,
-        userId: buddy.userId || buddy.user_id,
-      };
-    }
-
-    // Check if the top-level has buddy fields
-    if (data.buddyName) {
-      return {
-        name: data.buddyName,
-        species: data.buddySpecies,
-        accountUuid: data.oauthAccount?.accountUuid,
-        userId: data.userId || data.user_id,
-      };
-    }
-
-    return null;
+    return parseOldBuddy(JSON.parse(raw));
   } catch {
     return null;
   }
@@ -179,10 +143,13 @@ async function main() {
   // Try to import old buddy
   const oldBuddy = importOldBuddy();
 
-  // If species is missing but accountUuid exists, derive it deterministically
-  if (oldBuddy && !oldBuddy.species && oldBuddy.accountUuid) {
-    const speciesIndex = seededIndex(oldBuddy.accountUuid, 'friend-2026-401', SPECIES_LIST.length);
-    oldBuddy.species = SPECIES_LIST[speciesIndex];
+  // Normalize the species via the shared resolution ladder. This runs even
+  // when a species is already set because the legacy Claude Code config used
+  // short names ("turtle", "cat") that need to be mapped to canonical list
+  // entries ("Shell Turtle", "Void Cat") for the menu label to read correctly.
+  if (oldBuddy) {
+    const derived = deriveSpecies(oldBuddy);
+    if (derived) oldBuddy.species = derived;
   }
 
   // Build menu choices

--- a/src/lib/companion.ts
+++ b/src/lib/companion.ts
@@ -128,22 +128,24 @@ export function createCompanion(opts: {
 
 /**
  * Rescue an old buddy from imported data (e.g. ~/.claude.json).
- * The importResult should have at least { name, species }.
+ * The importResult should have at least { name }.
  */
 export function rescueCompanion(importResult: {
   name: string;
-  species: string;
+  species?: string;
+  accountUuid?: string;
   userId?: string;
   user_id?: string;
 }, opts: { userId?: string } = {}): { companion: Companion; id: string } {
   const userId = opts.userId
     || importResult.userId
     || importResult.user_id
+    || importResult.accountUuid
     || `imported-${importResult.name}`;
 
   const { bones } = roll(userId, SPECIES_LIST);
 
-  const finalSpecies = SPECIES_LIST.includes(importResult.species as any)
+  const finalSpecies = importResult.species && SPECIES_LIST.includes(importResult.species as any)
     ? importResult.species
     : bones.species;
 

--- a/src/lib/companion.ts
+++ b/src/lib/companion.ts
@@ -7,6 +7,7 @@ import { generateBio } from './personality.js';
 import { sanitizeName } from './sanitize.js';
 import { type Companion, RARITY_STARS } from './types.js';
 import { levelFromXp } from './leveling.js';
+import { deriveSpecies } from './oldBuddy.js';
 import { randomUUID } from 'crypto';
 import { writeFileSync, mkdirSync } from 'fs';
 import { dirname } from 'path';
@@ -129,10 +130,16 @@ export function createCompanion(opts: {
 /**
  * Rescue an old buddy from imported data (e.g. ~/.claude.json).
  * The importResult should have at least { name }.
+ *
+ * A "rescue" is a continuation, not a rebirth: if the imported record carries
+ * a hand-written personality or an original hatchedAt timestamp, we preserve
+ * them so the user doesn't lose the character they've already bonded with.
  */
 export function rescueCompanion(importResult: {
   name: string;
   species?: string;
+  personality?: string;
+  hatchedAt?: number;
   accountUuid?: string;
   userId?: string;
   user_id?: string;
@@ -145,18 +152,31 @@ export function rescueCompanion(importResult: {
 
   const { bones } = roll(userId, SPECIES_LIST);
 
-  const finalSpecies = importResult.species && SPECIES_LIST.includes(importResult.species as any)
-    ? importResult.species
-    : bones.species;
+  // Resolve species via the shared ladder (explicit → infer from personality →
+  // accountUuid-derived). bones.species is the last-resort fallback, keyed to
+  // the userId roll so it's stable per user even without personality/uuid.
+  const finalSpecies = deriveSpecies(importResult) ?? bones.species;
 
   const finalName = sanitizeName(importResult.name) || generateName(finalSpecies, userId);
   const id = randomUUID();
 
-  const bio = generateBio({ ...bones, species: finalSpecies });
+  // Preserve the imported personality if the user had one; otherwise generate fresh.
+  const bio = importResult.personality || generateBio({ ...bones, species: finalSpecies });
 
-  db.prepare(
-    'INSERT INTO companions (id, name, species, user_id, personality_bio) VALUES (?, ?, ?, ?, ?)'
-  ).run(id, finalName, finalSpecies, userId, bio);
+  // Preserve the imported hatchedAt if present — rescuing is continuation, not rebirth.
+  const hatchedAt = importResult.hatchedAt ?? Date.now();
+
+  if (importResult.hatchedAt !== undefined) {
+    // ISO 8601 'Z' round-trips cleanly through loadCompanion's new Date(row.created_at).getTime().
+    const createdAt = new Date(importResult.hatchedAt).toISOString();
+    db.prepare(
+      'INSERT INTO companions (id, name, species, user_id, personality_bio, created_at) VALUES (?, ?, ?, ?, ?, ?)'
+    ).run(id, finalName, finalSpecies, userId, bio, createdAt);
+  } else {
+    db.prepare(
+      'INSERT INTO companions (id, name, species, user_id, personality_bio) VALUES (?, ?, ?, ?, ?)'
+    ).run(id, finalName, finalSpecies, userId, bio);
+  }
 
   const companion: Companion = {
     ...bones,
@@ -166,7 +186,7 @@ export function rescueCompanion(importResult: {
     level: 1,
     xp: 0,
     mood: 'happy',
-    hatchedAt: Date.now(),
+    hatchedAt,
   };
 
   writeBuddyStatus(companion);

--- a/src/lib/oldBuddy.ts
+++ b/src/lib/oldBuddy.ts
@@ -1,0 +1,179 @@
+// src/lib/oldBuddy.ts — pure parser for legacy buddy data from ~/.claude.json,
+// plus the species-resolution ladder used when rescuing a buddy with missing fields.
+// Kept separate from the I/O-heavy onboarding CLI so it's trivially unit-testable.
+
+import { SPECIES_LIST } from './species.js';
+import { seededIndex } from './rng.js';
+
+// Namespace passed to seededIndex when deriving species from accountUuid.
+// Semantic name (not the internal rng SALT) so the two constants don't drift.
+const ACCOUNT_UUID_SPECIES_NAMESPACE = 'species:import';
+
+export interface OldBuddy {
+  name: string;
+  species?: string;
+  personality?: string;
+  hatchedAt?: number;
+  accountUuid?: string;
+  userId?: string;
+  user_id?: string;
+}
+
+/**
+ * Extract an OldBuddy record from a parsed ~/.claude.json object.
+ * Returns null if no recognizable buddy data is found.
+ *
+ * Claude Code stored buddy data under a few different shapes over time:
+ *   - Nested: data.companion / data.buddy / data.buddyCompanion with { name, species?, personality?, hatchedAt? }
+ *   - Flat:   data.buddyName / data.buddySpecies
+ * The `accountUuid` is pulled from data.oauthAccount.accountUuid when available,
+ * giving us a stable seed to derive missing fields deterministically.
+ */
+export function parseOldBuddy(data: any): OldBuddy | null {
+  if (!data || typeof data !== 'object') return null;
+
+  const buddy = data.buddy || data.companion || data.buddyCompanion;
+  if (buddy && buddy.name) {
+    return {
+      name: buddy.name,
+      species: buddy.species,
+      personality: buddy.personality,
+      hatchedAt: buddy.hatchedAt,
+      accountUuid: data.oauthAccount?.accountUuid,
+      userId: buddy.userId || buddy.user_id,
+    };
+  }
+
+  if (data.buddyName) {
+    return {
+      name: data.buddyName,
+      species: data.buddySpecies,
+      accountUuid: data.oauthAccount?.accountUuid,
+      userId: data.userId || data.user_id,
+    };
+  }
+
+  return null;
+}
+
+// ── Species inference from free-text personality ──────────────────────────
+
+/**
+ * Keywords used to infer a species from a free-text personality description.
+ * The default bio templates in personality.ts always name the species directly
+ * ("void cat", "rust hound", "shell turtle"); when Claude Code wrote a custom
+ * bio, the animal noun typically still appears ("turtle" in Fernsquire's bio
+ * from issue #60). We match those words with case-insensitive word boundaries,
+ * weighting multi-word matches over single-word ones so "shell turtle" beats
+ * a lone "turtle" when both appear.
+ *
+ * Exported for test visibility and so future species additions can't silently
+ * miss their keyword list.
+ */
+export const SPECIES_KEYWORDS: Record<string, string[]> = {
+  'Void Cat':     ['void cat', 'cat', 'kitten', 'feline'],
+  'Rust Hound':   ['rust hound', 'hound', 'dog', 'puppy', 'canine'],
+  'Data Drake':   ['data drake', 'drake', 'dragon'],
+  'Log Golem':    ['log golem', 'golem'],
+  'Cache Crow':   ['cache crow', 'crow', 'raven'],
+  'Shell Turtle': ['shell turtle', 'turtle', 'tortoise'],
+  'Duck':         ['duck', 'duckling', 'mallard'],
+  'Goose':        ['goose', 'gander'],
+  'Blob':         ['blob', 'slime'],
+  'Octopus':      ['octopus', 'cephalopod'],
+  'Owl':          ['owl', 'owlet'],
+  'Penguin':      ['penguin'],
+  'Snail':        ['snail', 'mollusk'],
+  'Ghost':        ['ghost', 'phantom', 'specter', 'spectre', 'wraith', 'spirit', 'apparition'],
+  'Axolotl':      ['axolotl'],
+  'Capybara':     ['capybara'],
+  'Cactus':       ['cactus', 'cacti', 'succulent'],
+  'Robot':        ['robot', 'android'],
+  'Rabbit':       ['rabbit', 'bunny', 'hare', 'leveret'],
+  'Mushroom':     ['mushroom', 'fungus', 'fungi', 'shroom', 'mycelium', 'mycelial'],
+  'Chonk':        ['chonk'],
+};
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Scan a personality string for species keywords and return the best match.
+ * Multi-word keywords (like "shell turtle") outrank single-word ones so the
+ * compound species wins when its full name appears in the text. Returns null
+ * when no keyword matches.
+ */
+export function inferSpeciesFromPersonality(text: string | undefined | null): string | null {
+  if (!text) return null;
+  const lower = text.toLowerCase();
+
+  let best: { species: string; score: number } | null = null;
+
+  for (const [species, keywords] of Object.entries(SPECIES_KEYWORDS)) {
+    let score = 0;
+    for (const kw of keywords) {
+      const pattern = new RegExp(`\\b${escapeRegExp(kw)}\\b`, 'g');
+      const matches = lower.match(pattern);
+      if (!matches) continue;
+      // Multi-word keys ("shell turtle") are ~100x more informative than
+      // single-word keys; the 100 factor ensures they dominate even when a
+      // bio repeats the generic noun several times.
+      score += matches.length * (kw.includes(' ') ? 100 : 1);
+    }
+    if (score > 0 && (!best || score > best.score)) {
+      best = { species, score };
+    }
+  }
+
+  return best?.species ?? null;
+}
+
+/**
+ * Resolve a species for a rescued buddy. Tries in order:
+ *   1. importResult.species, if it's a canonical SPECIES_LIST entry.
+ *   2. importResult.species, loose-matched — the legacy Claude Code config
+ *      stored short names like "turtle" or "cat" where the current list has
+ *      "Shell Turtle" / "Void Cat". The same keyword scanner we use for
+ *      personality inference handles these short names too.
+ *   3. Inference from importResult.personality text.
+ *   4. Deterministic derivation from importResult.accountUuid.
+ * Returns null if none apply — callers are expected to fall back to their
+ * own last resort (typically bones.species from a userId-seeded roll).
+ *
+ * This is the single source of truth for species resolution on the rescue
+ * path: both the onboarding CLI (for menu labels) and rescueCompanion (for
+ * the actual DB write) call this so they can't disagree.
+ */
+export function deriveSpecies(importResult: {
+  species?: string;
+  personality?: string;
+  accountUuid?: string;
+}): string | null {
+  if (
+    importResult.species &&
+    (SPECIES_LIST as readonly string[]).includes(importResult.species)
+  ) {
+    return importResult.species;
+  }
+  // Loose match for legacy short names. inferSpeciesFromPersonality works on
+  // any text via keyword scanning, so passing a bare species token like
+  // "turtle" or "Cat" resolves correctly (case-insensitive, word-boundary).
+  if (importResult.species) {
+    const loose = inferSpeciesFromPersonality(importResult.species);
+    if (loose) return loose;
+  }
+  if (importResult.personality) {
+    const inferred = inferSpeciesFromPersonality(importResult.personality);
+    if (inferred) return inferred;
+  }
+  if (importResult.accountUuid) {
+    const idx = seededIndex(
+      importResult.accountUuid,
+      ACCOUNT_UUID_SPECIES_NAMESPACE,
+      SPECIES_LIST.length
+    );
+    return SPECIES_LIST[idx];
+  }
+  return null;
+}

--- a/src/lib/species.ts
+++ b/src/lib/species.ts
@@ -384,6 +384,8 @@ export function calculateMood(xpEvents: any[], recentMemories: number): Mood {
   return 'grumpy';
 }
 
+export { seededIndex } from './rng.js';
+
 // Species-specific two-pool name system — combine first+second for ~100 unique names per species
 type NamePools = { first: string[]; second: string[] };
 


### PR DESCRIPTION
Fixes the 'Fernsquire bug' by allowing the CLI to import companions from `~/.claude.json` even when the `species` field is missing.

Key changes:
- Updated `OldBuddy` interface to make `species` optional and added support for `accountUuid`.
- Implemented deterministic species derivation using FNV-1a hash of `accountUuid` and `Mulberry32` PRNG when species is missing during import.
- Updated `rescueCompanion` to support optional species and use `accountUuid` as a stable `userId` for bone generation.
- Exported `seededIndex` from `species.ts` for use in the CLI.

Closes #60.