### PR TITLE
feat: add buddy_share snapshot system

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "buddy-statusline": "dist/statusline-wrapper.js",
     "buddy-onboard": "dist/cli/onboard.js",
     "buddy-doctor": "dist/cli/doctor-cli.js",
-    "buddy-snapshot": "dist/cli/snapshot-cli.js",
-    "buddy-share": "dist/cli/snapshot-cli.js"
+    "buddy-snapshot": "dist/cli/snapshot-cli.js"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "bin": {
     "buddy-statusline": "dist/statusline-wrapper.js",
     "buddy-onboard": "dist/cli/onboard.js",
-    "buddy-doctor": "dist/cli/doctor-cli.js"
+    "buddy-doctor": "dist/cli/doctor-cli.js",
+    "buddy-snapshot": "dist/cli/snapshot-cli.js"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "bin": {
     "buddy-statusline": "dist/statusline-wrapper.js",
     "buddy-onboard": "dist/cli/onboard.js",
-    "buddy-doctor": "dist/cli/doctor-cli.js",
-    "buddy-snapshot": "dist/cli/snapshot-cli.js"
+    "buddy-doctor": "dist/cli/doctor-cli.js"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "bin": {
     "buddy-statusline": "dist/statusline-wrapper.js",
     "buddy-onboard": "dist/cli/onboard.js",
-    "buddy-doctor": "dist/cli/doctor-cli.js"
+    "buddy-doctor": "dist/cli/doctor-cli.js",
+    "buddy-snapshot": "dist/cli/snapshot-cli.js",
+    "buddy-share": "dist/cli/snapshot-cli.js"
   },
   "files": [
     "dist",

--- a/src/cli/snapshot-cli.ts
+++ b/src/cli/snapshot-cli.ts
@@ -1,13 +1,35 @@
 import { initDb, db } from '../db/schema.js';
 import { loadCompanion } from '../lib/companion.js';
 import { captureSnapshot } from '../lib/snapshot.js';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { join } from 'path';
+import { parseArgs } from 'util';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+function usage(): never {
+  console.log(`Usage: buddy-snapshot [options]
+
+Options:
+  -o, --output <path>     Output PNG path (default: ./buddy_snapshot.png)
+  -m, --message <text>    Speech bubble message
+  --stat <name>           Delta stat name (e.g. WISDOM)
+  --points <n>            Delta points (default: 0)
+  -h, --help              Show this help`);
+  process.exit(0);
+}
 
 async function main() {
+  const { values } = parseArgs({
+    options: {
+      output:  { type: 'string', short: 'o' },
+      message: { type: 'string', short: 'm' },
+      stat:    { type: 'string' },
+      points:  { type: 'string' },
+      help:    { type: 'boolean', short: 'h' },
+    },
+    strict: true,
+  });
+
+  if (values.help) usage();
+
   initDb();
   const row = db.prepare("SELECT * FROM companions LIMIT 1").get() as any;
   if (!row) {
@@ -16,15 +38,11 @@ async function main() {
   }
 
   const companion = loadCompanion(row)!;
-  const outPath = process.argv[2] || join(process.cwd(), 'buddy_snapshot.png');
-  const message = process.argv[3];
-  
-  const deltaStat = process.argv[4];
-  const deltaPoints = parseInt(process.argv[5] || '0');
-  const delta = deltaStat ? { stat: deltaStat, points: deltaPoints } : undefined;
-  
+  const outPath = values.output || join(process.cwd(), 'buddy_snapshot.png');
+  const delta = values.stat ? { stat: values.stat, points: parseInt(values.points || '0') } : undefined;
+
   console.log(`Generating snapshot for ${companion.name}...`);
-  await captureSnapshot(companion, outPath, message, delta);
+  await captureSnapshot(companion, outPath, values.message, delta);
   console.log(`Snapshot saved to: ${outPath}`);
 }
 

--- a/src/cli/snapshot-cli.ts
+++ b/src/cli/snapshot-cli.ts
@@ -1,0 +1,29 @@
+import { initDb, db } from '../db/schema.js';
+import { loadCompanion } from '../lib/companion.js';
+import { captureSnapshot } from '../lib/snapshot.js';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+async function main() {
+  initDb();
+  const row = db.prepare("SELECT * FROM companions LIMIT 1").get() as any;
+  if (!row) {
+    console.error("No buddy found. Hatch one first!");
+    process.exit(1);
+  }
+
+  const companion = loadCompanion(row)!;
+  const outPath = process.argv[2] || join(process.cwd(), 'buddy_snapshot.png');
+  
+  console.log(`Generating snapshot for ${companion.name}...`);
+  await captureSnapshot(companion, outPath);
+  console.log(`Snapshot saved to: ${outPath}`);
+}
+
+main().catch(err => {
+  console.error("Failed to generate snapshot:", err);
+  process.exit(1);
+});

--- a/src/cli/snapshot-cli.ts
+++ b/src/cli/snapshot-cli.ts
@@ -17,9 +17,14 @@ async function main() {
 
   const companion = loadCompanion(row)!;
   const outPath = process.argv[2] || join(process.cwd(), 'buddy_snapshot.png');
+  const message = process.argv[3];
+  
+  const deltaStat = process.argv[4];
+  const deltaPoints = parseInt(process.argv[5] || '0');
+  const delta = deltaStat ? { stat: deltaStat, points: deltaPoints } : undefined;
   
   console.log(`Generating snapshot for ${companion.name}...`);
-  await captureSnapshot(companion, outPath);
+  await captureSnapshot(companion, outPath, message, delta);
   console.log(`Snapshot saved to: ${outPath}`);
 }
 

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,0 +1,210 @@
+import { type Companion, STAT_NAMES, RARITY_STARS } from './types.js';
+import { levelProgress } from './leveling.js';
+
+export function renderShareHtml(companion: Companion): string {
+  const stars = RARITY_STARS[companion.rarity];
+  const { level, currentXp, neededXp } = levelProgress(companion.xp);
+  const xpPercent = Math.min(100, Math.floor((currentXp / neededXp) * 100));
+
+  const statsHtml = STAT_NAMES.map(s => `
+    <div class="stat-row">
+      <span class="stat-name">${s}</span>
+      <div class="bar-bg">
+        <div class="bar-fill" style="width: ${companion.stats[s]}%"></div>
+      </div>
+      <span class="stat-value">${companion.stats[s]}</span>
+    </div>
+  `).join('');
+
+  return `
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    :root {
+      --bg: #0f0c29;
+      --card-bg: rgba(20, 20, 40, 0.9);
+      --accent: #00ff00;
+      --text: #ffffff;
+      --dim: #888899;
+      --border: #333344;
+    }
+    body {
+      margin: 0;
+      padding: 40px;
+      background: var(--bg);
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 500px;
+    }
+    .card {
+      background: var(--card-bg);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      width: 500px;
+      padding: 30px;
+      box-shadow: 0 20px 50px rgba(0,0,0,0.5);
+      position: relative;
+      overflow: hidden;
+    }
+    .card::before {
+      content: '';
+      position: absolute;
+      top: 0; left: 0; right: 0; height: 2px;
+      background: linear-gradient(90deg, transparent, var(--accent), transparent);
+    }
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 30px;
+    }
+    .rarity {
+      color: var(--accent);
+      font-size: 12px;
+      font-weight: 800;
+      letter-spacing: 2px;
+      text-transform: uppercase;
+    }
+    .species {
+      color: var(--dim);
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+    }
+    .main-area {
+      display: flex;
+      gap: 30px;
+      margin-bottom: 30px;
+    }
+    .sprite-box {
+      width: 140px;
+      height: 140px;
+      background: rgba(0,0,0,0.3);
+      border-radius: 15px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      border: 1px solid var(--border);
+    }
+    .sprite-box pre {
+      margin: 0;
+      color: var(--accent);
+      font-family: 'Cascadia Code', 'Fira Code', monospace;
+      font-size: 16px;
+      line-height: 1.2;
+    }
+    .info-box {
+      flex: 1;
+    }
+    .name {
+      font-size: 32px;
+      font-weight: 800;
+      margin: 0 0 10px 0;
+      color: var(--text);
+    }
+    .bio {
+      font-size: 14px;
+      color: var(--dim);
+      font-style: italic;
+      line-height: 1.5;
+    }
+    .stats-container {
+      background: rgba(0,0,0,0.2);
+      padding: 20px;
+      border-radius: 15px;
+      margin-bottom: 20px;
+    }
+    .stat-row {
+      display: flex;
+      align-items: center;
+      gap: 15px;
+      margin-bottom: 12px;
+    }
+    .stat-row:last-child { margin-bottom: 0; }
+    .stat-name {
+      width: 90px;
+      font-size: 10px;
+      font-weight: 700;
+      color: var(--dim);
+      text-transform: uppercase;
+    }
+    .bar-bg {
+      flex: 1;
+      height: 6px;
+      background: #222233;
+      border-radius: 3px;
+      overflow: hidden;
+    }
+    .bar-fill {
+      height: 100%;
+      background: var(--accent);
+      box-shadow: 0 0 10px var(--accent);
+    }
+    .stat-value {
+      width: 30px;
+      font-size: 12px;
+      font-family: monospace;
+      color: var(--accent);
+      text-align: right;
+    }
+    .footer {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      font-size: 12px;
+    }
+    .level-badge {
+      background: var(--accent);
+      color: #000;
+      padding: 4px 12px;
+      border-radius: 20px;
+      font-weight: 800;
+    }
+    .xp-info {
+      color: var(--dim);
+    }
+    .repo-link {
+      margin-top: 20px;
+      text-align: center;
+      font-size: 10px;
+      color: var(--dim);
+      letter-spacing: 1px;
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="header">
+      <div class="rarity">${stars} ${companion.rarity}</div>
+      <div class="species">${companion.species}</div>
+    </div>
+    
+    <div class="main-area">
+      <div class="sprite-box">
+        <pre>RENDER_SPRITE_HERE</pre>
+      </div>
+      <div class="info-box">
+        <h1 class="name">${companion.name}</h1>
+        <div class="bio">"${companion.personalityBio}"</div>
+      </div>
+    </div>
+    
+    <div class="stats-container">
+      ${statsHtml}
+    </div>
+    
+    <div class="footer">
+      <div class="level-badge">LVL ${level}</div>
+      <div class="xp-info">${currentXp} / ${neededXp} XP</div>
+    </div>
+    
+    <div class="repo-link">GITHUB.COM/FIORASTUDIO/BUDDY</div>
+  </div>
+</body>
+</html>
+  `;
+}

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,6 +1,10 @@
 import { type Companion, STAT_NAMES, RARITY_STARS } from './types.js';
 import { levelProgress } from './leveling.js';
 
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
 export type ShareDelta = {
   stat: string;
   points: number;
@@ -19,8 +23,8 @@ export function renderShareHtml(companion: Companion, message?: string, delta?: 
       <div class="stat-row ${isDelta ? 'has-delta' : ''}">
         <span class="stat-name">${s}</span>
         <div class="bar-bg">
-          <div class="bar-fill" style="width: ${baseValue}%"></div>
-          ${isDelta ? `<div class="bar-delta" style="width: ${delta.points}%"></div>` : ''}
+          <div class="bar-fill" style="width: ${Math.min(baseValue, 100)}%"></div>
+          ${isDelta ? `<div class="bar-delta" style="width: ${Math.min(delta.points, 100 - baseValue)}%"></div>` : ''}
         </div>
         <div class="stat-value-container">
           ${isDelta ? `<span class="delta-badge">+${delta.points}</span>` : ''}
@@ -33,7 +37,7 @@ export function renderShareHtml(companion: Companion, message?: string, delta?: 
   const bubbleHtml = message ? `
     <div class="bubble-container">
       <div class="bubble">
-        ${message}
+        ${escapeHtml(message)}
       </div>
       <div class="bubble-tail"></div>
     </div>

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,178 +1,270 @@
 import { type Companion, STAT_NAMES, RARITY_STARS } from './types.js';
 import { levelProgress } from './leveling.js';
 
-export function renderShareHtml(companion: Companion): string {
+export type ShareDelta = {
+  stat: string;
+  points: number;
+};
+
+export function renderShareHtml(companion: Companion, message?: string, delta?: ShareDelta): string {
   const stars = RARITY_STARS[companion.rarity];
   const { level, currentXp, neededXp } = levelProgress(companion.xp);
-  const xpPercent = Math.min(100, Math.floor((currentXp / neededXp) * 100));
-
-  const statsHtml = STAT_NAMES.map(s => `
-    <div class="stat-row">
-      <span class="stat-name">${s}</span>
-      <div class="bar-bg">
-        <div class="bar-fill" style="width: ${companion.stats[s]}%"></div>
+  
+  const statsHtml = STAT_NAMES.map(s => {
+    const isDelta = delta && delta.stat.toUpperCase() === s;
+    const baseValue = isDelta ? Math.max(0, companion.stats[s] - delta.points) : companion.stats[s];
+    const displayValue = companion.stats[s];
+    
+    return `
+      <div class="stat-row ${isDelta ? 'has-delta' : ''}">
+        <span class="stat-name">${s}</span>
+        <div class="bar-bg">
+          <div class="bar-fill" style="width: ${baseValue}%"></div>
+          ${isDelta ? `<div class="bar-delta" style="width: ${delta.points}%"></div>` : ''}
+        </div>
+        <div class="stat-value-container">
+          ${isDelta ? `<span class="delta-badge">+${delta.points}</span>` : ''}
+          <span class="stat-value">${displayValue}</span>
+        </div>
       </div>
-      <span class="stat-value">${companion.stats[s]}</span>
+    `;
+  }).join('');
+
+  const bubbleHtml = message ? `
+    <div class="bubble-container">
+      <div class="bubble">
+        ${message}
+      </div>
+      <div class="bubble-tail"></div>
     </div>
-  `).join('');
+  ` : '';
 
   return `
 <!DOCTYPE html>
 <html>
 <head>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=Fira+Code:wght@400;600&display=swap');
+    
     :root {
-      --bg: #0f0c29;
-      --card-bg: rgba(20, 20, 40, 0.9);
+      --bg: #030014;
+      --card-bg: rgba(13, 12, 34, 0.95);
       --accent: #00ff00;
+      --accent-glow: rgba(0, 255, 0, 0.2);
       --text: #ffffff;
-      --dim: #888899;
-      --border: #333344;
+      --dim: #a0a0c0;
+      --border: rgba(255, 255, 255, 0.1);
+      --surface-highlight: rgba(255, 255, 255, 0.03);
+      --delta-color: #00ffff;
     }
+    
     body {
       margin: 0;
       padding: 40px;
       background: var(--bg);
-      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      font-family: 'Inter', sans-serif;
       display: flex;
       justify-content: center;
       align-items: center;
-      min-height: 500px;
+      min-height: 800px;
     }
+    
     .card {
       background: var(--card-bg);
       border: 1px solid var(--border);
       border-radius: 20px;
-      width: 500px;
+      width: 460px;
       padding: 30px;
-      box-shadow: 0 20px 50px rgba(0,0,0,0.5);
+      box-shadow: 0 30px 60px rgba(0,0,0,0.8);
       position: relative;
-      overflow: hidden;
     }
-    .card::before {
-      content: '';
-      position: absolute;
-      top: 0; left: 0; right: 0; height: 2px;
-      background: linear-gradient(90deg, transparent, var(--accent), transparent);
-    }
+    
+    /* Header */
     .header {
       display: flex;
       justify-content: space-between;
       align-items: center;
-      margin-bottom: 30px;
+      margin-bottom: 20px;
+      padding-bottom: 12px;
+      border-bottom: 1px solid var(--border);
     }
     .rarity {
       color: var(--accent);
-      font-size: 12px;
-      font-weight: 800;
+      font-size: 10px;
+      font-weight: 900;
       letter-spacing: 2px;
       text-transform: uppercase;
     }
     .species {
       color: var(--dim);
-      font-size: 12px;
-      font-weight: 600;
+      font-size: 10px;
+      font-weight: 700;
       letter-spacing: 1px;
       text-transform: uppercase;
     }
-    .main-area {
-      display: flex;
-      gap: 30px;
-      margin-bottom: 30px;
-    }
-    .sprite-box {
-      width: 140px;
-      height: 140px;
-      background: rgba(0,0,0,0.3);
-      border-radius: 15px;
+
+    /* ROW 1: Sprite + Bubble */
+    .row-sprite {
       display: flex;
       justify-content: center;
-      align-items: center;
-      border: 1px solid var(--border);
+      align-items: flex-end;
+      margin-bottom: 5px;
+      position: relative;
+      height: 140px;
     }
     .sprite-box pre {
       margin: 0;
       color: var(--accent);
-      font-family: 'Cascadia Code', 'Fira Code', monospace;
-      font-size: 16px;
-      line-height: 1.2;
+      font-family: 'Fira Code', 'Courier New', monospace;
+      font-size: 18px;
+      line-height: 1.15;
+      text-align: center;
+      text-shadow: 0 0 10px var(--accent-glow);
     }
-    .info-box {
-      flex: 1;
+    
+    .bubble-container {
+      position: absolute;
+      top: 5px;
+      left: 62%; /* Moved slightly right */
+      max-width: 170px;
+      z-index: 10;
+    }
+    .bubble {
+      background: rgba(0, 15, 0, 0.9);
+      color: var(--accent);
+      padding: 12px 16px;
+      border-radius: 18px; /* Rounded bubble shape */
+      border: 1.5px dashed var(--accent); /* "Broken off" look kept */
+      font-family: 'Fira Code', monospace;
+      font-size: 11px;
+      line-height: 1.4;
+      box-shadow: 0 0 10px var(--accent-glow);
+    }
+    .bubble-tail {
+      position: absolute;
+      bottom: 12px;
+      left: -8px;
+      width: 0;
+      height: 0;
+      border-top: 8px solid transparent;
+      border-bottom: 8px solid transparent;
+      border-right: 8px solid var(--accent);
+    }
+    .bubble-tail::after {
+      content: '';
+      position: absolute;
+      top: -8px;
+      left: 1.5px;
+      border-top: 8px solid transparent;
+      border-bottom: 8px solid transparent;
+      border-right: 8px solid rgba(0, 15, 0, 1);
+    }
+
+    /* ROW 2: Bio */
+    .row-bio {
+      text-align: center;
+      margin-bottom: 25px;
+      padding: 15px;
+      background: var(--surface-highlight);
+      border: 1px solid var(--border);
+      border-radius: 16px;
     }
     .name {
-      font-size: 32px;
+      font-size: 24px;
       font-weight: 800;
-      margin: 0 0 10px 0;
+      margin: 0 0 8px 0;
       color: var(--text);
     }
     .bio {
-      font-size: 14px;
+      font-size: 13px;
       color: var(--dim);
       font-style: italic;
-      line-height: 1.5;
+      line-height: 1.4;
     }
-    .stats-container {
-      background: rgba(0,0,0,0.2);
-      padding: 20px;
-      border-radius: 15px;
+
+    /* ROW 3: Stats */
+    .row-stats {
       margin-bottom: 20px;
     }
     .stat-row {
       display: flex;
       align-items: center;
-      gap: 15px;
-      margin-bottom: 12px;
+      gap: 12px;
+      margin-bottom: 10px;
     }
-    .stat-row:last-child { margin-bottom: 0; }
     .stat-name {
-      width: 90px;
-      font-size: 10px;
-      font-weight: 700;
+      width: 80px;
+      font-size: 9px;
+      font-weight: 800;
       color: var(--dim);
       text-transform: uppercase;
     }
     .bar-bg {
       flex: 1;
       height: 6px;
-      background: #222233;
+      background: rgba(255,255,255,0.05);
       border-radius: 3px;
       overflow: hidden;
+      display: flex;
     }
     .bar-fill {
       height: 100%;
       background: var(--accent);
-      box-shadow: 0 0 10px var(--accent);
+    }
+    .bar-delta {
+      height: 100%;
+      background: var(--delta-color);
+    }
+    .stat-value-container {
+      width: 65px;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      justify-content: flex-end;
     }
     .stat-value {
-      width: 30px;
       font-size: 12px;
-      font-family: monospace;
-      color: var(--accent);
-      text-align: right;
+      font-weight: 700;
+      font-family: 'Fira Code', monospace;
+      color: var(--text);
     }
+    .delta-badge {
+      font-size: 9px;
+      font-weight: 900;
+      color: var(--delta-color);
+      background: rgba(0, 255, 255, 0.15);
+      padding: 1px 4px;
+      border-radius: 3px;
+    }
+
+    /* Footer */
     .footer {
       display: flex;
       justify-content: space-between;
       align-items: center;
-      font-size: 12px;
+      padding-top: 10px;
+      border-top: 1px solid var(--border);
     }
     .level-badge {
       background: var(--accent);
       color: #000;
-      padding: 4px 12px;
-      border-radius: 20px;
-      font-weight: 800;
+      padding: 3px 10px;
+      border-radius: 6px;
+      font-weight: 900;
+      font-size: 11px;
     }
     .xp-info {
       color: var(--dim);
+      font-size: 11px;
+      font-weight: 600;
     }
     .repo-link {
       margin-top: 20px;
       text-align: center;
-      font-size: 10px;
+      font-size: 8px;
       color: var(--dim);
-      letter-spacing: 1px;
+      letter-spacing: 1.5px;
+      opacity: 0.4;
     }
   </style>
 </head>
@@ -183,22 +275,24 @@ export function renderShareHtml(companion: Companion): string {
       <div class="species">${companion.species}</div>
     </div>
     
-    <div class="main-area">
+    <div class="row-sprite">
       <div class="sprite-box">
         <pre>RENDER_SPRITE_HERE</pre>
       </div>
-      <div class="info-box">
-        <h1 class="name">${companion.name}</h1>
-        <div class="bio">"${companion.personalityBio}"</div>
-      </div>
+      ${bubbleHtml}
     </div>
     
-    <div class="stats-container">
+    <div class="row-bio">
+      <h1 class="name">${companion.name}</h1>
+      <div class="bio">"${companion.personalityBio}"</div>
+    </div>
+    
+    <div class="row-stats">
       ${statsHtml}
     </div>
     
     <div class="footer">
-      <div class="level-badge">LVL ${level}</div>
+      <div class="level-badge">LEVEL ${level}</div>
       <div class="xp-info">${currentXp} / ${neededXp} XP</div>
     </div>
     

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -110,7 +110,8 @@ export function renderShareHtml(companion: Companion, message?: string, delta?: 
       align-items: flex-end;
       margin-bottom: 5px;
       position: relative;
-      height: 140px;
+      min-height: 140px;
+      overflow: visible;
     }
     .sprite-box pre {
       margin: 0;
@@ -125,7 +126,7 @@ export function renderShareHtml(companion: Companion, message?: string, delta?: 
     .bubble-container {
       position: absolute;
       top: 5px;
-      left: 62%; /* Moved slightly right */
+      right: -10px;
       max-width: 170px;
       z-index: 10;
     }

--- a/src/lib/snapshot.ts
+++ b/src/lib/snapshot.ts
@@ -1,0 +1,42 @@
+import puppeteer from 'puppeteer';
+import { type Companion, RARITY_STARS } from '../lib/types.js';
+import { renderShareHtml } from '../lib/share.js';
+import { renderSprite } from '../lib/species.js';
+import { join } from 'path';
+import { writeFileSync } from 'fs';
+
+export async function captureSnapshot(companion: Companion, outPath: string) {
+  const browser = await puppeteer.launch({ 
+    headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox']
+  });
+  const page = await browser.newPage();
+  
+  // Set viewport to card size plus padding
+  await page.setViewport({ width: 600, height: 600, deviceScaleFactor: 2 });
+
+  let html = renderShareHtml(companion);
+  
+  // Inject the actual sprite
+  const spriteLines = renderSprite(companion);
+  const spriteHtml = spriteLines.join('\n')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+    
+  html = html.replace('RENDER_SPRITE_HERE', spriteHtml);
+
+  await page.setContent(html);
+  
+  // Wait for font/styles to settle
+  await new Promise(r => setTimeout(r, 100));
+
+  const cardElement = await page.$('.card');
+  if (cardElement) {
+    await cardElement.screenshot({ path: outPath });
+  } else {
+    await page.screenshot({ path: outPath });
+  }
+
+  await browser.close();
+}

--- a/src/lib/snapshot.ts
+++ b/src/lib/snapshot.ts
@@ -1,21 +1,21 @@
 import puppeteer from 'puppeteer';
 import { type Companion, RARITY_STARS } from '../lib/types.js';
-import { renderShareHtml } from '../lib/share.js';
+import { renderShareHtml, type ShareDelta } from '../lib/share.js';
 import { renderSprite } from '../lib/species.js';
 import { join } from 'path';
 import { writeFileSync } from 'fs';
 
-export async function captureSnapshot(companion: Companion, outPath: string) {
+export async function captureSnapshot(companion: Companion, outPath: string, message?: string, delta?: ShareDelta) {
   const browser = await puppeteer.launch({ 
     headless: true,
     args: ['--no-sandbox', '--disable-setuid-sandbox']
   });
   const page = await browser.newPage();
   
-  // Set viewport to card size plus padding
-  await page.setViewport({ width: 600, height: 600, deviceScaleFactor: 2 });
+  // Set viewport to card size plus padding (increased height to ensure bottom isn't cut)
+  await page.setViewport({ width: 600, height: 900, deviceScaleFactor: 2 });
 
-  let html = renderShareHtml(companion);
+  let html = renderShareHtml(companion, message, delta);
   
   // Inject the actual sprite
   const spriteLines = renderSprite(companion);
@@ -33,10 +33,17 @@ export async function captureSnapshot(companion: Companion, outPath: string) {
 
   const cardElement = await page.$('.card');
   if (cardElement) {
-    await cardElement.screenshot({ path: outPath });
+    // If bubble is present, we need a larger bounding box or just screenshot the page
+    const bubble = await page.$('.bubble-container');
+    if (bubble) {
+      await page.screenshot({ path: outPath, fullPage: false });
+    } else {
+      await cardElement.screenshot({ path: outPath });
+    }
   } else {
     await page.screenshot({ path: outPath });
   }
 
   await browser.close();
 }
+

--- a/src/lib/snapshot.ts
+++ b/src/lib/snapshot.ts
@@ -1,49 +1,33 @@
 import puppeteer from 'puppeteer';
-import { type Companion, RARITY_STARS } from '../lib/types.js';
-import { renderShareHtml, type ShareDelta } from '../lib/share.js';
-import { renderSprite } from '../lib/species.js';
-import { join } from 'path';
-import { writeFileSync } from 'fs';
+import { type Companion } from './types.js';
+import { renderShareHtml, type ShareDelta } from './share.js';
+import { renderSprite } from './species.js';
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
 
 export async function captureSnapshot(companion: Companion, outPath: string, message?: string, delta?: ShareDelta) {
-  const browser = await puppeteer.launch({ 
+  const browser = await puppeteer.launch({
     headless: true,
     args: ['--no-sandbox', '--disable-setuid-sandbox']
   });
-  const page = await browser.newPage();
-  
-  // Set viewport to card size plus padding (increased height to ensure bottom isn't cut)
-  await page.setViewport({ width: 600, height: 900, deviceScaleFactor: 2 });
 
-  let html = renderShareHtml(companion, message, delta);
-  
-  // Inject the actual sprite
-  const spriteLines = renderSprite(companion);
-  const spriteHtml = spriteLines.join('\n')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-    
-  html = html.replace('RENDER_SPRITE_HERE', spriteHtml);
+  try {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 600, height: 900, deviceScaleFactor: 2 });
 
-  await page.setContent(html);
-  
-  // Wait for font/styles to settle
-  await new Promise(r => setTimeout(r, 100));
+    let html = renderShareHtml(companion, message, delta);
 
-  const cardElement = await page.$('.card');
-  if (cardElement) {
-    // If bubble is present, we need a larger bounding box or just screenshot the page
-    const bubble = await page.$('.bubble-container');
-    if (bubble) {
-      await page.screenshot({ path: outPath, fullPage: false });
-    } else {
-      await cardElement.screenshot({ path: outPath });
-    }
-  } else {
-    await page.screenshot({ path: outPath });
+    const spriteLines = renderSprite(companion);
+    const spriteHtml = escapeHtml(spriteLines.join('\n'));
+    html = html.replace('RENDER_SPRITE_HERE', spriteHtml);
+
+    await page.setContent(html);
+    await page.evaluateHandle(() => document.fonts.ready);
+
+    await page.screenshot({ path: outPath, fullPage: false });
+  } finally {
+    await browser.close();
   }
-
-  await browser.close();
 }
-

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -297,16 +297,6 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         description: "Run diagnostics on your Buddy installation. Checks companion state, database, MCP registration, statusline, hooks, and prompt injection. Returns a report you can paste into bug reports. IMPORTANT: Include the full diagnostic report verbatim in a code block in your response.",
         inputSchema: { type: "object", properties: {} },
       },
-      {
-        name: "buddy_share",
-        description: "Generate a beautiful shareable snapshot of your Buddy's current status and card. Returns the local path to the generated image.",
-        inputSchema: {
-          type: "object",
-          properties: {
-            user_id: { type: "string", description: "Optional user ID for bones." }
-          },
-        },
-      },
     ],
   };
 });
@@ -718,24 +708,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const checks = runDiagnostics();
     const report = formatReport(checks);
     return { content: [{ type: "text", text: '```\n' + report + '\n```' }] };
-  }
-
-  if (name === "buddy_share") {
-    const { user_id } = args as { user_id?: string };
-    const row = db.prepare("SELECT * FROM companions LIMIT 1").get() as any;
-    if (!row) return { content: [{ type: "text", text: "Hatch a buddy first!" }] };
-
-    const companion = loadCompanion(row, user_id || row.user_id)!;
-    const outPath = join(homedir(), '.buddy', `share_${companion.name.toLowerCase()}.png`);
-    
-    await captureSnapshot(companion, outPath);
-
-    return {
-      content: [
-        { type: "text", text: `📸 Snapshot generated for ${companion.name}!` },
-        { type: "text", text: `Path: ${outPath}` }
-      ],
-    };
   }
 
   throw new Error(`Tool not found: ${name}`);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -25,6 +25,7 @@ import { join, dirname } from "path";
 import { homedir } from "os";
 import { loadCompanion, writeBuddyStatus, createCompanion } from "../lib/companion.js";
 import { renderCard, hatchAnimation } from "../lib/card.js";
+import { captureSnapshot } from "../lib/snapshot.js";
 import { BUDDY_STATUS_PATH } from "../lib/constants.js";
 import { runDiagnostics, formatReport } from "../lib/doctor.js";
 import {
@@ -295,6 +296,16 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         name: "buddy_doctor",
         description: "Run diagnostics on your Buddy installation. Checks companion state, database, MCP registration, statusline, hooks, and prompt injection. Returns a report you can paste into bug reports. IMPORTANT: Include the full diagnostic report verbatim in a code block in your response.",
         inputSchema: { type: "object", properties: {} },
+      },
+      {
+        name: "buddy_share",
+        description: "Generate a beautiful shareable snapshot of your Buddy's current status and card. Returns the local path to the generated image.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            user_id: { type: "string", description: "Optional user ID for bones." }
+          },
+        },
       },
     ],
   };
@@ -707,6 +718,24 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const checks = runDiagnostics();
     const report = formatReport(checks);
     return { content: [{ type: "text", text: '```\n' + report + '\n```' }] };
+  }
+
+  if (name === "buddy_share") {
+    const { user_id } = args as { user_id?: string };
+    const row = db.prepare("SELECT * FROM companions LIMIT 1").get() as any;
+    if (!row) return { content: [{ type: "text", text: "Hatch a buddy first!" }] };
+
+    const companion = loadCompanion(row, user_id || row.user_id)!;
+    const outPath = join(homedir(), '.buddy', `share_${companion.name.toLowerCase()}.png`);
+    
+    await captureSnapshot(companion, outPath);
+
+    return {
+      content: [
+        { type: "text", text: `📸 Snapshot generated for ${companion.name}!` },
+        { type: "text", text: `Path: ${outPath}` }
+      ],
+    };
   }
 
   throw new Error(`Tool not found: ${name}`);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -25,7 +25,6 @@ import { join, dirname } from "path";
 import { homedir } from "os";
 import { loadCompanion, writeBuddyStatus, createCompanion } from "../lib/companion.js";
 import { renderCard, hatchAnimation } from "../lib/card.js";
-import { captureSnapshot } from "../lib/snapshot.js";
 import { BUDDY_STATUS_PATH } from "../lib/constants.js";
 import { runDiagnostics, formatReport } from "../lib/doctor.js";
 import {


### PR DESCRIPTION
Implements an HTML/Puppeteer-based snapshot system for generating high-res shareable Buddy cards. Includes a standalone CLI tool. Note: As per the 'Lean MCP' philosophy, the buddy_share tool is NOT registered in the MCP server list; it is intended to be used via an OpenClaw skill or the CLI directly to minimize token overhead.