### PR TITLE
fix: CLI binary, MCP settings.json registration, native module rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Kudos nudges are slightly favored — after 3 caution findings with zero kudos, 
 
 **Token cost:** ~500-1000 extra tokens per `buddy_observe` when on. Default calls with guard mode off are unaffected.
 
-**Host compatibility:** Works best on Claude hosts where the extraction prompt is reliably honored. Run `buddy_doctor` to check.
+**Host compatibility:** Works best on Claude hosts where the extraction prompt is reliably honored. Run `buddy-doctor` to check.
 
 </details>
 

--- a/install.ps1
+++ b/install.ps1
@@ -47,8 +47,18 @@ Push-Location $INSTALL_DIR
 
 Write-Host "  Installing dependencies..."
 npm install --quiet 2>$null
+npm rebuild --quiet 2>$null
 Write-Host "  Building..."
 npm run build --quiet 2>$null
+
+# ── Add CLI binaries to PATH ──
+$BIN_DIR = "$INSTALL_DIR\dist\cli"
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if ($userPath -notlike "*$BIN_DIR*") {
+  [Environment]::SetEnvironmentVariable("Path", "$userPath;$BIN_DIR", "User")
+  $env:Path = "$env:Path;$BIN_DIR"
+  Write-Host "  Added $BIN_DIR to user PATH"
+}
 
 $SERVER_PATH = "$INSTALL_DIR\dist\server\index.js"
 $SERVER_PATH_UNIX = $SERVER_PATH -replace '\\', '/'
@@ -159,6 +169,8 @@ $env:HOOK_COMMAND = "node $HOOK_PATH_UNIX"
 $env:STOP_HOOK_COMMAND = "node $STOP_HOOK_PATH_UNIX"
 $env:PROMPT_HOOK_COMMAND = "node $PROMPT_HOOK_PATH_UNIX"
 $env:STATUSLINE_COMMAND = $statuslineCommand
+$env:SERVER_PATH = $SERVER_PATH_UNIX
+$env:NODE_BIN = "node"
 $settingsResult = node -e @'
 const fs = require('fs');
 const settingsPath = process.env.CLAUDE_SETTINGS;
@@ -166,10 +178,23 @@ const hookCommand = process.env.HOOK_COMMAND;
 const stopHookCommand = process.env.STOP_HOOK_COMMAND;
 const promptHookCommand = process.env.PROMPT_HOOK_COMMAND;
 const statuslineCommand = process.env.STATUSLINE_COMMAND;
+const serverPath = process.env.SERVER_PATH;
+const nodeBin = process.env.NODE_BIN;
 let config = {};
 try { config = JSON.parse(fs.readFileSync(settingsPath, 'utf-8')); } catch {}
 let changed = false;
 const result = [];
+
+// MCP server registration
+if (!config.mcpServers) config.mcpServers = {};
+const existing = config.mcpServers.buddy;
+if (!existing || existing.command !== nodeBin || !Array.isArray(existing.args) || existing.args[0] !== serverPath) {
+  config.mcpServers.buddy = { type: 'stdio', command: nodeBin, args: [serverPath] };
+  changed = true;
+  result.push('mcp:updated');
+} else {
+  result.push('mcp:noop');
+}
 
 if (!config.hooks) config.hooks = {};
 
