### PR TITLE
fix: rescue species inference from name + CC-compatible stats via Bun hash

### DIFF
--- a/src/__tests__/oldBuddy.test.ts
+++ b/src/__tests__/oldBuddy.test.ts
@@ -3,6 +3,7 @@ import {
   parseOldBuddy,
   inferSpeciesFromPersonality,
   deriveSpecies,
+  rollWithCCCompat,
   SPECIES_KEYWORDS,
 } from '../lib/oldBuddy.js';
 import { SPECIES_LIST } from '../lib/species.js';
@@ -328,5 +329,109 @@ describe('deriveSpecies', () => {
         expect(deriveSpecies({ species: legacy }), `legacy "${legacy}" should map to "${canonical}"`).toBe(canonical);
       }
     });
+
+    it('infers species from companion name', () => {
+      expect(deriveSpecies({ name: 'Gritblob' })).toBe('Blob');
+      expect(deriveSpecies({ name: 'ShadowCat' })).toBe('Void Cat');
+      expect(deriveSpecies({ name: 'Ducksworth' })).toBe('Duck');
+      expect(deriveSpecies({ name: 'Shroomsworth' })).toBe('Mushroom');
+    });
+
+    it('name inference is tried before personality', () => {
+      // Name says "blob", personality says "turtle" — name wins
+      expect(deriveSpecies({
+        name: 'Gritblob',
+        personality: 'a turtle who likes to swim',
+      })).toBe('Blob');
+    });
+
+    it('falls back to personality when name has no keywords', () => {
+      expect(deriveSpecies({
+        name: 'Sparky',
+        personality: 'a patient troubleshooter turtle',
+      })).toBe('Shell Turtle');
+    });
   });
+});
+
+describe('parseOldBuddy — top-level userID', () => {
+  it('pulls userID from top-level .claude.json (CC format)', () => {
+    const data = {
+      userID: 'top-level-uid-123',
+      companion: {
+        name: 'Gritblob',
+        personality: 'A patient troubleshooter',
+        hatchedAt: 1775047109797,
+      },
+    };
+    const result = parseOldBuddy(data);
+    expect(result?.userId).toBe('top-level-uid-123');
+  });
+
+  it('companion-level userId takes precedence over top-level', () => {
+    const data = {
+      userID: 'top-level',
+      companion: {
+        name: 'Test',
+        userId: 'companion-level',
+      },
+    };
+    const result = parseOldBuddy(data);
+    expect(result?.userId).toBe('companion-level');
+  });
+
+  it('flat shape also picks up top-level userID', () => {
+    const data = {
+      userID: 'top-uid',
+      buddyName: 'FlatBuddy',
+      buddySpecies: 'Duck',
+    };
+    const result = parseOldBuddy(data);
+    expect(result?.userId).toBe('top-uid');
+  });
+});
+
+describe('rollWithCCCompat', () => {
+  it('returns valid bones with all required fields', () => {
+    const { bones, engine } = rollWithCCCompat('test-user-id');
+    expect(bones).toHaveProperty('species');
+    expect(bones).toHaveProperty('eye');
+    expect(bones).toHaveProperty('rarity');
+    expect(bones).toHaveProperty('stats');
+    expect(bones).toHaveProperty('hat');
+    expect(bones).toHaveProperty('shiny');
+    expect(['bun', 'fnv1a']).toContain(engine);
+  }, 15000);
+
+  it('is deterministic for the same userId', () => {
+    const a = rollWithCCCompat('determinism-test');
+    const b = rollWithCCCompat('determinism-test');
+    expect(a.bones.stats).toEqual(b.bones.stats);
+    expect(a.bones.species).toBe(b.bones.species);
+    expect(a.bones.eye).toBe(b.bones.eye);
+    expect(a.bones.rarity).toBe(b.bones.rarity);
+  }, 15000);
+
+  it('produces different results for different userIds', () => {
+    const a = rollWithCCCompat('user-alpha');
+    const b = rollWithCCCompat('user-beta');
+    // Stats should differ (extremely unlikely to match by chance)
+    expect(a.bones.stats).not.toEqual(b.bones.stats);
+  }, 15000);
+
+  it('species is from CC list (18 species, short names)', () => {
+    const CC_SPECIES = [
+      'duck', 'goose', 'blob', 'cat', 'dragon', 'octopus', 'owl', 'penguin',
+      'turtle', 'snail', 'ghost', 'axolotl', 'capybara', 'cactus', 'robot',
+      'rabbit', 'mushroom', 'chonk',
+    ];
+    const { bones } = rollWithCCCompat('species-test');
+    expect(CC_SPECIES).toContain(bones.species);
+  }, 15000);
+
+  it('eye is never ✦ (sparkle reserved in our system)', () => {
+    // Single roll — Bun spawn is expensive, don't loop
+    const { bones } = rollWithCCCompat('sparkle-eye-test');
+    expect(bones.eye).not.toBe('✦');
+  }, 15000);
 });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -72,4 +72,9 @@ export function initDb() {
   try {
     db.exec(`ALTER TABLE companions ADD COLUMN observer_mode TEXT DEFAULT 'both'`);
   } catch { /* column already exists */ }
+
+  // Migration: add cc_rescue flag for CC-imported buddies (uses Bun wyhash for stats)
+  try {
+    db.exec(`ALTER TABLE companions ADD COLUMN cc_rescue INTEGER DEFAULT 0`);
+  } catch { /* column already exists */ }
 }

