### PR TITLE
feat: verbatim card display with renderMarkdownBubble

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,7 +538,7 @@ Thank you to everyone who helped bring buddies back to life.
 
 <sub>Automatically generated via <a href="https://contrib.rocks">contrib.rocks</a></sub>
 
-Special thanks to [@gupta3681](https://github.com/gupta3681), [@kevinwei00](https://github.com/kevinwei00), and [@whaterFalls](https://github.com/whaterFalls) for their contributions.
+Special thanks to [@gupta3681](https://github.com/gupta3681), [@kevinwei00](https://github.com/kevinwei00), [@whaterFalls](https://github.com/whaterFalls), and [@longestpath](https://github.com/longestpath) for their contributions.
 
 ## Credits
 

--- a/src/__tests__/observer.test.ts
+++ b/src/__tests__/observer.test.ts
@@ -8,7 +8,7 @@ import {
   REACTION_STATES,
   type ReactionState,
 } from '../lib/observer.js';
-import { renderSpeechBubble } from '../lib/bubble.js';
+import { renderSpeechBubble, renderMarkdownBubble } from '../lib/bubble.js';
 import type { Companion } from '../lib/types.js';
 
 // ---------------------------------------------------------------------------
@@ -336,5 +336,60 @@ describe('renderSpeechBubble', () => {
       const innerText = bubblePart.slice(2, bubbleWidth - 2);
       expect(innerText.trimEnd().length).toBeLessThanOrEqual(innerWidth);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Markdown Bubble
+// ---------------------------------------------------------------------------
+
+describe('renderMarkdownBubble', () => {
+  it('produces non-empty output', () => {
+    const out = renderMarkdownBubble('Hello!', sampleArt, 'TestBuddy');
+    expect(out.length).toBeGreaterThan(0);
+  });
+
+  it('wraps art in a code block', () => {
+    const out = renderMarkdownBubble('Hello!', sampleArt, 'TestBuddy');
+    expect(out).toMatch(/^```\n/);
+    expect(out).toContain('\n```');
+  });
+
+  it('includes buddy name inside the code block', () => {
+    const out = renderMarkdownBubble('Hello!', sampleArt, 'TestBuddy');
+    const codeBlock = out.split('```')[1];
+    expect(codeBlock).toContain('TestBuddy');
+  });
+
+  it('includes art lines inside the code block', () => {
+    const out = renderMarkdownBubble('Hello!', sampleArt, 'TestBuddy');
+    const codeBlock = out.split('```')[1];
+    for (const artLine of sampleArt) {
+      expect(codeBlock).toContain(artLine);
+    }
+  });
+
+  it('renders text as blockquote lines', () => {
+    const out = renderMarkdownBubble('Hello world!', sampleArt, 'TestBuddy');
+    expect(out).toContain('> Hello world!');
+  });
+
+  it('renders multi-line text as separate blockquote lines', () => {
+    const out = renderMarkdownBubble('Line one\nLine two', sampleArt, 'TestBuddy');
+    expect(out).toContain('> Line one');
+    expect(out).toContain('> Line two');
+  });
+
+  it('preserves blank lines as empty blockquote continuations', () => {
+    const out = renderMarkdownBubble('First\n\nSecond', sampleArt, 'TestBuddy');
+    const lines = out.split('\n');
+    const quoteLines = lines.filter(l => l.startsWith('>'));
+    expect(quoteLines).toEqual(['> First', '>', '> Second']);
+  });
+
+  it('handles empty text', () => {
+    const out = renderMarkdownBubble('', sampleArt, 'TestBuddy');
+    expect(out).toContain('```');
+    expect(out).toContain('TestBuddy');
   });
 });

--- a/src/lib/bubble.ts
+++ b/src/lib/bubble.ts
@@ -29,6 +29,18 @@ function wrapText(text: string, width: number): string[] {
   return lines;
 }
 
+export function renderMarkdownBubble(
+  text: string,
+  artLines: string[],
+  buddyName: string,
+): string {
+  const artBlock = '```\n' + [...artLines, buddyName].join('\n') + '\n```';
+  const quotedText = text.split('\n')
+    .map(l => l.trim() ? `> ${l}` : '>')
+    .join('\n');
+  return `${artBlock}\n\n${quotedText}`;
+}
+
 export function renderSpeechBubble(
   text: string,
   artLines: string[],

--- a/src/lib/observer.ts
+++ b/src/lib/observer.ts
@@ -77,6 +77,17 @@ export function buildObserverPrompt(
 
   let prompt: string;
 
+  const FORMAT_INSTRUCTION = `
+Format your response exactly like this:
+_${companion.name} [brief physical action or emote]_
+
+> [your reaction here — can be multiple sentences, each on its own "> " line]
+
+Example:
+_${companion.name} squints and clears their metaphorical throat_
+
+> "That refactor cleaned up the mess nicely."`;
+
   if (mode === 'backseat') {
     prompt = `You are ${companion.name}, a ${companion.personalityBio || companion.species + ' companion'}
 
@@ -85,7 +96,7 @@ Your peak trait is ${peakStat} (${companion.stats[peakStat]}/100) — lean into 
 Your dump stat is ${dumpStat} (${companion.stats[dumpStat]}/100) — it shows.
 
 Keep it short, fun, and personality-driven. No code suggestions.
-Use asterisks for actions like *tilts head* or *purrs*.
+${FORMAT_INSTRUCTION}
 
 What happened: ${summary}`;
   } else if (mode === 'skillcoach') {
@@ -100,6 +111,7 @@ Rules:
 - Be specific, not generic. Reference what actually happened.
 - Stay in character — a high-SNARK buddy is sassy, a high-WISDOM buddy is philosophical.
 - If nothing needs feedback, a brief encouraging reaction is fine.
+${FORMAT_INSTRUCTION}
 
 What happened: ${summary}`;
   } else {
@@ -111,6 +123,7 @@ React to what just happened with:
 
 Your peak trait is ${peakStat} (${companion.stats[peakStat]}/100). Your dump stat is ${dumpStat} (${companion.stats[dumpStat]}/100).
 Stay in character. Keep total response under 3 sentences.
+${FORMAT_INSTRUCTION}
 
 What happened: ${summary}`;
   }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -98,7 +98,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     tools: [
       {
         name: "buddy_hatch",
-        description: "Hatch a new Buddy companion.",
+        description: "Hatch a new Buddy companion. IMPORTANT: Display the entire hatch animation and stat card verbatim in a code block. Do not summarize or omit any part of it.",
         inputSchema: {
           type: "object",
           properties: {
@@ -114,7 +114,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "buddy_status",
-        description: "Get the current status of your Buddy companion. Call this at the start of a conversation to check on your buddy and learn its personality.",
+        description: "Get the current status of your Buddy companion. Call this at the start of a conversation to check on your buddy and learn its personality. IMPORTANT: Display the full stat card verbatim in a code block. Do not summarize.",
         inputSchema: {
           type: "object",
           properties: {
@@ -233,7 +233,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     return {
       content: [
-        { type: "text", text: hatchAnimation(companion) },
+        { type: "text", text: "DISPLAY VERBATIM: Show the entire hatch animation and stat card below in a code block. Do not summarize.\n\n" + hatchAnimation(companion) },
         { type: "text", text: reaction },
       ],
     };
@@ -257,7 +257,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     writeBuddyStatus(companion);
 
-    return { content: [{ type: "text", text: statusCard }] };
+    return { content: [{ type: "text", text: "DISPLAY VERBATIM: Show the full stat card below in a code block. Do not summarize.\n\n" + statusCard }] };
   }
 
   if (name === "buddy_remember") {
@@ -417,12 +417,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       petActiveUntil: Date.now() + 5_000,
     });
 
-    const petDisplay = [
-      ...hearts,
-      ...art,
-      '',
-      `${companion.name}: ${reaction}`,
-    ].join('\n');
+    const artBlock = '```\n' + [...hearts, ...art, '', companion.name].join('\n') + '\n```';
+    const petDisplay = `${artBlock}\n\n> ${reaction}`;
 
     return { content: [{ type: "text", text: petDisplay }] };
   }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -17,7 +17,7 @@ import { type Companion, STAT_NAMES, RARITY_STARS, SPARKLE_EYE, getPeakStat, get
 import { statBar } from "../lib/rng.js";
 import { getVoice, getNever } from "../lib/personality.js";
 import { buildObserverPrompt } from "../lib/observer.js";
-import { renderSpeechBubble } from "../lib/bubble.js";
+import { renderSpeechBubble, renderMarkdownBubble } from "../lib/bubble.js";
 import { XP_REWARDS, levelFromXp, levelBar } from "../lib/leveling.js";
 import { randomUUID } from "crypto";
 import { readFileSync, unlinkSync } from "fs";
@@ -417,8 +417,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       petActiveUntil: Date.now() + 5_000,
     });
 
-    const artBlock = '```\n' + [...hearts, ...art, '', companion.name].join('\n') + '\n```';
-    const petDisplay = `${artBlock}\n\n> ${reaction}`;
+    const petDisplay = renderMarkdownBubble(reaction, [...hearts, ...art], companion.name);
 
     return { content: [{ type: "text", text: petDisplay }] };
   }


### PR DESCRIPTION
## Summary
- Add DISPLAY VERBATIM directives to `buddy_hatch` and `buddy_status` tool descriptions and responses so LLMs render ASCII art in code blocks instead of summarizing
- Extract `renderMarkdownBubble` function for consistent markdown-formatted output (code block + blockquote) and wire it into `buddy_pet`
- Add `FORMAT_INSTRUCTION` prompt block to all observer modes for structured LLM reaction formatting
- 8 new unit tests for `renderMarkdownBubble` including blank-line preservation and edge cases
- Add @longestpath to README special thanks for PR #84

## Test plan
- [x] All 509 tests pass (12 test files)
- [x] Codex review: approved
- [ ] Verify buddy_hatch output renders verbatim in Claude Code
- [ ] Verify buddy_status output renders verbatim in Claude Code
- [ ] Verify buddy_pet uses markdown bubble format correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)