### PR TITLE
Add non-Claude host hook auto-configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,12 @@ The installer:
 3. Auto-configures supported CLI clients when detected
 4. Injects Buddy instructions into supported terminal prompts where applicable
 
+Current integration details vary by host:
+
+- Claude Code: Buddy auto-configures MCP, statusline, and Claude hook wiring.
+- Codex CLI: Buddy configures MCP, writes a `PostToolUse` hook in `~/.codex/hooks.json`, and injects prompt instructions into `~/.codex/AGENTS.md` or `~/.codex/instructions.md`.
+- GitHub Copilot CLI: Buddy configures MCP, writes a user-level `postToolUse` hook in `~/.copilot/settings.json`, and injects prompt instructions into `~/.copilot/AGENTS.md` or `~/.copilot/copilot-instructions.md`.
+- Cursor CLI: Buddy configures MCP in `~/.cursor/mcp.json`, writes an `afterShellExecution` hook in `~/.cursor/hooks.json`, and injects prompt instructions into `~/.cursor/rules/buddy.md`.
 If you prefer to install from source:
 
 ```bash
@@ -775,5 +781,4 @@ Learn more about the mission to rescue Buddy and the engineering behind the scen
 ## License
 
 MIT. This project is licensed under the MIT License. See [LICENSE](LICENSE). You are free to use, host, and monetize this project (you must credit this project in case of distribution and monetization).
-
 

--- a/install.ps1
+++ b/install.ps1
@@ -207,9 +207,118 @@ if (Test-Path "$env:USERPROFILE\.cursor") {
   Add-BuddyToConfig "$env:USERPROFILE\.cursor\mcp.json" "Cursor"
 }
 
+$cursorHooks = "$env:USERPROFILE\.cursor\hooks.json"
+if (Test-Path "$env:USERPROFILE\.cursor") {
+  $cursorConfig = @{}
+  if (Test-Path $cursorHooks) {
+    try { $cursorConfig = Get-Content $cursorHooks -Raw | ConvertFrom-Json }
+    catch { $cursorConfig = @{} }
+  }
+  if (!$cursorConfig.version) {
+    $cursorConfig | Add-Member -NotePropertyName "version" -NotePropertyValue 1 -Force
+  }
+  if (!$cursorConfig.hooks) {
+    $cursorConfig | Add-Member -NotePropertyName "hooks" -NotePropertyValue @{} -Force
+  }
+  if (!$cursorConfig.hooks.afterShellExecution) {
+    $cursorConfig.hooks | Add-Member -NotePropertyName "afterShellExecution" -NotePropertyValue @() -Force
+  }
+  $hasCursorHook = $false
+  foreach ($entry in @($cursorConfig.hooks.afterShellExecution)) {
+    if ($entry.command -eq "node $HOOK_PATH_UNIX") {
+      $hasCursorHook = $true
+    }
+  }
+  if (-not $hasCursorHook) {
+    $cursorConfig.hooks.afterShellExecution = @($cursorConfig.hooks.afterShellExecution) + @(@{ command = "node $HOOK_PATH_UNIX" })
+    $cursorConfig | ConvertTo-Json -Depth 8 | Set-Content $cursorHooks -Encoding UTF8
+    Write-Host "  ✓ Cursor CLI afterShellExecution hook configured ($cursorHooks)" -ForegroundColor Green
+  } else {
+    Write-Host "  ✓ Cursor CLI afterShellExecution hook already configured" -ForegroundColor Green
+  }
+}
+
 # GitHub Copilot CLI (only if ~/.copilot exists — don't create dir for users without Copilot)
 if (Test-Path "$env:USERPROFILE\.copilot") {
   Add-BuddyToConfig "$env:USERPROFILE\.copilot\mcp-config.json" "GitHub Copilot CLI"
+
+  $copilotSettings = "$env:USERPROFILE\.copilot\settings.json"
+  $copilotConfig = @{}
+  if (Test-Path $copilotSettings) {
+    try { $copilotConfig = Get-Content $copilotSettings -Raw | ConvertFrom-Json }
+    catch { $copilotConfig = @{} }
+  }
+  if (!$copilotConfig.hooks) {
+    $copilotConfig | Add-Member -NotePropertyName "hooks" -NotePropertyValue @{} -Force
+  }
+  if (!$copilotConfig.hooks.postToolUse) {
+    $copilotConfig.hooks | Add-Member -NotePropertyName "postToolUse" -NotePropertyValue @() -Force
+  }
+  $hasCopilotHook = $false
+  foreach ($entry in @($copilotConfig.hooks.postToolUse)) {
+    if ($entry.bash -eq "node $HOOK_PATH_UNIX" -or $entry.powershell -eq "node $HOOK_PATH_UNIX") {
+      $hasCopilotHook = $true
+    }
+  }
+  if (-not $hasCopilotHook) {
+    $copilotConfig.hooks.postToolUse = @($copilotConfig.hooks.postToolUse) + @(@{
+      type = "command"
+      bash = "node $HOOK_PATH_UNIX"
+      powershell = "node $HOOK_PATH_UNIX"
+      timeoutSec = 3
+    })
+    $copilotConfig | ConvertTo-Json -Depth 8 | Set-Content $copilotSettings -Encoding UTF8
+    Write-Host "  ✓ GitHub Copilot CLI postToolUse hook configured ($copilotSettings)" -ForegroundColor Green
+  } else {
+    Write-Host "  ✓ GitHub Copilot CLI postToolUse hook already configured" -ForegroundColor Green
+  }
+}
+
+if (Get-Command codex -ErrorAction SilentlyContinue) {
+  $codexHooks = "$env:USERPROFILE\.codex\hooks.json"
+  $codexConfig = @{}
+  if (Test-Path $codexHooks) {
+    try { $codexConfig = Get-Content $codexHooks -Raw | ConvertFrom-Json }
+    catch { $codexConfig = @{} }
+  }
+  if (!$codexConfig.hooks) {
+    $codexConfig | Add-Member -NotePropertyName "hooks" -NotePropertyValue @{} -Force
+  }
+  if (!$codexConfig.hooks.PostToolUse) {
+    $codexConfig.hooks | Add-Member -NotePropertyName "PostToolUse" -NotePropertyValue @() -Force
+  }
+  $postToolUseGroups = @($codexConfig.hooks.PostToolUse)
+  $codexGroup = $null
+  foreach ($entry in $postToolUseGroups) {
+    if ($entry.matcher -eq 'Bash' -and $entry.hooks) {
+      $codexGroup = $entry
+      break
+    }
+  }
+  if (-not $codexGroup) {
+    $codexGroup = [ordered]@{
+      matcher = "Bash"
+      hooks = @()
+    }
+    $codexConfig.hooks.PostToolUse = @($postToolUseGroups) + @($codexGroup)
+  }
+  $hasCodexHook = $false
+  foreach ($entry in @($codexGroup.hooks)) {
+    if ($entry.command -eq "node $HOOK_PATH_UNIX") {
+      $hasCodexHook = $true
+    }
+  }
+  if (-not $hasCodexHook) {
+    $codexGroup.hooks = @($codexGroup.hooks) + @(@{
+      type = "command"
+      command = "node $HOOK_PATH_UNIX"
+      statusMessage = "Reviewing Bash output"
+    })
+    $codexConfig | ConvertTo-Json -Depth 10 | Set-Content $codexHooks -Encoding UTF8
+    Write-Host "  ✓ Codex CLI PostToolUse hook configured ($codexHooks)" -ForegroundColor Green
+  } else {
+    Write-Host "  ✓ Codex CLI PostToolUse hook already configured" -ForegroundColor Green
+  }
 }
 
 # ── Inject buddy instructions into CLI prompt files ──

--- a/install.ps1
+++ b/install.ps1
@@ -54,6 +54,10 @@ $SERVER_PATH = "$INSTALL_DIR\dist\server\index.js"
 $SERVER_PATH_UNIX = $SERVER_PATH -replace '\\', '/'
 $STATUSLINE_PATH = "$INSTALL_DIR\dist\statusline-wrapper.js"
 $STATUSLINE_PATH_UNIX = $STATUSLINE_PATH -replace '\\', '/'
+$CLAUDE_CONFIGURED = $false
+$CURSOR_CONFIGURED = $false
+$COPILOT_CONFIGURED = $false
+$CODEX_CONFIGURED = $false
 
 Pop-Location
 
@@ -135,6 +139,7 @@ if (-not $claudeRegistered) {
   $userConfig | ConvertTo-Json -Depth 8 | Set-Content $claudeUserFile -Encoding UTF8
   Write-Host "  ✓ Claude Code MCP config written ($claudeUserFile)" -ForegroundColor Green
 }
+$CLAUDE_CONFIGURED = $true
 
 $claudeSettings = "$claudeDir\settings.json"
 if (!(Test-Path $claudeSettings)) {
@@ -205,6 +210,7 @@ if ($statuslineConfigured) {
 # Cursor
 if (Test-Path "$env:USERPROFILE\.cursor") {
   Add-BuddyToConfig "$env:USERPROFILE\.cursor\mcp.json" "Cursor"
+  $CURSOR_CONFIGURED = $true
 }
 
 $cursorHooks = "$env:USERPROFILE\.cursor\hooks.json"
@@ -241,6 +247,7 @@ if (Test-Path "$env:USERPROFILE\.cursor") {
 # GitHub Copilot CLI (only if ~/.copilot exists — don't create dir for users without Copilot)
 if (Test-Path "$env:USERPROFILE\.copilot") {
   Add-BuddyToConfig "$env:USERPROFILE\.copilot\mcp-config.json" "GitHub Copilot CLI"
+  $COPILOT_CONFIGURED = $true
 
   $copilotSettings = "$env:USERPROFILE\.copilot\settings.json"
   $copilotConfig = @{}
@@ -275,6 +282,7 @@ if (Test-Path "$env:USERPROFILE\.copilot") {
 }
 
 if (Get-Command codex -ErrorAction SilentlyContinue) {
+  $CODEX_CONFIGURED = $true
   $codexHooks = "$env:USERPROFILE\.codex\hooks.json"
   $codexConfig = @{}
   if (Test-Path $codexHooks) {
@@ -324,7 +332,7 @@ if (Get-Command codex -ErrorAction SilentlyContinue) {
 # ── Inject buddy instructions into CLI prompt files ──
 
 $BUDDY_INSTRUCTIONS = @"
-<!-- buddy-companion -->
+<!-- buddy-companion v2 -->
 ## Buddy Companion
 
 You have a coding companion available via the buddy MCP server.
@@ -336,7 +344,7 @@ At the start of each conversation, call ``buddy_status`` to check on your buddy.
 If the user addresses the buddy by name, respond briefly in character before your normal response.
 
 After calling buddy_observe, relay the buddy's reaction to the user. The first text content is an ASCII speech bubble — include it verbatim.
-<!-- /buddy-companion -->
+<!-- /buddy-companion v2 -->
 "@
 
 function Inject-BuddyPrompt($filePath, $cliName) {
@@ -355,13 +363,17 @@ function Inject-BuddyPrompt($filePath, $cliName) {
 Write-Host ""
 Write-Host "  Injecting buddy instructions..."
 
-Inject-BuddyPrompt "$env:USERPROFILE\.claude\CLAUDE.md" "Claude Code"
+if ($CLAUDE_CONFIGURED) {
+  Inject-BuddyPrompt "$env:USERPROFILE\.claude\CLAUDE.md" "Claude Code"
+}
 $cursorRulesDir = "$env:USERPROFILE\.cursor\rules"
-if (!(Test-Path $cursorRulesDir)) { New-Item -ItemType Directory -Path $cursorRulesDir -Force | Out-Null }
-Inject-BuddyPrompt "$cursorRulesDir\buddy.md" "Cursor CLI"
+if ($CURSOR_CONFIGURED) {
+  if (!(Test-Path $cursorRulesDir)) { New-Item -ItemType Directory -Path $cursorRulesDir -Force | Out-Null }
+  Inject-BuddyPrompt "$cursorRulesDir\buddy.md" "Cursor CLI"
+}
 
 # Codex CLI (only inject prompts if codex command exists — matches bash behavior)
-if (Get-Command codex -ErrorAction SilentlyContinue) {
+if ($CODEX_CONFIGURED) {
   if (Test-Path "$env:USERPROFILE\.codex\AGENTS.md") {
     Inject-BuddyPrompt "$env:USERPROFILE\.codex\AGENTS.md" "Codex CLI"
   } else {
@@ -375,10 +387,12 @@ if ((Test-Path "$env:USERPROFILE\.gemini\AGENTS.md") -and !(Test-Path "$env:USER
   Inject-BuddyPrompt "$env:USERPROFILE\.gemini\GEMINI.md" "Gemini CLI"
 }
 # GitHub Copilot CLI (supports AGENTS.md and copilot-instructions.md — prefer AGENTS.md)
-if (Test-Path "$env:USERPROFILE\.copilot\AGENTS.md") {
-  Inject-BuddyPrompt "$env:USERPROFILE\.copilot\AGENTS.md" "GitHub Copilot CLI"
-} else {
-  Inject-BuddyPrompt "$env:USERPROFILE\.copilot\copilot-instructions.md" "GitHub Copilot CLI"
+if ($COPILOT_CONFIGURED) {
+  if (Test-Path "$env:USERPROFILE\.copilot\AGENTS.md") {
+    Inject-BuddyPrompt "$env:USERPROFILE\.copilot\AGENTS.md" "GitHub Copilot CLI"
+  } else {
+    Inject-BuddyPrompt "$env:USERPROFILE\.copilot\copilot-instructions.md" "GitHub Copilot CLI"
+  }
 }
 
 # ── Run onboarding wizard ──

--- a/install.ps1
+++ b/install.ps1
@@ -65,7 +65,7 @@ Pop-Location
 
 function Add-BuddyToConfig($configPath, $cliName) {
   $configDir = Split-Path $configPath -Parent
-  if (!(Test-Path $configDir)) { return }
+  if (!(Test-Path $configDir)) { return $false }
 
   $buddyConfig = @{
     type = "stdio"
@@ -77,13 +77,13 @@ function Add-BuddyToConfig($configPath, $cliName) {
     $config = @{ mcpServers = @{ buddy = $buddyConfig } }
     $config | ConvertTo-Json -Depth 5 | Set-Content $configPath -Encoding UTF8
     Write-Host "  ✓ $cliName configured ($configPath)" -ForegroundColor Green
-    return
+    return $true
   }
 
   $content = Get-Content $configPath -Raw | ConvertFrom-Json
   if ($content.mcpServers.buddy) {
     Write-Host "  ✓ $cliName already configured" -ForegroundColor Green
-    return
+    return $true
   }
 
   if (!$content.mcpServers) {
@@ -92,6 +92,7 @@ function Add-BuddyToConfig($configPath, $cliName) {
   $content.mcpServers | Add-Member -NotePropertyName "buddy" -NotePropertyValue $buddyConfig -Force
   $content | ConvertTo-Json -Depth 5 | Set-Content $configPath -Encoding UTF8
   Write-Host "  ✓ $cliName configured ($configPath)" -ForegroundColor Green
+  return $true
 }
 
 $HOOK_PATH = "$INSTALL_DIR\dist\hooks\post-tool-handler.js"
@@ -209,8 +210,7 @@ if ($statuslineConfigured) {
 
 # Cursor
 if (Test-Path "$env:USERPROFILE\.cursor") {
-  Add-BuddyToConfig "$env:USERPROFILE\.cursor\mcp.json" "Cursor"
-  $CURSOR_CONFIGURED = $true
+  $CURSOR_CONFIGURED = Add-BuddyToConfig "$env:USERPROFILE\.cursor\mcp.json" "Cursor"
 }
 
 $cursorHooks = "$env:USERPROFILE\.cursor\hooks.json"
@@ -246,86 +246,102 @@ if (Test-Path "$env:USERPROFILE\.cursor") {
 
 # GitHub Copilot CLI (only if ~/.copilot exists — don't create dir for users without Copilot)
 if (Test-Path "$env:USERPROFILE\.copilot") {
-  Add-BuddyToConfig "$env:USERPROFILE\.copilot\mcp-config.json" "GitHub Copilot CLI"
-  $COPILOT_CONFIGURED = $true
+  $COPILOT_CONFIGURED = Add-BuddyToConfig "$env:USERPROFILE\.copilot\mcp-config.json" "GitHub Copilot CLI"
 
-  $copilotSettings = "$env:USERPROFILE\.copilot\settings.json"
-  $copilotConfig = @{}
-  if (Test-Path $copilotSettings) {
-    try { $copilotConfig = Get-Content $copilotSettings -Raw | ConvertFrom-Json }
-    catch { $copilotConfig = @{} }
-  }
-  if (!$copilotConfig.hooks) {
-    $copilotConfig | Add-Member -NotePropertyName "hooks" -NotePropertyValue @{} -Force
-  }
-  if (!$copilotConfig.hooks.postToolUse) {
-    $copilotConfig.hooks | Add-Member -NotePropertyName "postToolUse" -NotePropertyValue @() -Force
-  }
-  $hasCopilotHook = $false
-  foreach ($entry in @($copilotConfig.hooks.postToolUse)) {
-    if ($entry.bash -eq "node $HOOK_PATH_UNIX" -or $entry.powershell -eq "node $HOOK_PATH_UNIX") {
-      $hasCopilotHook = $true
+  if ($COPILOT_CONFIGURED) {
+    $copilotSettings = "$env:USERPROFILE\.copilot\settings.json"
+    $copilotConfig = @{}
+    if (Test-Path $copilotSettings) {
+      try { $copilotConfig = Get-Content $copilotSettings -Raw | ConvertFrom-Json }
+      catch { $copilotConfig = @{} }
     }
-  }
-  if (-not $hasCopilotHook) {
-    $copilotConfig.hooks.postToolUse = @($copilotConfig.hooks.postToolUse) + @(@{
-      type = "command"
-      bash = "node $HOOK_PATH_UNIX"
-      powershell = "node $HOOK_PATH_UNIX"
-      timeoutSec = 3
-    })
-    $copilotConfig | ConvertTo-Json -Depth 8 | Set-Content $copilotSettings -Encoding UTF8
-    Write-Host "  ✓ GitHub Copilot CLI postToolUse hook configured ($copilotSettings)" -ForegroundColor Green
-  } else {
-    Write-Host "  ✓ GitHub Copilot CLI postToolUse hook already configured" -ForegroundColor Green
+    if (!$copilotConfig.hooks) {
+      $copilotConfig | Add-Member -NotePropertyName "hooks" -NotePropertyValue @{} -Force
+    }
+    if (!$copilotConfig.hooks.postToolUse) {
+      $copilotConfig.hooks | Add-Member -NotePropertyName "postToolUse" -NotePropertyValue @() -Force
+    }
+    $hasCopilotHook = $false
+    foreach ($entry in @($copilotConfig.hooks.postToolUse)) {
+      if ($entry.bash -eq "node $HOOK_PATH_UNIX" -or $entry.powershell -eq "node $HOOK_PATH_UNIX") {
+        $hasCopilotHook = $true
+      }
+    }
+    if (-not $hasCopilotHook) {
+      $copilotConfig.hooks.postToolUse = @($copilotConfig.hooks.postToolUse) + @(@{
+        type = "command"
+        bash = "node $HOOK_PATH_UNIX"
+        powershell = "node $HOOK_PATH_UNIX"
+        timeoutSec = 3
+      })
+      $copilotConfig | ConvertTo-Json -Depth 8 | Set-Content $copilotSettings -Encoding UTF8
+      Write-Host "  ✓ GitHub Copilot CLI postToolUse hook configured ($copilotSettings)" -ForegroundColor Green
+    } else {
+      Write-Host "  ✓ GitHub Copilot CLI postToolUse hook already configured" -ForegroundColor Green
+    }
   }
 }
 
 if (Get-Command codex -ErrorAction SilentlyContinue) {
-  $CODEX_CONFIGURED = $true
-  $codexHooks = "$env:USERPROFILE\.codex\hooks.json"
-  $codexConfig = @{}
-  if (Test-Path $codexHooks) {
-    try { $codexConfig = Get-Content $codexHooks -Raw | ConvertFrom-Json }
-    catch { $codexConfig = @{} }
-  }
-  if (!$codexConfig.hooks) {
-    $codexConfig | Add-Member -NotePropertyName "hooks" -NotePropertyValue @{} -Force
-  }
-  if (!$codexConfig.hooks.PostToolUse) {
-    $codexConfig.hooks | Add-Member -NotePropertyName "PostToolUse" -NotePropertyValue @() -Force
-  }
-  $postToolUseGroups = @($codexConfig.hooks.PostToolUse)
-  $codexGroup = $null
-  foreach ($entry in $postToolUseGroups) {
-    if ($entry.matcher -eq 'Bash' -and $entry.hooks) {
-      $codexGroup = $entry
-      break
-    }
-  }
-  if (-not $codexGroup) {
-    $codexGroup = [ordered]@{
-      matcher = "Bash"
-      hooks = @()
-    }
-    $codexConfig.hooks.PostToolUse = @($postToolUseGroups) + @($codexGroup)
-  }
-  $hasCodexHook = $false
-  foreach ($entry in @($codexGroup.hooks)) {
-    if ($entry.command -eq "node $HOOK_PATH_UNIX") {
-      $hasCodexHook = $true
-    }
-  }
-  if (-not $hasCodexHook) {
-    $codexGroup.hooks = @($codexGroup.hooks) + @(@{
-      type = "command"
-      command = "node $HOOK_PATH_UNIX"
-      statusMessage = "Reviewing Bash output"
-    })
-    $codexConfig | ConvertTo-Json -Depth 10 | Set-Content $codexHooks -Encoding UTF8
-    Write-Host "  ✓ Codex CLI PostToolUse hook configured ($codexHooks)" -ForegroundColor Green
+  codex mcp get buddy 1>$null 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    Write-Host "  ✓ Codex CLI already configured" -ForegroundColor Green
+    $CODEX_CONFIGURED = $true
   } else {
-    Write-Host "  ✓ Codex CLI PostToolUse hook already configured" -ForegroundColor Green
+    codex mcp add buddy -- node "$SERVER_PATH_UNIX" 1>$null 2>$null
+    if ($LASTEXITCODE -eq 0) {
+      Write-Host "  ✓ Codex CLI configured" -ForegroundColor Green
+      $CODEX_CONFIGURED = $true
+    } else {
+      Write-Host "  ! Codex CLI detected, but MCP registration failed" -ForegroundColor Yellow
+    }
+  }
+
+  if ($CODEX_CONFIGURED) {
+    $codexHooks = "$env:USERPROFILE\.codex\hooks.json"
+    $codexConfig = @{}
+    if (Test-Path $codexHooks) {
+      try { $codexConfig = Get-Content $codexHooks -Raw | ConvertFrom-Json }
+      catch { $codexConfig = @{} }
+    }
+    if (!$codexConfig.hooks) {
+      $codexConfig | Add-Member -NotePropertyName "hooks" -NotePropertyValue @{} -Force
+    }
+    if (!$codexConfig.hooks.PostToolUse) {
+      $codexConfig.hooks | Add-Member -NotePropertyName "PostToolUse" -NotePropertyValue @() -Force
+    }
+    $postToolUseGroups = @($codexConfig.hooks.PostToolUse)
+    $codexGroup = $null
+    foreach ($entry in $postToolUseGroups) {
+      if ($entry.matcher -eq 'Bash' -and $entry.hooks) {
+        $codexGroup = $entry
+        break
+      }
+    }
+    if (-not $codexGroup) {
+      $codexGroup = [ordered]@{
+        matcher = "Bash"
+        hooks = @()
+      }
+      $codexConfig.hooks.PostToolUse = @($postToolUseGroups) + @($codexGroup)
+    }
+    $hasCodexHook = $false
+    foreach ($entry in @($codexGroup.hooks)) {
+      if ($entry.command -eq "node $HOOK_PATH_UNIX") {
+        $hasCodexHook = $true
+      }
+    }
+    if (-not $hasCodexHook) {
+      $codexGroup.hooks = @($codexGroup.hooks) + @(@{
+        type = "command"
+        command = "node $HOOK_PATH_UNIX"
+        statusMessage = "Reviewing Bash output"
+      })
+      $codexConfig | ConvertTo-Json -Depth 10 | Set-Content $codexHooks -Encoding UTF8
+      Write-Host "  ✓ Codex CLI PostToolUse hook configured ($codexHooks)" -ForegroundColor Green
+    } else {
+      Write-Host "  ✓ Codex CLI PostToolUse hook already configured" -ForegroundColor Green
+    }
   }
 }
 
@@ -372,7 +388,7 @@ if ($CURSOR_CONFIGURED) {
   Inject-BuddyPrompt "$cursorRulesDir\buddy.md" "Cursor CLI"
 }
 
-# Codex CLI (only inject prompts if codex command exists — matches bash behavior)
+# Codex CLI (only inject prompts after Buddy MCP is configured; prefer AGENTS.md)
 if ($CODEX_CONFIGURED) {
   if (Test-Path "$env:USERPROFILE\.codex\AGENTS.md") {
     Inject-BuddyPrompt "$env:USERPROFILE\.codex\AGENTS.md" "Codex CLI"
@@ -380,11 +396,15 @@ if ($CODEX_CONFIGURED) {
     Inject-BuddyPrompt "$env:USERPROFILE\.codex\instructions.md" "Codex CLI"
   }
 }
-# Gemini CLI
-if ((Test-Path "$env:USERPROFILE\.gemini\AGENTS.md") -and !(Test-Path "$env:USERPROFILE\.gemini\GEMINI.md")) {
-  Inject-BuddyPrompt "$env:USERPROFILE\.gemini\AGENTS.md" "Gemini CLI"
-} else {
-  Inject-BuddyPrompt "$env:USERPROFILE\.gemini\GEMINI.md" "Gemini CLI"
+# Gemini CLI (only touch existing Gemini prompt locations; Buddy does not auto-configure Gemini MCP)
+if (Test-Path "$env:USERPROFILE\.gemini") {
+  if (Test-Path "$env:USERPROFILE\.gemini\GEMINI.md") {
+    Inject-BuddyPrompt "$env:USERPROFILE\.gemini\GEMINI.md" "Gemini CLI"
+  } elseif (Test-Path "$env:USERPROFILE\.gemini\AGENTS.md") {
+    Inject-BuddyPrompt "$env:USERPROFILE\.gemini\AGENTS.md" "Gemini CLI"
+  } else {
+    Write-Host "  ! Skipping Gemini CLI prompt injection because no existing Gemini prompt file was found" -ForegroundColor Yellow
+  }
 }
 # GitHub Copilot CLI (supports AGENTS.md and copilot-instructions.md — prefer AGENTS.md)
 if ($COPILOT_CONFIGURED) {
@@ -407,7 +427,19 @@ if (Test-Path $ONBOARD_SCRIPT) {
 }
 
 Write-Host ""
-Write-Host "  ✅ Buddy installed! Say `"hatch a buddy`" to start." -ForegroundColor Green
+if ($CLAUDE_CONFIGURED -or $CURSOR_CONFIGURED -or $COPILOT_CONFIGURED -or $CODEX_CONFIGURED) {
+  Write-Host "  ✅ Buddy installed! Say `"hatch a buddy`" to start." -ForegroundColor Green
+} elseif (Get-Command codex -ErrorAction SilentlyContinue) {
+  Write-Host "  ⚠ Buddy installed, but no supported host was fully configured." -ForegroundColor Yellow
+  Write-Host "  ! Codex CLI is installed, but MCP registration still needs attention." -ForegroundColor Yellow
+} else {
+  Write-Host "  ⚠ Buddy installed, but no supported host was fully configured." -ForegroundColor Yellow
+  Write-Host "  ! Open a supported CLI and rerun the installer to wire Buddy in automatically." -ForegroundColor Yellow
+}
+if ((-not $CODEX_CONFIGURED) -and (Get-Command codex -ErrorAction SilentlyContinue)) {
+  Write-Host ""
+  Write-Host "  ! Codex CLI prompt injection was skipped because Buddy MCP is not configured there yet." -ForegroundColor Yellow
+}
 Write-Host ""
 Write-Host "  💛 If you like it, star the repo:"
 Write-Host "  github.com/fiorastudio/buddy"

--- a/install.sh
+++ b/install.sh
@@ -65,6 +65,7 @@ npm run build --quiet 2>/dev/null
 
 SERVER_PATH="$INSTALL_DIR/dist/server/index.js"
 CODEX_CONFIGURED=0
+HOOK_PATH="$INSTALL_DIR/dist/hooks/post-tool-handler.js"
 
 # ── Auto-configure MCP for detected CLIs ──
 
@@ -72,7 +73,6 @@ configure_claude_code() {
   local config_dir="$HOME/.claude"
   local settings_file="$config_dir/settings.json"
   local user_file="$HOME/.claude.json"
-  local hook_path="$INSTALL_DIR/dist/hooks/post-tool-handler.js"
   local stop_hook_path="$INSTALL_DIR/dist/hooks/stop-handler.js"
   local prompt_hook_path="$INSTALL_DIR/dist/hooks/prompt-handler.js"
   local statusline_command="node $INSTALL_DIR/dist/statusline-wrapper.js"
@@ -122,7 +122,7 @@ EOJS
   # Configure hook + statusline in a single settings.json write
   if command -v node &> /dev/null; then
     local settings_result
-    settings_result=$(CLAUDE_SETTINGS="$settings_file" HOOK_COMMAND="node $hook_path" STOP_HOOK_COMMAND="node $stop_hook_path" PROMPT_HOOK_COMMAND="node $prompt_hook_path" STATUSLINE_COMMAND="$statusline_command" node <<'EOJS'
+    settings_result=$(CLAUDE_SETTINGS="$settings_file" HOOK_COMMAND="node $HOOK_PATH" STOP_HOOK_COMMAND="node $stop_hook_path" PROMPT_HOOK_COMMAND="node $prompt_hook_path" STATUSLINE_COMMAND="$statusline_command" node <<'EOJS'
 const fs = require('fs');
 const settingsPath = process.env.CLAUDE_SETTINGS;
 const hookCommand = process.env.HOOK_COMMAND;
@@ -226,6 +226,94 @@ EOJS
   fi
 }
 
+configure_cursor_hooks() {
+  local config_file="$HOME/.cursor/hooks.json"
+
+  if [ ! -d "$HOME/.cursor" ]; then
+    return 0
+  fi
+
+  if ! command -v node &> /dev/null; then
+    echo -e "  ${YELLOW}!${NC} Cursor CLI: node not found, could not configure hooks"
+    return 1
+  fi
+
+  local result
+  result=$(CURSOR_HOOKS_FILE="$config_file" HOOK_COMMAND="node $HOOK_PATH" node <<'EOJS'
+const fs = require('fs');
+const path = process.env.CURSOR_HOOKS_FILE;
+const hookCommand = process.env.HOOK_COMMAND;
+let config = {};
+try { config = JSON.parse(fs.readFileSync(path, 'utf-8')); } catch {}
+if (!config.version) config.version = 1;
+if (!config.hooks || typeof config.hooks !== 'object') config.hooks = {};
+if (!Array.isArray(config.hooks.afterShellExecution)) config.hooks.afterShellExecution = [];
+const hooks = config.hooks.afterShellExecution;
+const hasHook = hooks.some(h => typeof h?.command === 'string' && h.command === hookCommand);
+if (!hasHook) {
+  hooks.push({ command: hookCommand });
+  fs.mkdirSync(require('path').dirname(path), { recursive: true });
+  fs.writeFileSync(path, JSON.stringify(config, null, 2));
+  process.stdout.write('updated');
+} else {
+  process.stdout.write('noop');
+}
+EOJS
+)
+
+  case "$result" in
+    updated) echo -e "  ${GREEN}✓${NC} Cursor CLI afterShellExecution hook configured ${DIM}($config_file)${NC}" ;;
+    *)       echo -e "  ${GREEN}✓${NC} Cursor CLI afterShellExecution hook already configured" ;;
+  esac
+}
+
+configure_copilot_hooks() {
+  local settings_file="$HOME/.copilot/settings.json"
+
+  if [ ! -d "$HOME/.copilot" ]; then
+    return 0
+  fi
+
+  if ! command -v node &> /dev/null; then
+    echo -e "  ${YELLOW}!${NC} GitHub Copilot CLI: node not found, could not configure hooks"
+    return 1
+  fi
+
+  local result
+  result=$(COPILOT_SETTINGS="$settings_file" BASH_COMMAND="node $HOOK_PATH" POWERSHELL_COMMAND="node $HOOK_PATH" node <<'EOJS'
+const fs = require('fs');
+const path = require('path');
+const settingsPath = process.env.COPILOT_SETTINGS;
+const bashCommand = process.env.BASH_COMMAND;
+const powershellCommand = process.env.POWERSHELL_COMMAND;
+let config = {};
+try { config = JSON.parse(fs.readFileSync(settingsPath, 'utf-8')); } catch {}
+if (!config.hooks || typeof config.hooks !== 'object') config.hooks = {};
+if (!Array.isArray(config.hooks.postToolUse)) config.hooks.postToolUse = [];
+const hooks = config.hooks.postToolUse;
+const hasHook = hooks.some(h => h?.bash === bashCommand || h?.powershell === powershellCommand);
+if (!hasHook) {
+  hooks.push({
+    type: 'command',
+    bash: bashCommand,
+    powershell: powershellCommand,
+    timeoutSec: 3,
+  });
+  fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+  fs.writeFileSync(settingsPath, JSON.stringify(config, null, 2));
+  process.stdout.write('updated');
+} else {
+  process.stdout.write('noop');
+}
+EOJS
+)
+
+  case "$result" in
+    updated) echo -e "  ${GREEN}✓${NC} GitHub Copilot CLI postToolUse hook configured ${DIM}($settings_file)${NC}" ;;
+    *)       echo -e "  ${GREEN}✓${NC} GitHub Copilot CLI postToolUse hook already configured" ;;
+  esac
+}
+
 
 configure_cursor() {
   local config_file="$HOME/.cursor/mcp.json"
@@ -309,12 +397,65 @@ configure_codex() {
   return 1
 }
 
+configure_codex_hooks() {
+  local config_file="$HOME/.codex/hooks.json"
+
+  if [ "$CODEX_CONFIGURED" -ne 1 ]; then
+    return 0
+  fi
+
+  if ! command -v node &> /dev/null; then
+    echo -e "  ${YELLOW}!${NC} Codex CLI: node not found, could not configure hooks"
+    return 1
+  fi
+
+  local result
+  result=$(CODEX_HOOKS_FILE="$config_file" HOOK_COMMAND="node $HOOK_PATH" node <<'EOJS'
+const fs = require('fs');
+const path = require('path');
+const hooksPath = process.env.CODEX_HOOKS_FILE;
+const hookCommand = process.env.HOOK_COMMAND;
+let config = {};
+try { config = JSON.parse(fs.readFileSync(hooksPath, 'utf-8')); } catch {}
+if (!config.hooks || typeof config.hooks !== 'object') config.hooks = {};
+if (!Array.isArray(config.hooks.PostToolUse)) config.hooks.PostToolUse = [];
+const groups = config.hooks.PostToolUse;
+let group = groups.find(entry => entry?.matcher === 'Bash' && Array.isArray(entry?.hooks));
+if (!group) {
+  group = { matcher: 'Bash', hooks: [] };
+  groups.push(group);
+}
+const hasHook = group.hooks.some(h => typeof h?.command === 'string' && h.command === hookCommand);
+if (!hasHook) {
+  group.hooks.push({
+    type: 'command',
+    command: hookCommand,
+    statusMessage: 'Reviewing Bash output',
+  });
+  fs.mkdirSync(path.dirname(hooksPath), { recursive: true });
+  fs.writeFileSync(hooksPath, JSON.stringify(config, null, 2));
+  process.stdout.write('updated');
+} else {
+  process.stdout.write('noop');
+}
+EOJS
+)
+
+  case "$result" in
+    updated) echo -e "  ${GREEN}✓${NC} Codex CLI PostToolUse hook configured ${DIM}($config_file)${NC}" ;;
+    *)       echo -e "  ${GREEN}✓${NC} Codex CLI PostToolUse hook already configured" ;;
+  esac
+}
+
 echo ""
 echo "  Configuring MCP clients..."
 configure_claude_code
 configure_cursor
 configure_copilot
 configure_codex
+configure_cursor_hooks
+configure_copilot_hooks
+configure_codex_hooks
 
 # ── Inject buddy instructions into CLI prompt files ──
 

--- a/install.sh
+++ b/install.sh
@@ -511,7 +511,7 @@ if [ "$CURSOR_CONFIGURED" -eq 1 ]; then
   inject_prompt "$HOME/.cursor/rules/buddy.md" "Cursor CLI"
 fi
 
-# Codex CLI (supports AGENTS.md and instructions.md — prefer AGENTS.md)
+# Codex CLI (only inject prompts after Buddy MCP is configured; prefer AGENTS.md)
 if [ "$CODEX_CONFIGURED" -eq 1 ]; then
   if [ -f "$HOME/.codex/AGENTS.md" ]; then
     inject_prompt "$HOME/.codex/AGENTS.md" "Codex CLI"
@@ -522,11 +522,15 @@ else
   echo -e "  ${YELLOW}!${NC} Skipping Codex CLI prompt injection because Buddy MCP is not configured"
 fi
 
-# Gemini CLI (supports GEMINI.md and AGENTS.md — use whichever exists, prefer GEMINI.md)
-if [ -f "$HOME/.gemini/AGENTS.md" ] && [ ! -f "$HOME/.gemini/GEMINI.md" ]; then
-  inject_prompt "$HOME/.gemini/AGENTS.md" "Gemini CLI"
-else
-  inject_prompt "$HOME/.gemini/GEMINI.md" "Gemini CLI"
+# Gemini CLI (only touch existing Gemini prompt locations; Buddy does not auto-configure Gemini MCP)
+if [ -d "$HOME/.gemini" ]; then
+  if [ -f "$HOME/.gemini/GEMINI.md" ]; then
+    inject_prompt "$HOME/.gemini/GEMINI.md" "Gemini CLI"
+  elif [ -f "$HOME/.gemini/AGENTS.md" ]; then
+    inject_prompt "$HOME/.gemini/AGENTS.md" "Gemini CLI"
+  else
+    echo -e "  ${YELLOW}!${NC} Skipping Gemini CLI prompt injection because no existing Gemini prompt file was found"
+  fi
 fi
 
 # GitHub Copilot CLI (supports AGENTS.md and copilot-instructions.md — prefer AGENTS.md)
@@ -550,12 +554,20 @@ elif [ "$NO_ONBOARD" -eq 1 ]; then
 fi
 
 echo ""
-if [ "$CODEX_CONFIGURED" -eq 1 ] || ! command -v codex &> /dev/null; then
+if [ "$CLAUDE_CONFIGURED" -eq 1 ] || [ "$CURSOR_CONFIGURED" -eq 1 ] || [ "$COPILOT_CONFIGURED" -eq 1 ] || [ "$CODEX_CONFIGURED" -eq 1 ]; then
   echo -e "${GREEN}  ✅ Buddy installed! Say \"hatch a buddy\" to start.${NC}"
-  echo ""
-  echo -e "  💛 If you like it, star the repo:"
-  echo "  github.com/fiorastudio/buddy"
+elif command -v codex &> /dev/null; then
+  echo -e "${YELLOW}  ⚠ Buddy installed, but no supported host was fully configured.${NC}"
+  echo -e "  ${YELLOW}!${NC} Codex CLI is installed, but MCP registration still needs attention."
 else
-  echo -e "${YELLOW}  ⚠ Buddy installed, but Codex CLI still needs MCP configuration.${NC}"
+  echo -e "${YELLOW}  ⚠ Buddy installed, but no supported host was fully configured.${NC}"
+  echo -e "  ${YELLOW}!${NC} Open a supported CLI and rerun the installer to wire Buddy in automatically."
 fi
+if [ "$CODEX_CONFIGURED" -ne 1 ] && command -v codex &> /dev/null; then
+  echo ""
+  echo -e "  ${YELLOW}!${NC} Codex CLI prompt injection was skipped because Buddy MCP is not configured there yet."
+fi
+echo ""
+echo -e "  💛 If you like it, star the repo:"
+echo "  github.com/fiorastudio/buddy"
 echo ""

--- a/install.sh
+++ b/install.sh
@@ -66,6 +66,9 @@ npm run build --quiet 2>/dev/null
 SERVER_PATH="$INSTALL_DIR/dist/server/index.js"
 CODEX_CONFIGURED=0
 HOOK_PATH="$INSTALL_DIR/dist/hooks/post-tool-handler.js"
+CLAUDE_CONFIGURED=0
+CURSOR_CONFIGURED=0
+COPILOT_CONFIGURED=0
 
 # ── Auto-configure MCP for detected CLIs ──
 
@@ -224,6 +227,8 @@ EOJS
   else
     echo -e "  ${YELLOW}!${NC} node not found — cannot configure hooks or statusline"
   fi
+
+  CLAUDE_CONFIGURED=1
 }
 
 configure_cursor_hooks() {
@@ -340,6 +345,7 @@ EOJSON
       " 2>/dev/null
     fi
     echo -e "  ${GREEN}✓${NC} Cursor configured ${DIM}($config_file)${NC}"
+    CURSOR_CONFIGURED=1
   fi
 }
 
@@ -373,6 +379,7 @@ EOJSON
       fi
     fi
     echo -e "  ${GREEN}✓${NC} GitHub Copilot CLI configured ${DIM}($config_file)${NC}"
+    COPILOT_CONFIGURED=1
   fi
 }
 
@@ -459,7 +466,7 @@ configure_codex_hooks
 
 # ── Inject buddy instructions into CLI prompt files ──
 
-BUDDY_INSTRUCTIONS='<!-- buddy-companion -->
+BUDDY_INSTRUCTIONS='<!-- buddy-companion v2 -->
 ## Buddy Companion
 
 You have a coding companion available via the buddy MCP server.
@@ -471,7 +478,7 @@ At the start of each conversation, call `buddy_status` to check on your buddy.
 If the user addresses the buddy by name, respond briefly in character before your normal response.
 
 After calling buddy_observe, relay the buddy'\''s reaction to the user. The first text content is an ASCII speech bubble — include it verbatim.
-<!-- /buddy-companion -->'
+<!-- /buddy-companion v2 -->'
 
 inject_prompt() {
   local file="$1"
@@ -494,9 +501,15 @@ inject_prompt() {
 
 echo ""
 echo "  Injecting buddy instructions..."
-inject_prompt "$HOME/.claude/CLAUDE.md" "Claude Code"
-mkdir -p "$HOME/.cursor/rules" 2>/dev/null
-inject_prompt "$HOME/.cursor/rules/buddy.md" "Cursor CLI"
+
+if [ "$CLAUDE_CONFIGURED" -eq 1 ]; then
+  inject_prompt "$HOME/.claude/CLAUDE.md" "Claude Code"
+fi
+
+if [ "$CURSOR_CONFIGURED" -eq 1 ]; then
+  mkdir -p "$HOME/.cursor/rules" 2>/dev/null
+  inject_prompt "$HOME/.cursor/rules/buddy.md" "Cursor CLI"
+fi
 
 # Codex CLI (supports AGENTS.md and instructions.md — prefer AGENTS.md)
 if [ "$CODEX_CONFIGURED" -eq 1 ]; then
@@ -517,10 +530,12 @@ else
 fi
 
 # GitHub Copilot CLI (supports AGENTS.md and copilot-instructions.md — prefer AGENTS.md)
-if [ -f "$HOME/.copilot/AGENTS.md" ]; then
-  inject_prompt "$HOME/.copilot/AGENTS.md" "GitHub Copilot CLI"
-else
-  inject_prompt "$HOME/.copilot/copilot-instructions.md" "GitHub Copilot CLI"
+if [ "$COPILOT_CONFIGURED" -eq 1 ]; then
+  if [ -f "$HOME/.copilot/AGENTS.md" ]; then
+    inject_prompt "$HOME/.copilot/AGENTS.md" "GitHub Copilot CLI"
+  else
+    inject_prompt "$HOME/.copilot/copilot-instructions.md" "GitHub Copilot CLI"
+  fi
 fi
 
 # ── Run onboarding wizard ──

--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -79,7 +79,7 @@ describe('Doctor — formatReport', () => {
     expect(report).toContain('COMPANION');
     expect(report).toContain('DATABASE');
     expect(report).toContain('STATUS FILE');
-    expect(report).toContain('CLAUDE CODE INTEGRATION');
+    expect(report).toContain('HOST INTEGRATION');
     expect(report).toContain('REASONING LAYER');
     expect(report).toContain('SUMMARY');
   });
@@ -141,7 +141,7 @@ describe('Doctor — failure paths', () => {
     expect(['ok', 'fail']).toContain(mcp!.status);
     if (mcp!.status === 'fail') {
       expect(mcp!.suggestion).toBeDefined();
-      expect(mcp!.suggestion).toContain('claude mcp add');
+      expect(mcp!.suggestion).toContain('install script');
     }
   });
 

--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'fs';
 import { describe, it, expect } from 'vitest';
 import { runDiagnostics, formatReport, PROMPT_SENTINEL_V2 } from '../lib/doctor.js';
 
@@ -101,6 +102,16 @@ describe('Doctor — formatReport', () => {
 describe('Doctor — sentinel constant', () => {
   it('exports the v2 sentinel string', () => {
     expect(PROMPT_SENTINEL_V2).toBe('buddy-companion v2');
+  });
+
+  it('keeps installer prompt markers aligned with the v2 sentinel', () => {
+    const installSh = readFileSync(new URL('../../install.sh', import.meta.url), 'utf-8');
+    const installPs1 = readFileSync(new URL('../../install.ps1', import.meta.url), 'utf-8');
+
+    expect(installSh).toContain('<!-- buddy-companion v2 -->');
+    expect(installSh).toContain('<!-- /buddy-companion v2 -->');
+    expect(installPs1).toContain('<!-- buddy-companion v2 -->');
+    expect(installPs1).toContain('<!-- /buddy-companion v2 -->');
   });
 });
 

--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -217,6 +217,31 @@ describe('handlePostToolUse', () => {
     const result = handlePostToolUse(input, statusPath);
     expect(result).toBe(false);
   });
+
+  it('handles Codex/Copilot-style payloads', () => {
+    const input = {
+      toolName: 'bash',
+      toolResult: {
+        resultType: 'error',
+        textResultForLlm: 'Process exited with exit code 2',
+      },
+    };
+
+    const result = handlePostToolUse(input, statusPath);
+    expect(result).toBe(true);
+  });
+
+  it('handles Cursor-style shell payloads', () => {
+    const input = {
+      command: 'npm test',
+      stdout: 'Tests: 3 FAILED, 10 passed',
+      stderr: '',
+      exitCode: 1,
+    };
+
+    const result = handlePostToolUse(input, statusPath);
+    expect(result).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/hooks/post-tool-handler.ts
+++ b/src/hooks/post-tool-handler.ts
@@ -30,6 +30,48 @@ export interface PostToolUseInput {
   tool_response?: string;
 }
 
+interface GenericHookInput {
+  tool_name?: string;
+  tool_input?: Record<string, unknown>;
+  tool_response?: unknown;
+  toolName?: string;
+  toolArgs?: string;
+  toolResult?: {
+    resultType?: string;
+    textResultForLlm?: string;
+    [key: string]: unknown;
+  };
+  command?: string;
+  output?: string;
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+}
+
+function inferToolName(input: GenericHookInput): string {
+  if (typeof input.tool_name === "string") return input.tool_name;
+  if (typeof input.toolName === "string") return input.toolName;
+  if (typeof input.command === "string") return "Bash";
+  return "";
+}
+
+function inferToolOutput(input: GenericHookInput): string {
+  if (typeof input.tool_response === "string") return input.tool_response;
+  if (typeof input.toolResult?.textResultForLlm === "string") return input.toolResult.textResultForLlm;
+
+  const parts = [
+    typeof input.output === "string" ? input.output : "",
+    typeof input.stdout === "string" ? input.stdout : "",
+    typeof input.stderr === "string" ? input.stderr : "",
+  ].filter(Boolean);
+
+  if (typeof input.exitCode === "number" && input.exitCode !== 0) {
+    parts.push(`exit code ${input.exitCode}`);
+  }
+
+  return parts.join("\n");
+}
+
 /**
  * Check if a fresh reaction already exists (race protection).
  * Returns true if we should bail and not overwrite.
@@ -77,11 +119,11 @@ export function writeConcernedReaction(statusPath: string = BUDDY_STATUS_PATH, e
 /**
  * Main handler — reads stdin, processes PostToolUse event.
  */
-export function handlePostToolUse(input: PostToolUseInput, statusPath: string = BUDDY_STATUS_PATH): boolean {
-  // Only act on Bash tool
-  if (input.tool_name !== "Bash") return false;
+export function handlePostToolUse(input: PostToolUseInput | GenericHookInput, statusPath: string = BUDDY_STATUS_PATH): boolean {
+  const toolName = inferToolName(input);
+  if (toolName !== "Bash" && toolName.toLowerCase() !== "bash") return false;
 
-  const output = input.tool_response || "";
+  const output = inferToolOutput(input);
 
   // Check for error patterns
   if (!ERROR_REGEX.test(output)) return false;

--- a/src/hooks/post-tool-handler.ts
+++ b/src/hooks/post-tool-handler.ts
@@ -121,7 +121,7 @@ export function writeConcernedReaction(statusPath: string = BUDDY_STATUS_PATH, e
  */
 export function handlePostToolUse(input: PostToolUseInput | GenericHookInput, statusPath: string = BUDDY_STATUS_PATH): boolean {
   const toolName = inferToolName(input);
-  if (toolName !== "Bash" && toolName.toLowerCase() !== "bash") return false;
+  if (toolName.toLowerCase() !== "bash") return false;
 
   const output = inferToolOutput(input);
 

--- a/src/lib/doctor.ts
+++ b/src/lib/doctor.ts
@@ -52,6 +52,45 @@ function readTextSafe(path: string): string | null {
   try { return readFileSync(path, 'utf-8'); } catch { return null; }
 }
 
+function formatPathList(paths: string[]): string {
+  return paths.join(' | ');
+}
+
+function codexConfigPath(): string {
+  return join(homedir(), '.codex', 'config.toml');
+}
+
+function codexHooksPath(): string {
+  return join(homedir(), '.codex', 'hooks.json');
+}
+
+function cursorMcpPath(): string {
+  return join(homedir(), '.cursor', 'mcp.json');
+}
+
+function cursorHooksPath(): string {
+  return join(homedir(), '.cursor', 'hooks.json');
+}
+
+function copilotMcpPath(): string {
+  return join(homedir(), '.copilot', 'mcp-config.json');
+}
+
+function copilotSettingsPath(): string {
+  return join(homedir(), '.copilot', 'settings.json');
+}
+
+function hostPromptFiles(): Array<{ host: string, path: string }> {
+  return [
+    { host: 'Claude Code', path: join(homedir(), '.claude', 'CLAUDE.md') },
+    { host: 'Codex CLI', path: join(homedir(), '.codex', 'AGENTS.md') },
+    { host: 'Codex CLI', path: join(homedir(), '.codex', 'instructions.md') },
+    { host: 'Cursor CLI', path: join(homedir(), '.cursor', 'rules', 'buddy.md') },
+    { host: 'GitHub Copilot CLI', path: join(homedir(), '.copilot', 'AGENTS.md') },
+    { host: 'GitHub Copilot CLI', path: join(homedir(), '.copilot', 'copilot-instructions.md') },
+  ];
+}
+
 // ── Individual checks ──
 
 function checkNodeVersion(): DiagnosticCheck {
@@ -191,15 +230,31 @@ function checkMcpRegistered(): DiagnosticCheck {
   if (config?.mcpServers?.buddy) {
     return { id: 'mcp.registered', status: 'ok', label: 'MCP registration', detail: `\u2713 registered in ${claudeJsonPath}` };
   }
-  // Also check ~/.claude/settings.json as fallback
+
   const settingsPath = join(homedir(), '.claude', 'settings.json');
   const settings = readJsonSafe(settingsPath);
   if (settings?.mcpServers?.buddy) {
     return { id: 'mcp.registered', status: 'ok', label: 'MCP registration', detail: `\u2713 registered in ${settingsPath}` };
   }
+
+  const codexConfig = readTextSafe(codexConfigPath());
+  if (codexConfig?.includes('[mcp_servers.buddy]')) {
+    return { id: 'mcp.registered', status: 'ok', label: 'MCP registration', detail: `\u2713 registered in ${codexConfigPath()}` };
+  }
+
+  const cursorConfig = readJsonSafe(cursorMcpPath());
+  if (cursorConfig?.mcpServers?.buddy) {
+    return { id: 'mcp.registered', status: 'ok', label: 'MCP registration', detail: `\u2713 registered in ${cursorMcpPath()}` };
+  }
+
+  const copilotConfig = readJsonSafe(copilotMcpPath());
+  if (copilotConfig?.mcpServers?.buddy) {
+    return { id: 'mcp.registered', status: 'ok', label: 'MCP registration', detail: `\u2713 registered in ${copilotMcpPath()}` };
+  }
+
   return {
     id: 'mcp.registered', status: 'fail', label: 'MCP registration', detail: '\u2717 not found',
-    suggestion: 'Run: claude mcp add buddy -s user -- node ~/.buddy/server/dist/server/index.js',
+    suggestion: 'Re-run the install script, or register Buddy in your host CLI MCP config.',
   };
 }
 
@@ -248,24 +303,45 @@ function checkStatuslineRefresh(): DiagnosticCheck {
 }
 
 function checkHooks(): DiagnosticCheck {
-  const settingsPath = join(homedir(), '.claude', 'settings.json');
-  const settings = readJsonSafe(settingsPath);
-  if (!settings?.hooks?.PostToolUse) {
-    return { id: 'config.hooks', status: 'warn', label: 'Hooks', detail: '\u2717 no PostToolUse hooks', suggestion: 'Re-run install script to configure hooks' };
-  }
-  const hooks: any[] = Array.isArray(settings.hooks.PostToolUse) ? settings.hooks.PostToolUse : [];
-  const hasBuddy = hooks.some((entry: any) => {
+  const found: string[] = [];
+
+  const claudeSettingsPath = join(homedir(), '.claude', 'settings.json');
+  const claudeSettings = readJsonSafe(claudeSettingsPath);
+  const claudeHooks: any[] = Array.isArray(claudeSettings?.hooks?.PostToolUse) ? claudeSettings.hooks.PostToolUse : [];
+  const hasClaudeHook = claudeHooks.some((entry: any) => {
     if (entry.matcher === 'Bash' && Array.isArray(entry.hooks)) {
       return entry.hooks.some((h: any) => h.command && h.command.includes('post-tool-handler'));
     }
-    // Handle legacy string format
     if (typeof entry === 'string' && entry.includes('post-tool-handler')) return true;
     return false;
   });
-  if (!hasBuddy) {
-    return { id: 'config.hooks', status: 'warn', label: 'Hooks', detail: '\u2717 buddy hook not found in PostToolUse', suggestion: 'Re-run install script to configure hooks' };
+  if (hasClaudeHook) found.push(`Claude Code (${claudeSettingsPath})`);
+
+  const codexHooks = readJsonSafe(codexHooksPath());
+  const codexGroups: any[] = Array.isArray(codexHooks?.hooks?.PostToolUse) ? codexHooks.hooks.PostToolUse : [];
+  const hasCodexHook = codexGroups.some((entry: any) =>
+    Array.isArray(entry?.hooks) && entry.hooks.some((hook: any) => typeof hook?.command === 'string' && hook.command.includes('post-tool-handler'))
+  );
+  if (hasCodexHook) found.push(`Codex CLI (${codexHooksPath()})`);
+
+  const cursorHooks = readJsonSafe(cursorHooksPath());
+  const cursorShellHooks: any[] = Array.isArray(cursorHooks?.hooks?.afterShellExecution) ? cursorHooks.hooks.afterShellExecution : [];
+  const hasCursorHook = cursorShellHooks.some((entry: any) => typeof entry?.command === 'string' && entry.command.includes('post-tool-handler'));
+  if (hasCursorHook) found.push(`Cursor CLI (${cursorHooksPath()})`);
+
+  const copilotSettings = readJsonSafe(copilotSettingsPath());
+  const copilotHooks: any[] = Array.isArray(copilotSettings?.hooks?.postToolUse) ? copilotSettings.hooks.postToolUse : [];
+  const hasCopilotHook = copilotHooks.some((entry: any) => {
+    const bash = typeof entry?.bash === 'string' ? entry.bash : '';
+    const powershell = typeof entry?.powershell === 'string' ? entry.powershell : '';
+    return bash.includes('post-tool-handler') || powershell.includes('post-tool-handler');
+  });
+  if (hasCopilotHook) found.push(`GitHub Copilot CLI (${copilotSettingsPath()})`);
+
+  if (found.length === 0) {
+    return { id: 'config.hooks', status: 'warn', label: 'Hooks', detail: '\u2717 no buddy post-tool hook found', suggestion: 'Re-run install script to configure hooks' };
   }
-  return { id: 'config.hooks', status: 'ok', label: 'Hooks', detail: '\u2713 PostToolUse hook present' };
+  return { id: 'config.hooks', status: 'ok', label: 'Hooks', detail: `\u2713 ${formatPathList(found)}` };
 }
 
 function checkStopHook(): DiagnosticCheck {
@@ -297,18 +373,23 @@ function checkPromptHook(): DiagnosticCheck {
 }
 
 function checkPromptInjection(): DiagnosticCheck {
-  const claudeMdPath = join(homedir(), '.claude', 'CLAUDE.md');
-  const content = readTextSafe(claudeMdPath);
-  if (!content) {
-    return { id: 'prompt.injected', status: 'warn', label: 'Prompt injection', detail: `${claudeMdPath} not found or unreadable`, suggestion: 'Re-run install script to inject buddy instructions' };
+  const found: string[] = [];
+  const legacy: string[] = [];
+
+  for (const file of hostPromptFiles()) {
+    const content = readTextSafe(file.path);
+    if (!content) continue;
+    if (content.includes(PROMPT_SENTINEL_V2)) found.push(`${file.host} (${file.path})`);
+    else if (content.includes('buddy-companion')) legacy.push(`${file.host} (${file.path})`);
   }
-  if (content.includes(PROMPT_SENTINEL_V2)) {
-    return { id: 'prompt.injected', status: 'ok', label: 'Prompt injection', detail: `\u2713 ${PROMPT_SENTINEL_V2} found in CLAUDE.md` };
+
+  if (found.length > 0) {
+    return { id: 'prompt.injected', status: 'ok', label: 'Prompt injection', detail: `\u2713 ${formatPathList(found)}` };
   }
-  if (content.includes('buddy-companion')) {
-    return { id: 'prompt.injected', status: 'warn', label: 'Prompt injection', detail: 'v1 sentinel found — needs upgrade to v2', suggestion: 'Re-run install script to upgrade prompt instructions' };
+  if (legacy.length > 0) {
+    return { id: 'prompt.injected', status: 'warn', label: 'Prompt injection', detail: `v1 sentinel found in ${formatPathList(legacy)}`, suggestion: 'Re-run install script to upgrade prompt instructions' };
   }
-  return { id: 'prompt.injected', status: 'warn', label: 'Prompt injection', detail: '\u2717 no buddy instructions in CLAUDE.md', suggestion: 'Re-run install script to inject buddy instructions' };
+  return { id: 'prompt.injected', status: 'warn', label: 'Prompt injection', detail: '\u2717 no buddy instructions found in supported host prompt files', suggestion: 'Re-run install script to inject buddy instructions' };
 }
 
 function checkReasoningMaxMode(): DiagnosticCheck {
@@ -488,7 +569,7 @@ export function formatReport(checks: DiagnosticCheck[]): string {
     'COMPANION': checks.filter(c => c.id.startsWith('companion.')),
     'DATABASE': checks.filter(c => c.id.startsWith('db.')),
     'STATUS FILE': checks.filter(c => c.id.startsWith('status.')),
-    'CLAUDE CODE INTEGRATION': checks.filter(c => c.id.startsWith('mcp.') || c.id.startsWith('config.') || c.id.startsWith('prompt.')),
+    'HOST INTEGRATION': checks.filter(c => c.id.startsWith('mcp.') || c.id.startsWith('config.') || c.id.startsWith('prompt.')),
     'REASONING LAYER': checks.filter(c => c.id.startsWith('reasoning.')),
   };
 


### PR DESCRIPTION
## Summary
- add Buddy post-tool hook auto-configuration for Codex, Cursor, and GitHub Copilot CLI installers
- make the shared post-tool handler accept Codex, Copilot, and Cursor payload shapes
- update buddy_doctor and README so host integration checks no longer assume Claude-only setup

Closes #94.

## Verification
- npm run build
- npm test (blocked by local rolldown native binding failure: ERR_DLOPEN_FAILED in this checkout)