--- a/src/lib/companion.ts
+++ b/src/lib/companion.ts
@@ -31,7 +31,11 @@ export function companionExists(): any | null {
 export function loadCompanion(row: any, userIdOverride?: string): Companion | null {
   if (!row) return null;
   const userId = userIdOverride || row.user_id || 'anon';
-  const { bones } = roll(userId, SPECIES_LIST);
+  // CC-rescued buddies need Bun's wyhash to reproduce original stats.
+  // The cc_rescue flag is set during rescueCompanion when importing from CC.
+  const bones = row.cc_rescue
+    ? rollWithCCCompat(userId).bones
+    : roll(userId, SPECIES_LIST).bones;
   const xp = row.xp || 0;
   const derivedLevel = levelFromXp(xp);
 
@@ -170,16 +174,18 @@ export function rescueCompanion(importResult: {
   // Preserve the imported hatchedAt if present — rescuing is continuation, not rebirth.
   const hatchedAt = importResult.hatchedAt ?? Date.now();
 
+  const ccRescue = hasCCUserId ? 1 : 0;
+
   if (importResult.hatchedAt !== undefined) {
     // ISO 8601 'Z' round-trips cleanly through loadCompanion's new Date(row.created_at).getTime().
     const createdAt = new Date(importResult.hatchedAt).toISOString();
     db.prepare(
-      'INSERT INTO companions (id, name, species, user_id, personality_bio, created_at) VALUES (?, ?, ?, ?, ?, ?)'
-    ).run(id, finalName, finalSpecies, userId, bio, createdAt);
+      'INSERT INTO companions (id, name, species, user_id, personality_bio, created_at, cc_rescue) VALUES (?, ?, ?, ?, ?, ?, ?)'
+    ).run(id, finalName, finalSpecies, userId, bio, createdAt, ccRescue);
   } else {
     db.prepare(
-      'INSERT INTO companions (id, name, species, user_id, personality_bio) VALUES (?, ?, ?, ?, ?)'
-    ).run(id, finalName, finalSpecies, userId, bio);
+      'INSERT INTO companions (id, name, species, user_id, personality_bio, cc_rescue) VALUES (?, ?, ?, ?, ?, ?)'
+    ).run(id, finalName, finalSpecies, userId, bio, ccRescue);
   }
 
   const companion: Companion = {

--- a/src/lib/companion.ts
+++ b/src/lib/companion.ts
@@ -7,7 +7,7 @@ import { generateBio } from './personality.js';
 import { sanitizeName } from './sanitize.js';
 import { type Companion, RARITY_STARS } from './types.js';
 import { levelFromXp } from './leveling.js';
-import { deriveSpecies } from './oldBuddy.js';
+import { deriveSpecies, rollWithCCCompat } from './oldBuddy.js';
 import { randomUUID } from 'crypto';
 import { writeFileSync, mkdirSync } from 'fs';
 import { dirname } from 'path';
@@ -151,11 +151,14 @@ export function rescueCompanion(importResult: {
     || importResult.accountUuid
     || `imported-${importResult.name}`;
 
-  const { bones } = roll(userId, SPECIES_LIST);
+  // Use CC-compatible roll to reproduce exact stats/rarity/eye from the
+  // original Claude Code buddy. Falls back to our roll() if no CC userId.
+  const hasCCUserId = !!(importResult.userId || importResult.user_id);
+  const ccResult = hasCCUserId ? rollWithCCCompat(userId) : null;
+  const bones = ccResult ? ccResult.bones : roll(userId, SPECIES_LIST).bones;
 
-  // Resolve species via the shared ladder (explicit → infer from personality →
-  // accountUuid-derived). bones.species is the last-resort fallback, keyed to
-  // the userId roll so it's stable per user even without personality/uuid.
+  // Resolve species via the shared ladder (explicit → name → personality →
+  // accountUuid-derived). bones.species is the last-resort fallback.
   const finalSpecies = deriveSpecies(importResult) ?? bones.species;
 
   const finalName = sanitizeName(importResult.name) || generateName(finalSpecies, userId);

--- a/src/lib/oldBuddy.ts
+++ b/src/lib/oldBuddy.ts
@@ -3,7 +3,7 @@
 // Kept separate from the I/O-heavy onboarding CLI so it's trivially unit-testable.
 
 import { SPECIES_LIST } from './species.js';
-import { seededIndex, type Roll } from './rng.js';
+import { seededIndex } from './rng.js';
 import {
   type CompanionBones,
   type Rarity,
@@ -13,7 +13,7 @@ import {
   RARITY_FLOOR,
   STAT_NAMES,
 } from './types.js';
-import { execSync } from 'child_process';
+import { spawnSync } from 'child_process';
 
 // Namespace passed to seededIndex when deriving species from accountUuid.
 // Semantic name (not the internal rng SALT) so the two constants don't drift.
@@ -178,11 +178,20 @@ export function deriveSpecies(importResult: {
     const loose = inferSpeciesFromPersonality(importResult.species);
     if (loose) return loose;
   }
-  // Check the companion name for species keywords (e.g., "Gritblob" → Blob).
-  // Many CC-generated names embed the species as a suffix or substring.
+  // Check the companion name for species keywords as substrings (e.g., "Gritblob" → Blob).
+  // CC-generated names embed the species as a suffix or substring without word boundaries.
+  // Use case-insensitive substring matching, not word-boundary regex.
   if (importResult.name) {
-    const fromName = inferSpeciesFromPersonality(importResult.name);
-    if (fromName) return fromName;
+    const nameLower = importResult.name.toLowerCase();
+    let bestMatch: { species: string; len: number } | null = null;
+    for (const [species, keywords] of Object.entries(SPECIES_KEYWORDS)) {
+      for (const kw of keywords) {
+        if (nameLower.includes(kw) && (!bestMatch || kw.length > bestMatch.len)) {
+          bestMatch = { species, len: kw.length };
+        }
+      }
+    }
+    if (bestMatch) return bestMatch.species;
   }
   if (importResult.personality) {
     const inferred = inferSpeciesFromPersonality(importResult.personality);
@@ -244,8 +253,8 @@ let bunAvailable: boolean | undefined;
 function ccHashString(s: string): { hash: number; engine: 'bun' | 'fnv1a' } {
   if (bunAvailable === undefined) {
     try {
-      execSync('bun --version', { timeout: 3000, stdio: 'pipe' });
-      bunAvailable = true;
+      const check = spawnSync('bun', ['--version'], { timeout: 5000, stdio: 'pipe' });
+      bunAvailable = check.status === 0;
     } catch {
       bunAvailable = false;
     }
@@ -253,12 +262,13 @@ function ccHashString(s: string): { hash: number; engine: 'bun' | 'fnv1a' } {
 
   if (bunAvailable) {
     try {
-      const escaped = s.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/\n/g, '\\n');
-      const result = execSync(
-        `bun -e "console.log(Number(BigInt(Bun.hash('${escaped}')) & 0xffffffffn))"`,
-        { timeout: 5000, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
-      ).trim();
-      const hash = parseInt(result, 10);
+      // Pass input as process.argv to avoid shell injection — no string interpolation
+      const result = spawnSync('bun', [
+        '-e',
+        'console.log(Number(BigInt(Bun.hash(process.argv[1])) & 0xffffffffn))',
+        s,
+      ], { timeout: 5000, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+      const hash = parseInt((result.stdout || '').trim(), 10);
       if (!isNaN(hash)) return { hash, engine: 'bun' };
     } catch { /* fall through */ }
   }

--- a/src/lib/oldBuddy.ts
+++ b/src/lib/oldBuddy.ts
@@ -3,7 +3,17 @@
 // Kept separate from the I/O-heavy onboarding CLI so it's trivially unit-testable.
 
 import { SPECIES_LIST } from './species.js';
-import { seededIndex } from './rng.js';
+import { seededIndex, type Roll } from './rng.js';
+import {
+  type CompanionBones,
+  type Rarity,
+  type StatName,
+  RARITIES,
+  RARITY_WEIGHTS,
+  RARITY_FLOOR,
+  STAT_NAMES,
+} from './types.js';
+import { execSync } from 'child_process';
 
 // Namespace passed to seededIndex when deriving species from accountUuid.
 // Semantic name (not the internal rng SALT) so the two constants don't drift.
@@ -32,6 +42,10 @@ export interface OldBuddy {
 export function parseOldBuddy(data: any): OldBuddy | null {
   if (!data || typeof data !== 'object') return null;
 
+  // Claude Code stored the userID at the top level of .claude.json, not inside
+  // the companion sub-object. Check all known locations for a stable userId seed.
+  const topLevelUserId = data.userID || data.userId || data.user_id;
+
   const buddy = data.buddy || data.companion || data.buddyCompanion;
   if (buddy && buddy.name) {
     return {
@@ -40,7 +54,7 @@ export function parseOldBuddy(data: any): OldBuddy | null {
       personality: buddy.personality,
       hatchedAt: buddy.hatchedAt,
       accountUuid: data.oauthAccount?.accountUuid,
-      userId: buddy.userId || buddy.user_id,
+      userId: buddy.userId || buddy.user_id || topLevelUserId,
     };
   }
 
@@ -49,7 +63,7 @@ export function parseOldBuddy(data: any): OldBuddy | null {
       name: data.buddyName,
       species: data.buddySpecies,
       accountUuid: data.oauthAccount?.accountUuid,
-      userId: data.userId || data.user_id,
+      userId: data.userId || data.user_id || topLevelUserId,
     };
   }
 
@@ -146,6 +160,7 @@ export function inferSpeciesFromPersonality(text: string | undefined | null): st
  * the actual DB write) call this so they can't disagree.
  */
 export function deriveSpecies(importResult: {
+  name?: string;
   species?: string;
   personality?: string;
   accountUuid?: string;
@@ -163,6 +178,12 @@ export function deriveSpecies(importResult: {
     const loose = inferSpeciesFromPersonality(importResult.species);
     if (loose) return loose;
   }
+  // Check the companion name for species keywords (e.g., "Gritblob" → Blob).
+  // Many CC-generated names embed the species as a suffix or substring.
+  if (importResult.name) {
+    const fromName = inferSpeciesFromPersonality(importResult.name);
+    if (fromName) return fromName;
+  }
   if (importResult.personality) {
     const inferred = inferSpeciesFromPersonality(importResult.personality);
     if (inferred) return inferred;
@@ -176,4 +197,150 @@ export function deriveSpecies(importResult: {
     return SPECIES_LIST[idx];
   }
   return null;
+}
+
+// ── CC-compatible roll ──────────────────────────────────────────────────
+// Claude Code's original buddy used different species/eyes lists and ordering.
+// To reproduce exact stats for rescued buddies, we replay the CC roll algorithm
+// with CC's exact constants. Same Mulberry32 + FNV-1a + salt as our roll(),
+// but different pick arrays change the RNG consumption pattern.
+
+// CC's original species list (18 species, different order from ours)
+const CC_SPECIES = [
+  'duck', 'goose', 'blob', 'cat', 'dragon', 'octopus', 'owl', 'penguin',
+  'turtle', 'snail', 'ghost', 'axolotl', 'capybara', 'cactus', 'robot',
+  'rabbit', 'mushroom', 'chonk',
+] as const;
+
+// CC had ✦ at index 1 where we have '.'
+const CC_EYES = ['·', '✦', '×', '◉', '@', '°'] as const;
+
+// CC hats included 'none' in the pick array for non-common
+const CC_HATS = ['none', 'crown', 'tophat', 'propeller', 'halo', 'wizard', 'beanie', 'tinyduck'] as const;
+
+const CC_SALT = 'friend-2026-401';
+
+function ccMulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return function () {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// Cache Bun availability so we only check once per process
+let bunAvailable: boolean | undefined;
+
+/**
+ * Hash matching Claude Code's runtime behavior:
+ * - CC runs on Bun → uses Bun.hash() (wyhash), truncated to 32 bits
+ * - CC on Node fallback → FNV-1a
+ * We shell out to Bun to match the wyhash path. Falls back to FNV-1a if Bun
+ * is not installed (stats will differ, but rescue still works).
+ */
+function ccHashString(s: string): { hash: number; engine: 'bun' | 'fnv1a' } {
+  if (bunAvailable === undefined) {
+    try {
+      execSync('bun --version', { timeout: 3000, stdio: 'pipe' });
+      bunAvailable = true;
+    } catch {
+      bunAvailable = false;
+    }
+  }
+
+  if (bunAvailable) {
+    try {
+      const escaped = s.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/\n/g, '\\n');
+      const result = execSync(
+        `bun -e "console.log(Number(BigInt(Bun.hash('${escaped}')) & 0xffffffffn))"`,
+        { timeout: 5000, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+      ).trim();
+      const hash = parseInt(result, 10);
+      if (!isNaN(hash)) return { hash, engine: 'bun' };
+    } catch { /* fall through */ }
+  }
+
+  // FNV-1a fallback (matches CC's Node.js path)
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return { hash: h >>> 0, engine: 'fnv1a' };
+}
+
+function ccPick<T>(rng: () => number, arr: readonly T[]): T {
+  return arr[Math.floor(rng() * arr.length)]!;
+}
+
+function ccRollRarity(rng: () => number): Rarity {
+  const total = Object.values(RARITY_WEIGHTS).reduce((a, b) => a + b, 0);
+  let roll = rng() * total;
+  for (const rarity of RARITIES) {
+    roll -= RARITY_WEIGHTS[rarity];
+    if (roll < 0) return rarity;
+  }
+  return 'common';
+}
+
+function ccRollStats(rng: () => number, rarity: Rarity): Record<StatName, number> {
+  const floor = RARITY_FLOOR[rarity];
+  const peak = ccPick(rng, STAT_NAMES);
+  let dump = ccPick(rng, STAT_NAMES);
+  while (dump === peak) dump = ccPick(rng, STAT_NAMES);
+
+  const stats = {} as Record<StatName, number>;
+  for (const name of STAT_NAMES) {
+    if (name === peak) {
+      stats[name] = Math.min(100, floor + 50 + Math.floor(rng() * 30));
+    } else if (name === dump) {
+      stats[name] = Math.max(1, floor - 10 + Math.floor(rng() * 15));
+    } else {
+      stats[name] = floor + Math.floor(rng() * 40);
+    }
+  }
+  return stats;
+}
+
+/**
+ * Replay Claude Code's original roll algorithm to get exact stats/rarity/eye
+ * for a rescued buddy. Uses CC's species/eyes/hats lists and ordering so the
+ * RNG consumption pattern matches exactly.
+ *
+ * Shells out to Bun for hash (CC runs on Bun → wyhash). Falls back to FNV-1a
+ * if Bun is not installed (stats will differ but rescue still works).
+ *
+ * Returns the CC-derived bones + engine used. Callers should override `species`
+ * with `deriveSpecies()` result (mapped to our canonical names) since CC used
+ * short names like 'blob' not 'Blob'.
+ */
+export function rollWithCCCompat(userId: string): { bones: CompanionBones; engine: 'bun' | 'fnv1a' } {
+  const key = userId + CC_SALT;
+  const { hash, engine } = ccHashString(key);
+  const rng = ccMulberry32(hash);
+
+  const rarity = ccRollRarity(rng);
+  const ccSpecies = ccPick(rng, CC_SPECIES);
+  const ccEye = ccPick(rng, CC_EYES);
+  const ccHat = rarity === 'common' ? 'none' : ccPick(rng, CC_HATS);
+  const shiny = rng() < 0.01;
+  const stats = ccRollStats(rng, rarity);
+
+  // Map CC eye '✦' to our '.' (sparkle eye is reserved in our system)
+  const eye = ccEye === '✦' ? '·' : ccEye;
+
+  return {
+    bones: {
+      rarity,
+      species: ccSpecies,  // CC short name — caller maps to canonical
+      eye,
+      hat: ccHat as any,
+      shiny,
+      stats,
+    },
+    engine,
+  };
 }


### PR DESCRIPTION
## Summary

- **Species from name:** `deriveSpecies()` now checks companion name for species keywords (e.g., "Grit**blob**" → Blob). Previously only checked personality text.
- **CC-compatible stats:** Added `rollWithCCCompat()` that shells out to Bun for wyhash (CC's runtime hash), reproducing exact original stats. Falls back to FNV-1a if Bun not installed.
- **Top-level userID:** `parseOldBuddy()` now pulls `userID` from top-level `.claude.json` (where CC stores it), not just from the companion sub-object.

Verified: Gritblob rescue now produces exact match — Blob species, `·` eye, DEBUGGING:24 PATIENCE:62 CHAOS:9 WISDOM:9 SNARK:42.

## Test plan

- [x] 488 tests pass
- [x] `rollWithCCCompat` with known CC userID produces exact stat match vs screenshot
- [x] Name-based species inference: "Gritblob" → Blob
- [ ] End-to-end: respawn → onboard → rescue Gritblob → verify species + stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)