### PR TITLE
docs: add buddy_share to MCP tools table

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ These stay tucked away by default, but Buddy exposes a real MCP surface for comp
 | `buddy_dream` | Consolidate memories (Placeholder) |
 | `buddy_mute` | Pause reactions |
 | `buddy_unmute` | Resume reactions |
+| `buddy_share` | Generate a shareable PNG snapshot of your buddy's current status and card art. Saved to `~/.buddy/shares/`. |
 | `buddy_respawn` | Reset and start over |
 | `buddy_mode` | Set voice and Guard independently. `buddy_mode voice=skillcoach` for code feedback, `buddy_mode guard=true` for reasoning analysis. See [Guard Mode](#guard-mode). |
 | `buddy_forget` | Purge stored reasoning data. Scope `session` (default, current workspace/day) or `all`. |


### PR DESCRIPTION
## Summary
- `buddy_share` is registered as an MCP tool in `src/server/index.ts` but was missing from the README's tool reference table
- Adds a one-line entry describing the tool: generates a shareable PNG snapshot saved to `~/.buddy/shares/`

## Test plan
- [ ] Verify the tool table renders correctly on GitHub
- [ ] Confirm description matches the actual tool behavior in `src/server/index.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)