### PR TITLE
fix(rescue): prefer accountUuid over userID as CC-compat seed

### DIFF
--- a/src/__tests__/companion.test.ts
+++ b/src/__tests__/companion.test.ts
@@ -205,6 +205,27 @@ describe('rescueCompanion', () => {
     expect(row.user_id).toBe('override-win');
   });
 
+  it('prefers accountUuid over importResult.userId when both are present', () => {
+    rescueCompanion({
+      name: 'Dual',
+      species: 'Axolotl',
+      accountUuid: 'account-wins',
+      userId: 'userid-loses',
+    });
+    const row = db.prepare('SELECT user_id FROM companions LIMIT 1').get() as any;
+    expect(row.user_id).toBe('account-wins');
+  });
+
+  it('sets cc_rescue when only accountUuid is present', () => {
+    rescueCompanion({
+      name: 'UuidOnly',
+      species: 'Ghost',
+      accountUuid: 'uuid-cc-origin',
+    });
+    const row = db.prepare('SELECT cc_rescue FROM companions LIMIT 1').get() as any;
+    expect(row.cc_rescue).toBe(1);
+  });
+
   it('rescues a buddy with no species (rolls one from bones)', () => {
     const { companion } = rescueCompanion({ name: 'Speciesless' });
     expect(SPECIES_LIST).toContain(companion.species);

--- a/src/lib/companion.ts
+++ b/src/lib/companion.ts
@@ -150,14 +150,14 @@ export function rescueCompanion(importResult: {
   user_id?: string;
 }, opts: { userId?: string } = {}): { companion: Companion; id: string } {
   const userId = opts.userId
+    || importResult.accountUuid
     || importResult.userId
     || importResult.user_id
-    || importResult.accountUuid
     || `imported-${importResult.name}`;
 
-  // Use CC-compatible roll to reproduce exact stats/rarity/eye from the
-  // original Claude Code buddy. Falls back to our roll() if no CC userId.
-  const hasCCUserId = !!(importResult.userId || importResult.user_id);
+  const hasCCUserId = !!(
+    importResult.accountUuid || importResult.userId || importResult.user_id
+  );
   const ccResult = hasCCUserId ? rollWithCCCompat(userId) : null;
   const bones = ccResult ? ccResult.bones : roll(userId, SPECIES_LIST).bones;
 


### PR DESCRIPTION
Hello 👋 Ran into this when rescuing my buddy, preferring the UUID as seed got the stats to match the screenshot I had from when it first generated exactly.

Auto description with change details:

rescueCompanion's seed ladder picks importResult.userId before importResult.accountUuid. When both are present (the normal shape of ~/.claude.json), rollWithCCCompat runs off the wrong field and produces a rescued card with different rarity, eye, hat, and stats than the original Claude Code hatch card.

Reorder the ladder so accountUuid wins over importResult.userId. Explicit opts.userId still takes precedence so callers can override.

Also broaden hasCCUserId: a rescue record with only accountUuid (no userID) is still CC-originated, and should set cc_rescue=1 so subsequent loadCompanion reads keep using rollWithCCCompat rather than falling through to the default roll.

Two tests added:
  - priority between importResult.userId and importResult.accountUuid
  - cc_rescue is set when only accountUuid is present

Repro: rescued buddy with accountUuid seed produced exact match of the screenshotted original card (rare axolotl, eye=×, hat=tophat, 5/5 stats). With the current main-branch seed priority, 4 of 5 stats drift.