### PR TITLE
feat: add Stop and UserPromptSubmit hooks for robust automatic reactions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -73,6 +73,8 @@ configure_claude_code() {
   local settings_file="$config_dir/settings.json"
   local user_file="$HOME/.claude.json"
   local hook_path="$INSTALL_DIR/dist/hooks/post-tool-handler.js"
+  local stop_hook_path="$INSTALL_DIR/dist/hooks/stop-handler.js"
+  local prompt_hook_path="$INSTALL_DIR/dist/hooks/prompt-handler.js"
   local statusline_command="node $INSTALL_DIR/dist/statusline-wrapper.js"
 
   mkdir -p "$config_dir"
@@ -120,25 +122,28 @@ EOJS
   # Configure hook + statusline in a single settings.json write
   if command -v node &> /dev/null; then
     local settings_result
-    settings_result=$(CLAUDE_SETTINGS="$settings_file" HOOK_COMMAND="node $hook_path" STATUSLINE_COMMAND="$statusline_command" node <<'EOJS'
+    settings_result=$(CLAUDE_SETTINGS="$settings_file" HOOK_COMMAND="node $hook_path" STOP_HOOK_COMMAND="node $stop_hook_path" PROMPT_HOOK_COMMAND="node $prompt_hook_path" STATUSLINE_COMMAND="$statusline_command" node <<'EOJS'
 const fs = require('fs');
 const settingsPath = process.env.CLAUDE_SETTINGS;
 const hookCommand = process.env.HOOK_COMMAND;
+const stopHookCommand = process.env.STOP_HOOK_COMMAND;
+const promptHookCommand = process.env.PROMPT_HOOK_COMMAND;
 const statuslineCommand = process.env.STATUSLINE_COMMAND;
 let config = {};
 try { config = JSON.parse(fs.readFileSync(settingsPath, 'utf-8')); } catch {}
 let changed = false;
 const result = [];
 
-// Hook
 if (!config.hooks) config.hooks = {};
+
+// PostToolUse — error detection (Bash only)
 if (!Array.isArray(config.hooks.PostToolUse)) config.hooks.PostToolUse = [];
-const hasHook = config.hooks.PostToolUse.some(entry =>
+const hasPostHook = config.hooks.PostToolUse.some(entry =>
   entry.matcher === 'Bash' &&
   Array.isArray(entry.hooks) &&
   entry.hooks.some(h => h.command === hookCommand)
 );
-if (!hasHook) {
+if (!hasPostHook) {
   config.hooks.PostToolUse.push({
     matcher: 'Bash',
     hooks: [{ type: 'command', command: hookCommand, async: true, timeout: 3 }]
@@ -147,6 +152,38 @@ if (!hasHook) {
   result.push('hook:updated');
 } else {
   result.push('hook:noop');
+}
+
+// Stop — task-completion reactions
+if (!Array.isArray(config.hooks.Stop)) config.hooks.Stop = [];
+const hasStopHook = config.hooks.Stop.some(entry =>
+  Array.isArray(entry.hooks) &&
+  entry.hooks.some(h => h.command === stopHookCommand)
+);
+if (!hasStopHook) {
+  config.hooks.Stop.push({
+    hooks: [{ type: 'command', command: stopHookCommand, async: true, timeout: 5 }]
+  });
+  changed = true;
+  result.push('stop:updated');
+} else {
+  result.push('stop:noop');
+}
+
+// UserPromptSubmit — name + mood reactions
+if (!Array.isArray(config.hooks.UserPromptSubmit)) config.hooks.UserPromptSubmit = [];
+const hasPromptHook = config.hooks.UserPromptSubmit.some(entry =>
+  Array.isArray(entry.hooks) &&
+  entry.hooks.some(h => h.command === promptHookCommand)
+);
+if (!hasPromptHook) {
+  config.hooks.UserPromptSubmit.push({
+    hooks: [{ type: 'command', command: promptHookCommand, async: true, timeout: 3 }]
+  });
+  changed = true;
+  result.push('prompt:updated');
+} else {
+  result.push('prompt:noop');
 }
 
 // Statusline
@@ -171,6 +208,14 @@ EOJS
     case "$settings_result" in
       *hook:updated*) echo -e "  ${GREEN}✓${NC} PostToolUse hook configured" ;;
       *)              echo -e "  ${GREEN}✓${NC} PostToolUse hook already configured" ;;
+    esac
+    case "$settings_result" in
+      *stop:updated*) echo -e "  ${GREEN}✓${NC} Stop hook configured" ;;
+      *)              echo -e "  ${GREEN}✓${NC} Stop hook already configured" ;;
+    esac
+    case "$settings_result" in
+      *prompt:updated*) echo -e "  ${GREEN}✓${NC} UserPromptSubmit hook configured" ;;
+      *)                echo -e "  ${GREEN}✓${NC} UserPromptSubmit hook already configured" ;;
     esac
     case "$settings_result" in
       *statusline:updated*) echo -e "  ${GREEN}✓${NC} Claude Code statusline configured" ;;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,20 @@
 {
   "name": "@fiorastudio/buddy",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fiorastudio/buddy",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "better-sqlite3": "^12.8.0"
       },
       "bin": {
+        "buddy-doctor": "dist/cli/doctor-cli.js",
+        "buddy-onboard": "dist/cli/onboard.js",
         "buddy-statusline": "dist/statusline-wrapper.js"
       },
       "devDependencies": {

--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -5,7 +5,7 @@ describe('Doctor — runDiagnostics', () => {
   it('returns an array of checks', () => {
     const checks = runDiagnostics();
     expect(Array.isArray(checks)).toBe(true);
-    expect(checks.length).toBe(15);
+    expect(checks.length).toBe(17);
   });
 
   it('every check has required fields', () => {
@@ -86,7 +86,7 @@ describe('Doctor — formatReport', () => {
   it('includes check count in header', () => {
     const checks = runDiagnostics();
     const report = formatReport(checks);
-    expect(report).toContain('15 checks:');
+    expect(report).toContain('17 checks:');
   });
 
   it('includes ISO timestamp', () => {

--- a/src/__tests__/prompt-handler.test.ts
+++ b/src/__tests__/prompt-handler.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { writeFileSync, readFileSync, mkdirSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  FRUSTRATION_REGEX,
+  EXCITEMENT_REGEX,
+  handlePromptSubmit,
+  type PromptInput,
+} from '../hooks/prompt-handler.js';
+
+// ---------------------------------------------------------------------------
+// FRUSTRATION_REGEX
+// ---------------------------------------------------------------------------
+
+describe('FRUSTRATION_REGEX', () => {
+  it('matches "wtf"', () => {
+    expect(FRUSTRATION_REGEX.test("wtf is happening here")).toBe(true);
+  });
+  it('matches "not working"', () => {
+    expect(FRUSTRATION_REGEX.test("this is not working again")).toBe(true);
+  });
+  it('matches "still broken"', () => {
+    expect(FRUSTRATION_REGEX.test("It's still broken")).toBe(true);
+  });
+  it('matches "I\'m stuck"', () => {
+    expect(FRUSTRATION_REGEX.test("I'm stuck on this for hours")).toBe(true);
+  });
+  it('matches "so frustrated"', () => {
+    expect(FRUSTRATION_REGEX.test("I'm so frustrated with this")).toBe(true);
+  });
+  it('does not match normal messages', () => {
+    expect(FRUSTRATION_REGEX.test("Can you help me refactor this function?")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EXCITEMENT_REGEX
+// ---------------------------------------------------------------------------
+
+describe('EXCITEMENT_REGEX', () => {
+  it('matches "nailed it"', () => {
+    expect(EXCITEMENT_REGEX.test("we nailed it!")).toBe(true);
+  });
+  it('matches "it\'s working!"', () => {
+    expect(EXCITEMENT_REGEX.test("it's working!")).toBe(true);
+  });
+  it('matches "finally!"', () => {
+    expect(EXCITEMENT_REGEX.test("finally!")).toBe(true);
+  });
+  it('matches "shipped it"', () => {
+    expect(EXCITEMENT_REGEX.test("shipped it to prod")).toBe(true);
+  });
+  it('does not match neutral messages', () => {
+    expect(EXCITEMENT_REGEX.test("Can you look at this function?")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handlePromptSubmit integration
+// ---------------------------------------------------------------------------
+
+describe('handlePromptSubmit', () => {
+  let statusPath: string;
+
+  const baseStatus = {
+    name: 'Pixel',
+    species: 'Mushroom',
+    level: 3,
+    xp: 42,
+    mood: 'happy',
+  };
+
+  beforeEach(() => {
+    const dir = join(tmpdir(), 'buddy-prompt-test-' + Date.now());
+    mkdirSync(dir, { recursive: true });
+    statusPath = join(dir, 'buddy-status.json');
+    writeFileSync(statusPath, JSON.stringify(baseStatus));
+  });
+
+  afterEach(() => {
+    try { unlinkSync(statusPath); } catch { /* cleanup */ }
+  });
+
+  it('returns "name" and writes excited reaction when buddy name is mentioned', () => {
+    const input: PromptInput = { prompt: "Hey Pixel, what do you think?" };
+    const result = handlePromptSubmit(input, statusPath);
+    expect(result).toBe('name');
+
+    const status = JSON.parse(readFileSync(statusPath, 'utf-8'));
+    expect(status.reaction).toBe('excited');
+    expect(status.reaction_eye).toBe('^');
+    expect(status.reaction_expires).toBeGreaterThan(Date.now());
+  });
+
+  it('name detection is case-insensitive', () => {
+    const input: PromptInput = { prompt: "pixel, wake up!" };
+    expect(handlePromptSubmit(input, statusPath)).toBe('name');
+  });
+
+  it('does not match name as substring of another word', () => {
+    const input: PromptInput = { prompt: "I need to fix the pixelation issue" };
+    // "Pixel" is embedded in "pixelation" — word boundary should prevent match
+    // but "Pixelation" starts with "Pixel" — depends on word boundary position
+    // This will match because \bPixel\b at the start of "pixelation" is not a boundary
+    // Let's just verify it behaves consistently — no assertion on outcome needed
+    // since the regex uses word boundaries (\b)
+    const result = handlePromptSubmit(input, statusPath);
+    // "pixelation" — \bPixel\b: 'P' is word char, preceding 'I' in "fix the " is space → \b before P
+    // but after 'l' comes 'a' (word char) → no \b after 'l'. So \bPixel\b should NOT match.
+    expect(result).toBe(false);
+  });
+
+  it('returns "frustration" on frustrated prompt', () => {
+    const input: PromptInput = { prompt: "wtf is going on with this build" };
+    const result = handlePromptSubmit(input, statusPath);
+    expect(result).toBe('frustration');
+
+    const status = JSON.parse(readFileSync(statusPath, 'utf-8'));
+    expect(status.reaction).toBe('concerned');
+    expect(status.reaction_eye).toBe('.');
+  });
+
+  it('returns "excitement" on excited prompt', () => {
+    const input: PromptInput = { prompt: "we finally got it working!" };
+    const result = handlePromptSubmit(input, statusPath);
+    expect(result).toBe('excitement');
+
+    const status = JSON.parse(readFileSync(statusPath, 'utf-8'));
+    expect(status.reaction).toBe('happy');
+  });
+
+  it('name takes priority over frustration', () => {
+    const input: PromptInput = { prompt: "Pixel wtf, this is still broken" };
+    expect(handlePromptSubmit(input, statusPath)).toBe('name');
+  });
+
+  it('returns false for neutral prompt', () => {
+    const input: PromptInput = { prompt: "Can you refactor this function?" };
+    expect(handlePromptSubmit(input, statusPath)).toBe(false);
+  });
+
+  it('reads prompt from "message" field if "prompt" absent', () => {
+    const input: PromptInput = { message: "wtf is happening" };
+    expect(handlePromptSubmit(input, statusPath)).toBe('frustration');
+  });
+
+  it('reads prompt from "user_message" field as final fallback', () => {
+    const input: PromptInput = { user_message: "we nailed it!" };
+    expect(handlePromptSubmit(input, statusPath)).toBe('excitement');
+  });
+
+  it('does NOT overwrite active reaction', () => {
+    const status = JSON.parse(readFileSync(statusPath, 'utf-8'));
+    status.reaction = 'excited';
+    status.reaction_text = 'existing!';
+    status.reaction_expires = Date.now() + 30_000;
+    writeFileSync(statusPath, JSON.stringify(status));
+
+    const input: PromptInput = { prompt: "wtf broken again" };
+    handlePromptSubmit(input, statusPath);
+
+    const updated = JSON.parse(readFileSync(statusPath, 'utf-8'));
+    expect(updated.reaction_text).toBe('existing!');
+  });
+
+  it('handles missing status file gracefully', () => {
+    const input: PromptInput = { prompt: "wtf" };
+    expect(() => handlePromptSubmit(input, '/tmp/nonexistent-buddy-prompt-test.json')).not.toThrow();
+  });
+
+  it('returns false for empty prompt', () => {
+    expect(handlePromptSubmit({ prompt: '' }, statusPath)).toBe(false);
+    expect(handlePromptSubmit({}, statusPath)).toBe(false);
+  });
+});

--- a/src/__tests__/stop-handler.test.ts
+++ b/src/__tests__/stop-handler.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { writeFileSync, readFileSync, mkdirSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  COMPLETION_REGEX,
+  ONGOING_REGEX,
+  handleStop,
+  writeCompletionReaction,
+  type StopInput,
+} from '../hooks/stop-handler.js';
+
+// ---------------------------------------------------------------------------
+// COMPLETION_REGEX
+// ---------------------------------------------------------------------------
+
+describe('COMPLETION_REGEX', () => {
+  describe('true positives', () => {
+    it('matches "I have implemented"', () => {
+      expect(COMPLETION_REGEX.test("I have implemented the feature")).toBe(true);
+    });
+    it('matches "I\'ve fixed"', () => {
+      expect(COMPLETION_REGEX.test("I've fixed the null pointer bug")).toBe(true);
+    });
+    it('matches "tests pass"', () => {
+      expect(COMPLETION_REGEX.test("All tests pass now")).toBe(true);
+    });
+    it('matches "tests passed"', () => {
+      expect(COMPLETION_REGEX.test("The tests passed after the refactor")).toBe(true);
+    });
+    it('matches "successfully deployed"', () => {
+      expect(COMPLETION_REGEX.test("I've successfully deployed the service")).toBe(true);
+    });
+    it('matches "build succeeded"', () => {
+      expect(COMPLETION_REGEX.test("The build succeeded with no warnings")).toBe(true);
+    });
+    it('matches "I\'ve committed"', () => {
+      expect(COMPLETION_REGEX.test("I've committed the changes")).toBe(true);
+    });
+    it('matches "the fix is in place"', () => {
+      expect(COMPLETION_REGEX.test("The fix is in place and working")).toBe(true);
+    });
+  });
+
+  describe('false positives — should NOT match', () => {
+    it('rejects "I will implement"', () => {
+      expect(COMPLETION_REGEX.test("I will implement this next")).toBe(false);
+    });
+    it('rejects "implementing"', () => {
+      expect(COMPLETION_REGEX.test("I am implementing the feature")).toBe(false);
+    });
+    it('rejects "tests are failing"', () => {
+      expect(COMPLETION_REGEX.test("The tests are failing right now")).toBe(false);
+    });
+    it('rejects short planning sentence', () => {
+      expect(COMPLETION_REGEX.test("Let me check the error")).toBe(false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ONGOING_REGEX
+// ---------------------------------------------------------------------------
+
+describe('ONGOING_REGEX', () => {
+  it('matches "I\'ll "', () => {
+    expect(ONGOING_REGEX.test("I'll look into this")).toBe(true);
+  });
+  it('matches "Let me "', () => {
+    expect(ONGOING_REGEX.test("Let me read the file first")).toBe(true);
+  });
+  it('matches "I\'m going to"', () => {
+    expect(ONGOING_REGEX.test("I'm going to refactor this")).toBe(true);
+  });
+  it('does not match completion sentences', () => {
+    expect(ONGOING_REGEX.test("I've implemented the feature")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleStop integration
+// ---------------------------------------------------------------------------
+
+describe('handleStop', () => {
+  let statusPath: string;
+
+  const baseStatus = {
+    name: 'TestBuddy',
+    species: 'Mushroom',
+    level: 3,
+    xp: 42,
+    mood: 'happy',
+  };
+
+  beforeEach(() => {
+    const dir = join(tmpdir(), 'buddy-stop-test-' + Date.now());
+    mkdirSync(dir, { recursive: true });
+    statusPath = join(dir, 'buddy-status.json');
+    writeFileSync(statusPath, JSON.stringify(baseStatus));
+  });
+
+  afterEach(() => {
+    try { unlinkSync(statusPath); } catch { /* cleanup */ }
+  });
+
+  it('writes excited reaction when last_assistant_message has completion signal', () => {
+    const input: StopInput = {
+      last_assistant_message: "I've implemented the authentication module and all tests pass.",
+    };
+    const result = handleStop(input, statusPath);
+    expect(result).toBe(true);
+
+    const status = JSON.parse(readFileSync(statusPath, 'utf-8'));
+    expect(status.reaction).toBe('excited');
+    expect(status.reaction_eye).toBe('^');
+    expect(status.reaction_expires).toBeGreaterThan(Date.now());
+    expect(status.name).toBe('TestBuddy');
+  });
+
+  it('does NOT fire when message is too short', () => {
+    const input: StopInput = { last_assistant_message: "Done." };
+    expect(handleStop(input, statusPath)).toBe(false);
+  });
+
+  it('does NOT fire on ongoing work', () => {
+    const input: StopInput = {
+      last_assistant_message: "I'll implement this feature by modifying the auth module and running the tests afterwards.",
+    };
+    expect(handleStop(input, statusPath)).toBe(false);
+  });
+
+  it('does NOT fire when no completion signal', () => {
+    const input: StopInput = {
+      last_assistant_message: "Here is a long explanation of why this approach is better than the alternatives we discussed earlier.",
+    };
+    expect(handleStop(input, statusPath)).toBe(false);
+  });
+
+  it('does NOT overwrite active reaction', () => {
+    const status = JSON.parse(readFileSync(statusPath, 'utf-8'));
+    status.reaction = 'concerned';
+    status.reaction_text = 'uh oh';
+    status.reaction_expires = Date.now() + 30_000;
+    writeFileSync(statusPath, JSON.stringify(status));
+
+    const input: StopInput = {
+      last_assistant_message: "I've fixed the bug and all tests pass now successfully.",
+    };
+    expect(handleStop(input, statusPath)).toBe(false);
+
+    const updated = JSON.parse(readFileSync(statusPath, 'utf-8'));
+    expect(updated.reaction).toBe('concerned');
+  });
+
+  it('handles missing status file gracefully', () => {
+    const input: StopInput = {
+      last_assistant_message: "I've implemented the feature and tests are passing.",
+    };
+    expect(handleStop(input, '/tmp/nonexistent-buddy-stop-test.json')).toBe(false);
+  });
+
+  it('handles missing input gracefully', () => {
+    expect(handleStop({}, statusPath)).toBe(false);
+  });
+});

--- a/src/hooks/prompt-handler.ts
+++ b/src/hooks/prompt-handler.ts
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+// src/hooks/prompt-handler.ts
+//
+// UserPromptSubmit hook handler for Buddy MCP.
+// Fires before Claude processes the user's message.
+// Detects buddy-name mentions and mood signals; writes a statusline reaction.
+// Zero token cost — purely pattern-matching and file I/O.
+//
+// Pure Node.js — only fs imports.
+
+import { readFileSync, writeFileSync } from "fs";
+import { BUDDY_STATUS_PATH } from "../lib/constants.js";
+
+export const FRUSTRATION_REGEX =
+  /\b(?:wtf|ugh+|argh+|grr+|not working|doesn['']t work|still broken|why (?:is|won['']t|doesn['']t)|this is (?:so |still )?broken|i['']m stuck|stuck on this|can['']t figure|so frustrated)\b/i;
+
+export const EXCITEMENT_REGEX =
+  /\b(?:awesome|nailed it|love it|works?!|(?:it['']?s? )?working!|finally!|hell yeah|let['']s (?:go|ship)|shipped it|we did it)(?!\w)/i;
+
+const FRUSTRATION_REACTIONS = [
+  "hey, let's figure this out together",
+  "ugh, debugging again... I'm here",
+  "something's being tricky. let's get it",
+  "don't worry, we'll crack it",
+];
+
+const EXCITEMENT_REACTIONS = [
+  "yes!! great energy",
+  "that's the good stuff!",
+  "love when things click",
+  "let's keep that momentum",
+];
+
+const NAME_REACTIONS = [
+  "you called~?",
+  "hm? oh hi!",
+  "yeah?",
+  "present!",
+  "listening...",
+];
+
+export interface PromptInput {
+  session_id?: string;
+  // Claude Code may use any of these field names across versions.
+  prompt?: string;
+  message?: string;
+  user_message?: string;
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function writeReaction(
+  statusPath: string,
+  reaction: string,
+  text: string,
+  eye: string,
+  indicator: string,
+  expiryMs: number
+): boolean {
+  try {
+    const raw = readFileSync(statusPath, "utf-8");
+    const status = JSON.parse(raw);
+    if (!status?.name) return false;
+
+    // Single-pass race protection.
+    if (status.reaction_expires && status.reaction_expires > Date.now()) return false;
+
+    status.reaction = reaction;
+    status.reaction_text = text;
+    status.reaction_expires = Date.now() + expiryMs;
+    status.reaction_eye = eye;
+    status.reaction_indicator = indicator;
+
+    writeFileSync(statusPath, JSON.stringify(status));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function handlePromptSubmit(
+  input: PromptInput,
+  statusPath: string = BUDDY_STATUS_PATH
+): "name" | "frustration" | "excitement" | false {
+  const prompt = (input.prompt ?? input.message ?? input.user_message ?? "").trim();
+  if (!prompt) return false;
+
+  let buddyName: string | undefined;
+  try {
+    buddyName = JSON.parse(readFileSync(statusPath, "utf-8"))?.name;
+  } catch { /* status file may not exist yet */ }
+
+  // Name mention — highest priority, very short TTL so it doesn't linger.
+  if (buddyName) {
+    const nameRe = new RegExp(`\\b${escapeRegex(buddyName)}\\b`, "i");
+    if (nameRe.test(prompt)) {
+      const text = NAME_REACTIONS[Math.floor(Date.now() / 1000) % NAME_REACTIONS.length];
+      writeReaction(statusPath, "excited", text, "^", "!", 8_000);
+      return "name";
+    }
+  }
+
+  if (FRUSTRATION_REGEX.test(prompt)) {
+    const text = FRUSTRATION_REACTIONS[Math.floor(Date.now() / 1000) % FRUSTRATION_REACTIONS.length];
+    writeReaction(statusPath, "concerned", text, ".", "~", 12_000);
+    return "frustration";
+  }
+
+  if (EXCITEMENT_REGEX.test(prompt)) {
+    const text = EXCITEMENT_REACTIONS[Math.floor(Date.now() / 1000) % EXCITEMENT_REACTIONS.length];
+    writeReaction(statusPath, "happy", text, "^", "!", 10_000);
+    return "excitement";
+  }
+
+  return false;
+}
+
+// --- CLI entry point ---
+const isDirectRun = process.argv[1]?.includes("prompt-handler");
+if (isDirectRun) {
+  try {
+    const stdin = readFileSync(0, "utf-8");
+    const input: PromptInput = JSON.parse(stdin);
+    handlePromptSubmit(input);
+  } catch {
+    // Silent failure — hooks must never crash the host.
+  }
+}

--- a/src/hooks/stop-handler.ts
+++ b/src/hooks/stop-handler.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// src/hooks/stop-handler.ts
+//
+// Stop hook handler for Buddy MCP.
+// Fires after every Claude response. Detects task-completion signals
+// and writes an encouraging statusline reaction — zero token cost.
+//
+// Pure Node.js — only fs imports.
+
+import { readFileSync, writeFileSync } from "fs";
+import { BUDDY_STATUS_PATH } from "../lib/constants.js";
+
+// Conservative completion signals — require explicit past-tense "done" phrasing.
+// Avoids firing on planning sentences like "I'll implement..." or mid-task narration.
+export const COMPLETION_REGEX =
+  /\b(?:I(?:'ve| have) (?:implemented|added|created|updated|fixed|refactored|written|deployed|pushed|committed|completed|finished)|(?:all )?tests? (?:pass(?:ed|ing)?|are passing)|(?:the )?(?:fix|change|implementation) is (?:in place|complete|done)|successfully (?:deployed|committed|pushed|built)|(?:build|compilation) (?:succeeded|passed))\b/i;
+
+// Bail if the response looks like ongoing work rather than completion.
+export const ONGOING_REGEX =
+  /^(?:I'?ll |Let me |I (?:need to|should|will|can)|Looking at|Checking|Reading|I'm (?:going to|working on|looking at))/i;
+
+const COMPLETION_REACTIONS = [
+  "ooh, new code! let me have a look...",
+  "nice work! shipping things...",
+  "that looks solid",
+  "progress! the bits are flying",
+  "task complete~",
+  "committed? good.",
+];
+
+export interface StopInput {
+  session_id?: string;
+  transcript_path?: string;
+  stop_hook_active?: boolean;
+  // Some Claude Code builds surface this directly; fall back to transcript otherwise.
+  last_assistant_message?: string;
+}
+
+function extractLastMessage(input: StopInput): string {
+  if (input.last_assistant_message) return input.last_assistant_message;
+
+  if (!input.transcript_path) return "";
+  try {
+    const raw = readFileSync(input.transcript_path, "utf-8");
+    const lines = raw.trim().split("\n").filter(Boolean);
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const entry = JSON.parse(lines[i]);
+      // Handle both flat {role, content} and nested {type, message} transcript formats
+      const role = entry.role ?? entry.message?.role;
+      const content = entry.content ?? entry.message?.content;
+      if (role !== "assistant" || !content) continue;
+      if (typeof content === "string") return content;
+      if (Array.isArray(content)) {
+        return content
+          .filter((c: { type?: string }) => c.type === "text")
+          .map((c: { text?: string }) => c.text ?? "")
+          .join(" ");
+      }
+    }
+  } catch { /* silent — transcript may not exist yet */ }
+  return "";
+}
+
+export function writeCompletionReaction(statusPath: string = BUDDY_STATUS_PATH, expiryMs: number = 15_000): boolean {
+  try {
+    const raw = readFileSync(statusPath, "utf-8");
+    const status = JSON.parse(raw);
+    if (!status?.name) return false;
+
+    // Single-pass race protection: don't overwrite an active reaction.
+    if (status.reaction_expires && status.reaction_expires > Date.now()) return false;
+
+    const reaction = COMPLETION_REACTIONS[Math.floor(Date.now() / 1000) % COMPLETION_REACTIONS.length];
+    status.reaction = "excited";
+    status.reaction_text = reaction;
+    status.reaction_expires = Date.now() + expiryMs;
+    status.reaction_eye = "^";
+    status.reaction_indicator = "!";
+    // No bubble_lines — hook reactions are statusline-only to keep them lightweight.
+
+    writeFileSync(statusPath, JSON.stringify(status));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function handleStop(input: StopInput, statusPath: string = BUDDY_STATUS_PATH): boolean {
+  const message = extractLastMessage(input);
+  // Skip very short responses — unlikely to be a task completion turn.
+  if (!message || message.length < 60) return false;
+  if (ONGOING_REGEX.test(message)) return false;
+  if (!COMPLETION_REGEX.test(message)) return false;
+
+  return writeCompletionReaction(statusPath);
+}
+
+// --- CLI entry point ---
+const isDirectRun = process.argv[1]?.includes("stop-handler");
+if (isDirectRun) {
+  try {
+    const stdin = readFileSync(0, "utf-8");
+    const input: StopInput = JSON.parse(stdin);
+    handleStop(input);
+  } catch {
+    // Silent failure — hooks must never crash the host.
+  }
+}

--- a/src/lib/doctor.ts
+++ b/src/lib/doctor.ts
@@ -265,6 +265,34 @@ function checkHooks(): DiagnosticCheck {
   return { id: 'config.hooks', status: 'ok', label: 'Hooks', detail: '\u2713 PostToolUse hook present' };
 }
 
+function checkStopHook(): DiagnosticCheck {
+  const settingsPath = join(homedir(), '.claude', 'settings.json');
+  const settings = readJsonSafe(settingsPath);
+  const hooks: any[] = Array.isArray(settings?.hooks?.Stop) ? settings.hooks.Stop : [];
+  const has = hooks.some((entry: any) =>
+    Array.isArray(entry.hooks) &&
+    entry.hooks.some((h: any) => h.command && h.command.includes('stop-handler'))
+  );
+  if (!has) {
+    return { id: 'config.hooks.stop', status: 'warn', label: 'Stop hook', detail: '\u2717 stop-handler not found', suggestion: 'Re-run install script to configure hooks' };
+  }
+  return { id: 'config.hooks.stop', status: 'ok', label: 'Stop hook', detail: '\u2713 Stop hook present' };
+}
+
+function checkPromptHook(): DiagnosticCheck {
+  const settingsPath = join(homedir(), '.claude', 'settings.json');
+  const settings = readJsonSafe(settingsPath);
+  const hooks: any[] = Array.isArray(settings?.hooks?.UserPromptSubmit) ? settings.hooks.UserPromptSubmit : [];
+  const has = hooks.some((entry: any) =>
+    Array.isArray(entry.hooks) &&
+    entry.hooks.some((h: any) => h.command && h.command.includes('prompt-handler'))
+  );
+  if (!has) {
+    return { id: 'config.hooks.prompt', status: 'warn', label: 'Prompt hook', detail: '\u2717 prompt-handler not found', suggestion: 'Re-run install script to configure hooks' };
+  }
+  return { id: 'config.hooks.prompt', status: 'ok', label: 'Prompt hook', detail: '\u2713 UserPromptSubmit hook present' };
+}
+
 function checkPromptInjection(): DiagnosticCheck {
   const claudeMdPath = join(homedir(), '.claude', 'CLAUDE.md');
   const content = readTextSafe(claudeMdPath);
@@ -298,6 +326,8 @@ export function runDiagnostics(): DiagnosticCheck[] {
     checkStatusline(),
     checkStatuslineRefresh(),
     checkHooks(),
+    checkStopHook(),
+    checkPromptHook(),
     checkPromptInjection(),
   ];
 }


### PR DESCRIPTION
Adds two new hook handlers that fire without relying on CLAUDE.md prompt
injection, matching the hook coverage of competing implementations:

- stop-handler.ts: fires after each Claude response, detects task-completion
  signals via regex, writes an encouraging statusline reaction (15s TTL).
  Zero token cost — no LLM calls, pure pattern-matching and file I/O.

- prompt-handler.ts: fires before each user message, detects buddy name
  mentions (highest priority), frustration keywords, and excitement signals.
  Writes a matching mood reaction to the statusline (8-12s TTL).

Both hooks are async with short timeouts so they never block the host.
install.sh registers all three hook types (PostToolUse, Stop,
UserPromptSubmit) in a single settings.json write. doctor.ts now checks
for all three hook types and reports their status in diagnostics.

545 tests passing.

https://claude.ai/code/session_01XanC2TkW5Czf4QC5gbjxdi