### PR TITLE
Fix stats workflow no-op guard so README updates

### DIFF
--- a/.github/workflows/update-stats.yml
+++ b/.github/workflows/update-stats.yml
@@ -109,6 +109,13 @@ jobs:
           sed -i "s/[0-9,]*+ buddies rescued or hatched/${RESCUED_TEXT} buddies rescued or hatched/" README.md
           sed -i "s/~[0-9]* weeks\? in the wild/${WEEKS_TEXT} in the wild/" README.md
 
+          EXPECTED_HEADLINE="**🚀 ${CLONES_TEXT} clones · ${RESCUED_TEXT} buddies rescued or hatched · ${WEEKS_ALIVE} weeks in the wild**"
+          if ! grep -Fq "$EXPECTED_HEADLINE" README.md; then
+            echo "README headline did not update to the expected stats line."
+            echo "Expected: $EXPECTED_HEADLINE"
+            exit 1
+          fi
+
           # 7. Commit and push directly to master
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"

--- a/.github/workflows/update-stats.yml
+++ b/.github/workflows/update-stats.yml
@@ -60,13 +60,6 @@ jobs:
             )
           ')
 
-          # Exit early when the latest traffic window hasn't changed. This keeps
-          # the backup schedule from producing redundant commits.
-          if [ "$NEW_DAILY_UNIQUES" = "$DAILY_UNIQUES" ] && [ "$NEW_DAILY_CLONES" = "$DAILY_CLONES" ]; then
-            echo "Traffic snapshot unchanged; skipping README and stats update."
-            exit 0
-          fi
-
           # 4. Recalculate totals (Baseline + Sum of Daily)
           UNIQUES_SUM=$(echo "$NEW_DAILY_UNIQUES" | jq '[.[]] | add // 0')
           CLONES_SUM=$(echo "$NEW_DAILY_CLONES" | jq '[.[]] | add // 0')
@@ -109,7 +102,7 @@ jobs:
           WEEKS_TEXT="~${WEEKS_ALIVE} weeks"
 
           # Update clones count
-          sed -i "s/[0-9,]*+ clones/${CLONES_TEXT} clones/" README.md
+          sed -i "s/\*\*🚀 [0-9,]*+ clones · [0-9,]*+ buddies rescued or hatched · [0-9]* weeks in the wild\*\*/\*\*🚀 ${CLONES_TEXT} clones · ${RESCUED_TEXT} buddies rescued or hatched · ${WEEKS_ALIVE} weeks in the wild\*\*/" README.md
           # Update buddies rescued/hatched count
           sed -i "s/\*\*🐾 [0-9,]*+ Buddies Rescued & Hatched · Our terminal companions are finally coming home\.\*\*/\*\*🐾 ${RESCUED_TEXT} Buddies Rescued \& Hatched · Our terminal companions are finally coming home.\*\*/" README.md
           sed -i "s|!\[Buddies Rescued\](https://img.shields.io/badge/buddies_rescued-[0-9,]*+-green?style=flat-square&logo=gitlfs)|!\[Buddies Rescued\](https://img.shields.io/badge/buddies_rescued-${RESCUED_TEXT}-green?style=flat-square\&logo=gitlfs)|" README.md
@@ -127,4 +120,3 @@ jobs:
           else
             echo "No changes to commit."
           fi
-


### PR DESCRIPTION
## Summary
- remove the early exit that skipped README rewrites when traffic data was unchanged
- tighten the README clone-line replacement so it matches the actual README format

## Why
After the baseline-clone fix merged, the stats JSON on master became correct but the README line remained stale. The workflow exited early because the traffic snapshot had not changed, so it never rewrote README.md.

With this fix, backup runs remain safe because the workflow still only commits when the staged diff is non-empty.