@@ -248,6 +273,11 @@ if (changed) {
 process.stdout.write(result.join(','));
 '@ 2>$null
 
+if ($settingsResult -match 'mcp:updated') {
+  Write-Host "  ✓ MCP server registered in settings.json" -ForegroundColor Green
+} else {
+  Write-Host "  ✓ MCP server already in settings.json" -ForegroundColor Green
+}
 if ($settingsResult -match 'hook:updated') {
   Write-Host "  ✓ PostToolUse hook configured" -ForegroundColor Green
 } else {

--- a/install.sh
+++ b/install.sh
@@ -97,8 +97,21 @@ cd "$INSTALL_DIR"
 
 echo "  Installing dependencies..."
 npm install --quiet 2>/dev/null
+npm rebuild --quiet 2>/dev/null
 echo "  Building..."
 npm run build --quiet 2>/dev/null
+
+# ── Symlink CLI binaries onto PATH ──
+for bin_entry in buddy:buddy.js buddy-doctor:doctor-cli.js; do
+  bin_name="${bin_entry%%:*}"
+  bin_file="$INSTALL_DIR/dist/cli/${bin_entry##*:}"
+  if [ -f "$bin_file" ]; then
+    chmod +x "$bin_file"
+    ln -sf "$bin_file" "/usr/local/bin/$bin_name" 2>/dev/null \
+      || sudo ln -sf "$bin_file" "/usr/local/bin/$bin_name" 2>/dev/null \
+      || echo "  ${YELLOW}Could not symlink $bin_name to /usr/local/bin — add $INSTALL_DIR/dist/cli to your PATH${NC}"
+  fi
+done
 
 SERVER_PATH="$INSTALL_DIR/dist/server/index.js"
 CODEX_CONFIGURED=0
@@ -164,17 +177,30 @@ EOJS
 
   # Configure hook + statusline in a single settings.json write
   local settings_result
-  settings_result=$(CLAUDE_SETTINGS="$settings_file" HOOK_COMMAND="$HOOK_COMMAND" STOP_HOOK_COMMAND="$stop_hook_command" PROMPT_HOOK_COMMAND="$prompt_hook_command" STATUSLINE_COMMAND="$statusline_command" "$NODE_BIN" <<'EOJS'
+  settings_result=$(CLAUDE_SETTINGS="$settings_file" HOOK_COMMAND="$HOOK_COMMAND" STOP_HOOK_COMMAND="$stop_hook_command" PROMPT_HOOK_COMMAND="$prompt_hook_command" STATUSLINE_COMMAND="$statusline_command" SERVER_PATH="$SERVER_PATH" NODE_BIN="$CONFIG_NODE_BIN" "$NODE_BIN" <<'EOJS'
 const fs = require('fs');
 const settingsPath = process.env.CLAUDE_SETTINGS;
 const hookCommand = process.env.HOOK_COMMAND;
 const stopHookCommand = process.env.STOP_HOOK_COMMAND;
 const promptHookCommand = process.env.PROMPT_HOOK_COMMAND;
 const statuslineCommand = process.env.STATUSLINE_COMMAND;
+const serverPath = process.env.SERVER_PATH;
+const nodeBin = process.env.NODE_BIN;
 let config = {};
 try { config = JSON.parse(fs.readFileSync(settingsPath, 'utf-8')); } catch {}
 let changed = false;
 const result = [];
+
+// MCP server registration
+if (!config.mcpServers) config.mcpServers = {};
+const existing = config.mcpServers.buddy;
+if (!existing || existing.command !== nodeBin || !Array.isArray(existing.args) || existing.args[0] !== serverPath) {
+  config.mcpServers.buddy = { type: 'stdio', command: nodeBin, args: [serverPath] };
+  changed = true;
+  result.push('mcp:updated');
+} else {
+  result.push('mcp:noop');
+}
 
 if (!config.hooks) config.hooks = {};
 
@@ -253,6 +279,10 @@ if (changed) {
 process.stdout.write(result.join(','));
 EOJS
 )
+  case "$settings_result" in
+    *mcp:updated*) echo -e "  ${GREEN}✓${NC} MCP server registered in settings.json" ;;
+    *)             echo -e "  ${GREEN}✓${NC} MCP server already in settings.json" ;;
+  esac
   case "$settings_result" in
     *hook:updated*) echo -e "  ${GREEN}✓${NC} PostToolUse hook configured" ;;
     *)              echo -e "  ${GREEN}✓${NC} PostToolUse hook already configured" ;;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fiorastudio/buddy",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fiorastudio/buddy",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Persistent AI coding companion - MCP server with 21 species, personality stats, and code feedback",
   "main": "dist/server/index.js",
   "bin": {
+    "buddy": "dist/cli/buddy.js",
     "buddy-statusline": "dist/statusline-wrapper.js",
     "buddy-onboard": "dist/cli/onboard.js",
     "buddy-doctor": "dist/cli/doctor-cli.js"

--- a/src/cli/buddy.ts
+++ b/src/cli/buddy.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+const subcommand = process.argv[2];
+
+if (!subcommand || subcommand === '--help' || subcommand === '-h') {
+  console.log(`Usage: buddy <command>
+
+Commands:
+  doctor    Run diagnostics on your Buddy installation
+  onboard   Interactive onboarding wizard`);
+  process.exit(0);
+}
+
+if (subcommand === 'doctor') {
+  await import('./doctor-cli.js');
+} else if (subcommand === 'onboard') {
+  await import('./onboard.js');
+} else {
+  console.error(`Unknown command: ${subcommand}\nRun "buddy --help" for usage.`);
+  process.exit(1);
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -26,7 +26,6 @@ import { homedir } from "os";
 import { loadCompanion, writeBuddyStatus, createCompanion } from "../lib/companion.js";
 import { renderCard, hatchAnimation } from "../lib/card.js";
 import { BUDDY_STATUS_PATH } from "../lib/constants.js";
-import { runDiagnostics, formatReport } from "../lib/doctor.js";
 import {
   deriveSessionId,
   formatModeResponse,
@@ -289,11 +288,6 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       {
         name: "buddy_reasoning_status",
         description: "Inspect what guard mode has stored: claim count, findings history, graph size per session. Useful for users who want to audit what's in buddy.db or debug guard-mode behavior.",
-        inputSchema: { type: "object", properties: {} },
-      },
-      {
-        name: "buddy_doctor",
-        description: "Run diagnostics on your Buddy installation. Checks companion state, database, MCP registration, statusline, hooks, and prompt injection. Returns a report you can paste into bug reports. IMPORTANT: Include the full diagnostic report verbatim in a code block in your response.",
         inputSchema: { type: "object", properties: {} },
       },
     ],
@@ -701,12 +695,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     lines.push(`Purge with buddy_forget (scope: session | all).`);
 
     return { content: [{ type: "text", text: lines.join('\n') }] };
-  }
-
-  if (name === "buddy_doctor") {
-    const checks = runDiagnostics();
-    const report = formatReport(checks);
-    return { content: [{ type: "text", text: '```\n' + report + '\n```' }] };
   }
 
   throw new Error(`Tool not found: ${name}`);


### PR DESCRIPTION
## Summary
- **`buddy doctor` CLI**: Added top-level `buddy` CLI router so both `buddy doctor` (subcommand) and `buddy-doctor` (direct bin) work. Symlinks created during install.
- **MCP in settings.json**: Installer now registers `mcpServers.buddy` in `~/.claude/settings.json` alongside hooks/statusline — fixes first-time users not seeing the MCP server.
- **Native module rebuild**: Added `npm rebuild` after `npm install` in both installers to fix `better-sqlite3` NODE_MODULE_VERSION mismatches when Node upgrades.
- **Removed `buddy_doctor` MCP tool**: Diagnostics are now CLI-only via `buddy-doctor` / `buddy doctor`.

## Test plan
- [x] Run `install.sh` on a clean machine — verify `buddy-doctor` and `buddy doctor` both work
- [x] Check `~/.claude/settings.json` contains `mcpServers.buddy` after install
- [x] Upgrade Node, re-run installer — verify no `ERR_DLOPEN_FAILED` from better-sqlite3
- [x] Verify `buddy_doctor` MCP tool is no longer listed by the server

🤖 Generated with [Claude Code](https://claude.com/claude-code)