### PR TITLE
feat: include claims/edges/cwd guidance in BUDDY_INSTRUCTIONS when guard mode is on

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -428,6 +428,8 @@ At the start of each conversation, call ``buddy_status`` to check on your buddy.
 If the user addresses the buddy by name, respond briefly in character before your normal response.
 
 After calling buddy_observe, relay the buddy's reaction to the user. The first text content is an ASCII speech bubble — include it verbatim.
+
+When guard mode is on, also pass ``claims`` (key assertions from the turn, ≤240 chars each, with ``basis``, ``confidence``, ``speaker``, ``external_id``), ``edges`` (relationships between claims), and ``cwd`` (absolute path to the project root) to ``buddy_observe``.
 <!-- /buddy-companion v2 -->
 "@
 

--- a/install.ps1
+++ b/install.ps1
@@ -416,7 +416,7 @@ if (!hasHook) {
 # ── Inject buddy instructions into CLI prompt files ──
 
 $BUDDY_INSTRUCTIONS = @"
-<!-- buddy-companion v2 -->
+<!-- buddy-companion v3 -->
 ## Buddy Companion
 
 You have a coding companion available via the buddy MCP server.
@@ -430,16 +430,24 @@ If the user addresses the buddy by name, respond briefly in character before you
 After calling buddy_observe, relay the buddy's reaction to the user. The first text content is an ASCII speech bubble — include it verbatim.
 
 When guard mode is on, also pass ``claims`` (key assertions from the turn, ≤240 chars each, with ``basis``, ``confidence``, ``speaker``, ``external_id``), ``edges`` (relationships between claims), and ``cwd`` (absolute path to the project root) to ``buddy_observe``.
-<!-- /buddy-companion v2 -->
+<!-- /buddy-companion v3 -->
 "@
 
 function Inject-BuddyPrompt($filePath, $cliName) {
   $dir = Split-Path $filePath -Parent
   if (!(Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
 
-  if ((Test-Path $filePath) -and (Select-String -Path $filePath -Pattern "buddy-companion" -Quiet)) {
+  if ((Test-Path $filePath) -and (Select-String -Path $filePath -Pattern "buddy-companion v3" -Quiet)) {
     Write-Host "  ✓ $cliName prompt already has buddy instructions" -ForegroundColor Green
     return
+  }
+
+  # Remove older buddy-companion block (v1/v2) before appending current version
+  if ((Test-Path $filePath) -and (Select-String -Path $filePath -Pattern "buddy-companion" -Quiet)) {
+    $content = Get-Content $filePath -Raw
+    $content = [regex]::Replace($content, '(?s)\s*<!-- buddy-companion[^>]*-->.*?<!-- /buddy-companion[^>]*-->\s*', '')
+    Set-Content $filePath -Value $content.Trim() -Encoding UTF8
+    Write-Host "  ✓ $cliName prompt upgraded to v3" -ForegroundColor Green
   }
 
   Add-Content -Path $filePath -Value "`n$BUDDY_INSTRUCTIONS" -Encoding UTF8

--- a/install.sh
+++ b/install.sh
@@ -539,7 +539,8 @@ inject_prompt() {
 
   # Remove older buddy-companion block (v1/v2) before appending current version
   if [ -f "$file" ] && grep -q "buddy-companion" "$file" 2>/dev/null; then
-    sed -i '' '/<!-- buddy-companion/,/<!-- \/buddy-companion/d' "$file"
+    local tmp="${file}.tmp.$$"
+    sed '/<!-- buddy-companion/,/<!-- \/buddy-companion/d' "$file" > "$tmp" && mv "$tmp" "$file"
     echo -e "  ${GREEN}✓${NC} $cli_name prompt upgraded to v3"
   fi
 

--- a/install.sh
+++ b/install.sh
@@ -520,6 +520,8 @@ At the start of each conversation, call `buddy_status` to check on your buddy.
 If the user addresses the buddy by name, respond briefly in character before your normal response.
 
 After calling buddy_observe, relay the buddy'\''s reaction to the user. The first text content is an ASCII speech bubble — include it verbatim.
+
+When guard mode is on, also pass `claims` (key assertions from the turn, ≤240 chars each, with `basis`, `confidence`, `speaker`, `external_id`), `edges` (relationships between claims), and `cwd` (absolute path to the project root) to `buddy_observe`.
 <!-- /buddy-companion v2 -->'
 
 inject_prompt() {

--- a/install.sh
+++ b/install.sh
@@ -508,7 +508,7 @@ configure_codex_hooks
 
 # ── Inject buddy instructions into CLI prompt files ──
 
-BUDDY_INSTRUCTIONS='<!-- buddy-companion v2 -->
+BUDDY_INSTRUCTIONS='<!-- buddy-companion v3 -->
 ## Buddy Companion
 
 You have a coding companion available via the buddy MCP server.
@@ -522,7 +522,7 @@ If the user addresses the buddy by name, respond briefly in character before you
 After calling buddy_observe, relay the buddy'\''s reaction to the user. The first text content is an ASCII speech bubble — include it verbatim.
 
 When guard mode is on, also pass `claims` (key assertions from the turn, ≤240 chars each, with `basis`, `confidence`, `speaker`, `external_id`), `edges` (relationships between claims), and `cwd` (absolute path to the project root) to `buddy_observe`.
-<!-- /buddy-companion v2 -->'
+<!-- /buddy-companion v3 -->'
 
 inject_prompt() {
   local file="$1"
@@ -532,9 +532,15 @@ inject_prompt() {
 
   mkdir -p "$dir"
 
-  if [ -f "$file" ] && grep -q "buddy-companion" "$file" 2>/dev/null; then
+  if [ -f "$file" ] && grep -q "buddy-companion v3" "$file" 2>/dev/null; then
     echo -e "  ${GREEN}✓${NC} $cli_name prompt already has buddy instructions"
     return 0
+  fi
+
+  # Remove older buddy-companion block (v1/v2) before appending current version
+  if [ -f "$file" ] && grep -q "buddy-companion" "$file" 2>/dev/null; then
+    sed -i '' '/<!-- buddy-companion/,/<!-- \/buddy-companion/d' "$file"
+    echo -e "  ${GREEN}✓${NC} $cli_name prompt upgraded to v3"
   fi
 
   # Append to existing file or create new one

--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { describe, it, expect } from 'vitest';
-import { runDiagnostics, formatReport, PROMPT_SENTINEL_V2 } from '../lib/doctor.js';
+import { runDiagnostics, formatReport, PROMPT_SENTINEL_V2, PROMPT_SENTINEL_V3 } from '../lib/doctor.js';
 
 describe('Doctor — runDiagnostics', () => {
   it('returns an array of checks', () => {
@@ -110,18 +110,22 @@ describe('Doctor — formatReport', () => {
 });
 
 describe('Doctor — sentinel constant', () => {
-  it('exports the v2 sentinel string', () => {
+  it('exports the v2 sentinel string for backward compat', () => {
     expect(PROMPT_SENTINEL_V2).toBe('buddy-companion v2');
   });
 
-  it('keeps installer prompt markers aligned with the v2 sentinel', () => {
+  it('exports the v3 sentinel string', () => {
+    expect(PROMPT_SENTINEL_V3).toBe('buddy-companion v3');
+  });
+
+  it('keeps installer prompt markers aligned with the v3 sentinel', () => {
     const installSh = readFileSync(new URL('../../install.sh', import.meta.url), 'utf-8');
     const installPs1 = readFileSync(new URL('../../install.ps1', import.meta.url), 'utf-8');
 
-    expect(installSh).toContain('<!-- buddy-companion v2 -->');
-    expect(installSh).toContain('<!-- /buddy-companion v2 -->');
-    expect(installPs1).toContain('<!-- buddy-companion v2 -->');
-    expect(installPs1).toContain('<!-- /buddy-companion v2 -->');
+    expect(installSh).toContain('<!-- buddy-companion v3 -->');
+    expect(installSh).toContain('<!-- /buddy-companion v3 -->');
+    expect(installPs1).toContain('<!-- buddy-companion v3 -->');
+    expect(installPs1).toContain('<!-- /buddy-companion v3 -->');
   });
 });
 

--- a/src/lib/doctor.ts
+++ b/src/lib/doctor.ts
@@ -14,6 +14,7 @@ import { basisDistributionHealth } from './reasoning/telemetry.js';
 
 // Shared sentinel — keep in sync with install.sh / install.ps1
 export const PROMPT_SENTINEL_V2 = 'buddy-companion v2';
+export const PROMPT_SENTINEL_V3 = 'buddy-companion v3';
 
 /** Default clone/build root from install.sh (INSTALL_DIR) */
 export function canonicalBuddyInstallDir(): string {
@@ -571,7 +572,7 @@ function checkPromptInjection(): DiagnosticCheck {
   for (const file of hostPromptFiles()) {
     const content = readTextSafe(file.path);
     if (!content) continue;
-    if (content.includes(PROMPT_SENTINEL_V2)) found.push(`${file.host} (${file.path})`);
+    if (content.includes(PROMPT_SENTINEL_V3)) found.push(`${file.host} (${file.path})`);
     else if (content.includes('buddy-companion')) legacy.push(`${file.host} (${file.path})`);
   }
 
@@ -579,7 +580,7 @@ function checkPromptInjection(): DiagnosticCheck {
     return { id: 'prompt.injected', status: 'ok', label: 'Prompt injection', detail: `\u2713 ${formatPathList(found)}` };
   }
   if (legacy.length > 0) {
-    return { id: 'prompt.injected', status: 'warn', label: 'Prompt injection', detail: `v1 sentinel found in ${formatPathList(legacy)}`, suggestion: 'Re-run install script to upgrade prompt instructions' };
+    return { id: 'prompt.injected', status: 'warn', label: 'Prompt injection', detail: `older sentinel found in ${formatPathList(legacy)}`, suggestion: 'Re-run install script to upgrade prompt instructions' };
   }
   return { id: 'prompt.injected', status: 'warn', label: 'Prompt injection', detail: '\u2717 no buddy instructions found in supported host prompt files', suggestion: 'Re-run install script to inject buddy instructions' };
 }


### PR DESCRIPTION
Closes #110

## Summary

- Adds guard mode `claims`/`edges`/`cwd` guidance to the `BUDDY_INSTRUCTIONS` block in both `install.sh` and `install.ps1`
- Bumps sentinel from `v2` to `v3` so existing users get the update on reinstall
- `inject_prompt()` and `Inject-BuddyPrompt()` now detect older blocks (v1/v2) and replace them instead of skipping
- `doctor.ts` updated: v3 = ok, older = legacy warning
- Tests updated to verify v3 sentinel alignment

## Why

The injected `CLAUDE.md` block is the AI's system prompt. Without the guard mode line, the AI drops `claims`/`edges`/`cwd` during fast iterative cycles — the reasoning graph stays empty even during active sessions. The sentinel bump ensures existing users get this fix on reinstall without manual intervention.

## Test plan

- [x] Build passes (`npm run build`)
- [x] Sentinel tests pass (`vitest run src/__tests__/doctor.test.ts` — 21/24 pass, 3 failures are pre-existing)
- [x] Codex review: P1 fixed (portable sed for GNU/BSD compat)
- [x] Reinstall over existing v2 block — old block replaced with v3, no duplicates
- [x] Re-run after upgrade — idempotent (no-op)
- [x] Guard mode line present in upgraded block
- [x] Enable guard mode, do a coding task, verify `buddy_observe` includes `claims` array

🤖 Generated with [Claude Code](https://claude.com/claude-code)