### PR TITLE
fix: insight mode claim extraction instructions in CLAUDE.md (v3)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -381,7 +381,7 @@ function Inject-BuddyPrompt($filePath, $cliName) {
   # Upgrade from older version: strip the old block before appending new one
   if ((Test-Path $filePath) -and (Select-String -Path $filePath -Pattern "buddy-companion" -Quiet)) {
     $content = Get-Content $filePath -Raw
-    $content = $content -replace '(?s)<!-- buddy-companion.*?<!-- /buddy-companion[^>]*-->', ''
+    $content = $content -replace '(?s)<!-- buddy-companion.*?<!-- /buddy-companion v\d+\s*-->', ''
     $content = $content.Trim()
     Set-Content -Path $filePath -Value $content -Encoding UTF8
     Write-Host "  ↑ $cliName prompt upgrading buddy instructions to v3" -ForegroundColor Green

--- a/install.ps1
+++ b/install.ps1
@@ -348,28 +348,43 @@ if (Get-Command codex -ErrorAction SilentlyContinue) {
 # ── Inject buddy instructions into CLI prompt files ──
 
 $BUDDY_INSTRUCTIONS = @"
-<!-- buddy-companion v2 -->
+<!-- buddy-companion v3 -->
 ## Buddy Companion
 
 You have a coding companion available via the buddy MCP server.
 
 **After completing any coding task** (writing code, fixing bugs, refactoring, deploying, running tests), **automatically call ``buddy_observe``** with a 1-sentence summary of what you did. This gives your companion XP and triggers a personality-flavored reaction. Do this every time — the user expects it.
 
+**When insight mode is on**, also pass ``claims``, ``edges``, and ``cwd`` on every ``buddy_observe`` call:
+- ``claims``: 1-4 substantive assertions from the turn that just ended. Each claim needs ``text`` (≤240 chars), ``basis`` (research/empirical/deduction/analogy/definition/llm_output/assumption/vibes), ``speaker`` (user/assistant), ``confidence`` (low/medium/high), and ``external_id`` (e.g. c1).
+- ``edges``: relationships between claims — ``{ from, to, type }`` where type is supports/depends_on/contradicts/questions.
+- ``cwd``: absolute path of the current project root for workspace isolation.
+Skip claims/edges if the turn had no substantive structure. Check ``buddy_status`` or ``buddy_reasoning_status`` to see if insight mode is on.
+
 At the start of each conversation, call ``buddy_status`` to check on your buddy.
 
 If the user addresses the buddy by name, respond briefly in character before your normal response.
 
 After calling buddy_observe, relay the buddy's reaction to the user. The first text content is an ASCII speech bubble — include it verbatim.
-<!-- /buddy-companion v2 -->
+<!-- /buddy-companion v3 -->
 "@
 
 function Inject-BuddyPrompt($filePath, $cliName) {
   $dir = Split-Path $filePath -Parent
   if (!(Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
 
-  if ((Test-Path $filePath) -and (Select-String -Path $filePath -Pattern "buddy-companion" -Quiet)) {
-    Write-Host "  ✓ $cliName prompt already has buddy instructions" -ForegroundColor Green
+  if ((Test-Path $filePath) -and (Select-String -Path $filePath -Pattern "buddy-companion v3" -Quiet)) {
+    Write-Host "  ✓ $cliName prompt already has buddy instructions (v3)" -ForegroundColor Green
     return
+  }
+
+  # Upgrade from older version: strip the old block before appending new one
+  if ((Test-Path $filePath) -and (Select-String -Path $filePath -Pattern "buddy-companion" -Quiet)) {
+    $content = Get-Content $filePath -Raw
+    $content = $content -replace '(?s)<!-- buddy-companion.*?<!-- /buddy-companion[^>]*-->', ''
+    $content = $content.Trim()
+    Set-Content -Path $filePath -Value $content -Encoding UTF8
+    Write-Host "  ↑ $cliName prompt upgrading buddy instructions to v3" -ForegroundColor Green
   }
 
   Add-Content -Path $filePath -Value "`n$BUDDY_INSTRUCTIONS" -Encoding UTF8

--- a/install.sh
+++ b/install.sh
@@ -466,19 +466,25 @@ configure_codex_hooks
 
 # ── Inject buddy instructions into CLI prompt files ──
 
-BUDDY_INSTRUCTIONS='<!-- buddy-companion v2 -->
+BUDDY_INSTRUCTIONS='<!-- buddy-companion v3 -->
 ## Buddy Companion
 
 You have a coding companion available via the buddy MCP server.
 
 **After completing any coding task** (writing code, fixing bugs, refactoring, deploying, running tests), **automatically call `buddy_observe`** with a 1-sentence summary of what you did. This gives your companion XP and triggers a personality-flavored reaction. Do this every time — the user expects it.
 
+**When insight mode is on**, also pass `claims`, `edges`, and `cwd` on every `buddy_observe` call:
+- `claims`: 1-4 substantive assertions from the turn that just ended. Each claim needs `text` (≤240 chars), `basis` (research/empirical/deduction/analogy/definition/llm_output/assumption/vibes), `speaker` (user/assistant), `confidence` (low/medium/high), and `external_id` (e.g. c1).
+- `edges`: relationships between claims — `{ from, to, type }` where type is supports/depends_on/contradicts/questions.
+- `cwd`: absolute path of the current project root for workspace isolation.
+Skip claims/edges if the turn had no substantive structure. Check `buddy_status` or `buddy_reasoning_status` to see if insight mode is on.
+
 At the start of each conversation, call `buddy_status` to check on your buddy.
 
 If the user addresses the buddy by name, respond briefly in character before your normal response.
 
 After calling buddy_observe, relay the buddy'\''s reaction to the user. The first text content is an ASCII speech bubble — include it verbatim.
-<!-- /buddy-companion v2 -->'
+<!-- /buddy-companion v3 -->'
 
 inject_prompt() {
   local file="$1"
@@ -488,9 +494,15 @@ inject_prompt() {
 
   mkdir -p "$dir"
 
-  if [ -f "$file" ] && grep -q "buddy-companion" "$file" 2>/dev/null; then
-    echo -e "  ${GREEN}✓${NC} $cli_name prompt already has buddy instructions"
+  if [ -f "$file" ] && grep -q "buddy-companion v3" "$file" 2>/dev/null; then
+    echo -e "  ${GREEN}✓${NC} $cli_name prompt already has buddy instructions (v3)"
     return 0
+  fi
+
+  # Upgrade from older version: strip the old block before appending new one
+  if [ -f "$file" ] && grep -q "buddy-companion" "$file" 2>/dev/null; then
+    sed -i '/<!-- buddy-companion/,/<!-- \/buddy-companion/d' "$file"
+    echo -e "  ${GREEN}↑${NC} $cli_name prompt upgrading buddy instructions to v3"
   fi
 
   # Append to existing file or create new one

--- a/install.sh
+++ b/install.sh
@@ -501,7 +501,12 @@ inject_prompt() {
 
   # Upgrade from older version: strip the old block before appending new one
   if [ -f "$file" ] && grep -q "buddy-companion" "$file" 2>/dev/null; then
-    sed -i '/<!-- buddy-companion/,/<!-- \/buddy-companion/d' "$file"
+    if grep -q "<!-- /buddy-companion" "$file" 2>/dev/null; then
+      sed -i '/<!-- buddy-companion/,/<!-- \/buddy-companion/d' "$file"
+    else
+      # Malformed block (no closing marker) — remove just the opening line
+      sed -i '/<!-- buddy-companion/d' "$file"
+    fi
     echo -e "  ${GREEN}↑${NC} $cli_name prompt upgrading buddy instructions to v3"
   fi
 

--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { describe, it, expect } from 'vitest';
-import { runDiagnostics, formatReport, PROMPT_SENTINEL_V2 } from '../lib/doctor.js';
+import { runDiagnostics, formatReport, PROMPT_SENTINEL_V2, PROMPT_SENTINEL_V3 } from '../lib/doctor.js';
 
 describe('Doctor — runDiagnostics', () => {
   it('returns an array of checks', () => {
@@ -110,18 +110,19 @@ describe('Doctor — formatReport', () => {
 });
 
 describe('Doctor — sentinel constant', () => {
-  it('exports the v2 sentinel string', () => {
+  it('exports the v2 and v3 sentinel strings', () => {
     expect(PROMPT_SENTINEL_V2).toBe('buddy-companion v2');
+    expect(PROMPT_SENTINEL_V3).toBe('buddy-companion v3');
   });
 
-  it('keeps installer prompt markers aligned with the v2 sentinel', () => {
+  it('keeps installer prompt markers aligned with the v3 sentinel', () => {
     const installSh = readFileSync(new URL('../../install.sh', import.meta.url), 'utf-8');
     const installPs1 = readFileSync(new URL('../../install.ps1', import.meta.url), 'utf-8');
 
-    expect(installSh).toContain('<!-- buddy-companion v2 -->');
-    expect(installSh).toContain('<!-- /buddy-companion v2 -->');
-    expect(installPs1).toContain('<!-- buddy-companion v2 -->');
-    expect(installPs1).toContain('<!-- /buddy-companion v2 -->');
+    expect(installSh).toContain('<!-- buddy-companion v3 -->');
+    expect(installSh).toContain('<!-- /buddy-companion v3 -->');
+    expect(installPs1).toContain('<!-- buddy-companion v3 -->');
+    expect(installPs1).toContain('<!-- /buddy-companion v3 -->');
   });
 });
 

--- a/src/lib/doctor.ts
+++ b/src/lib/doctor.ts
@@ -12,8 +12,9 @@ import { levelProgress } from './leveling.js';
 import { REASONING_CONFIG, telemetry } from './reasoning/index.js';
 import { basisDistributionHealth } from './reasoning/telemetry.js';
 
-// Shared sentinel — keep in sync with install.sh / install.ps1
+// Shared sentinels — keep in sync with install.sh / install.ps1
 export const PROMPT_SENTINEL_V2 = 'buddy-companion v2';
+export const PROMPT_SENTINEL_V3 = 'buddy-companion v3';
 
 /** Default clone/build root from install.sh (INSTALL_DIR) */
 export function canonicalBuddyInstallDir(): string {
@@ -571,7 +572,7 @@ function checkPromptInjection(): DiagnosticCheck {
   for (const file of hostPromptFiles()) {
     const content = readTextSafe(file.path);
     if (!content) continue;
-    if (content.includes(PROMPT_SENTINEL_V2)) found.push(`${file.host} (${file.path})`);
+    if (content.includes(PROMPT_SENTINEL_V3) || content.includes(PROMPT_SENTINEL_V2)) found.push(`${file.host} (${file.path})`);
     else if (content.includes('buddy-companion')) legacy.push(`${file.host} (${file.path})`);
   }
 


### PR DESCRIPTION
## Summary
- Bumps CLAUDE.md prompt injection from v2 → v3 with explicit insight mode instructions for passing `claims`, `edges`, and `cwd` on every `buddy_observe` call
- Installer upgrade logic strips old v2 blocks and replaces with v3 (both install.sh and install.ps1)
- Doctor sentinel updated to recognize both v2 and v3 as current

## Problem
Insight mode was "inert" — on but collecting zero claims — because the CLAUDE.md injection only told hosts to pass a summary. The extraction instruction was buried in the observer prompt response which hosts don't reliably act on across turns.

## Test plan
- [x] `npm test` — 727 tests pass
- [x] Doctor sentinel test updated for v3
- [ ] Manual: re-run installer on a machine with v2 instructions, verify upgrade to v3
- [ ] Manual: verify fresh install gets v3 instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)