### PR TITLE
fix: keep community CTA after install onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The installer will guide you through onboarding:
 
 Connect with other buddy rescuers, share your companion's evolution, and get help in our Slack community:
 
-[**Join Buddy Slack Workspace**](https://join.slack.com/t/buddy-mcp/invite/enQtMTEwOTI4OTM1MzUzOTktMzVlMjc0YWRiZDllODgxMDQ1MzYwZDhhM2ZmNDRkNGEyNTBkZDU4MDQxNTM0N2EyYWQwNTBhN2QwMjFjYTBkZf)
+[**Join Buddy Slack Workspace**](https://join.slack.com/t/buddy-mcp/shared_invite/zt-3xn6v1qza-R~fgkVCov9sCLZDXh9wErQ)
 
 | Client | Status |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ curl -fsSL https://raw.githubusercontent.com/fiorastudio/buddy/master/install.sh
 irm https://raw.githubusercontent.com/fiorastudio/buddy/master/install.ps1 | iex
 ```
 
+### Join the Community
+
+Connect with other buddy rescuers, share your companion's evolution, and get help in our Slack community:
+
+[**Join Buddy Slack Workspace**](https://join.slack.com/t/buddy-mcp/invite/enQtMTEwOTI4OTM1MzUzOTktMzVlMjc0YWRiZDllODgxMDQ1MzYwZDhhM2ZmNDRkNGEyNTBkZDU4MDQxNTM0N2EyYWQwNTBhN2QwMjFjYTBkZf)
+
 The installer will guide you through onboarding:
 
 - **Rescue your old buddy** — if you had a `/buddy` in Claude Code, the wizard finds it in `~/.claude.json` and brings it home with the same name, species, and stats, now with leveling + XP

--- a/README.md
+++ b/README.md
@@ -107,18 +107,18 @@ curl -fsSL https://raw.githubusercontent.com/fiorastudio/buddy/master/install.sh
 irm https://raw.githubusercontent.com/fiorastudio/buddy/master/install.ps1 | iex
 ```
 
-### Join the Community
-
-Connect with other buddy rescuers, share your companion's evolution, and get help in our Slack community:
-
-[**Join Buddy Slack Workspace**](https://join.slack.com/t/buddy-mcp/invite/enQtMTEwOTI4OTM1MzUzOTktMzVlMjc0YWRiZDllODgxMDQ1MzYwZDhhM2ZmNDRkNGEyNTBkZDU4MDQxNTM0N2EyYWQwNTBhN2QwMjFjYTBkZf)
-
 The installer will guide you through onboarding:
 
 - **Rescue your old buddy** — if you had a `/buddy` in Claude Code, the wizard finds it in `~/.claude.json` and brings it home with the same name, species, and stats, now with leveling + XP
 - **Hatch a new buddy** — get a fresh companion with random species, stats, and personality
 
 > Requires `node` 18+ and `git`. Use `--no-onboard` to skip the wizard in CI.
+
+### Join the Community
+
+Connect with other buddy rescuers, share your companion's evolution, and get help in our Slack community:
+
+[**Join Buddy Slack Workspace**](https://join.slack.com/t/buddy-mcp/invite/enQtMTEwOTI4OTM1MzUzOTktMzVlMjc0YWRiZDllODgxMDQ1MzYwZDhhM2ZmNDRkNGEyNTBkZDU4MDQxNTM0N2EyYWQwNTBhN2QwMjFjYTBkZf)
 
 | Client | Status |
 |---|---|

--- a/install.ps1
+++ b/install.ps1
@@ -525,6 +525,12 @@ if ($COPILOT_CONFIGURED) {
 
 # ── Run onboarding wizard ──
 
+Write-Host ""
+Write-Host "  💬 Join the Buddy Community!" -ForegroundColor Blue
+Write-Host "  Connect with other rescuers on Slack:"
+Write-Host "  https://join.slack.com/t/buddy-mcp/invite/enQtMTEwOTI4OTM1MzUzOTktMzVlMjc0YWRiZDllODgxMDQ1MzYwZDhhM2ZmNDRkNGEyNTBkZDU4MDQxNTM0N2EyYWQwNTBhN2QwMjFjYTBkZf" -ForegroundColor Gray
+Write-Host ""
+
 $ONBOARD_SCRIPT = "$INSTALL_DIR\dist\cli\onboard.js"
 if (Test-Path $ONBOARD_SCRIPT) {
   try {

--- a/install.ps1
+++ b/install.ps1
@@ -528,7 +528,7 @@ if ($COPILOT_CONFIGURED) {
 Write-Host ""
 Write-Host "  💬 Join the Buddy Community!" -ForegroundColor Blue
 Write-Host "  Connect with other rescuers on Slack:"
-Write-Host "  https://join.slack.com/t/buddy-mcp/invite/enQtMTEwOTI4OTM1MzUzOTktMzVlMjc0YWRiZDllODgxMDQ1MzYwZDhhM2ZmNDRkNGEyNTBkZDU4MDQxNTM0N2EyYWQwNTBhN2QwMjFjYTBkZf" -ForegroundColor Gray
+Write-Host "  https://join.slack.com/t/buddy-mcp/shared_invite/zt-3xn6v1qza-R~fgkVCov9sCLZDXh9wErQ" -ForegroundColor Gray
 Write-Host ""
 
 $ONBOARD_SCRIPT = "$INSTALL_DIR\dist\cli\onboard.js"

--- a/install.sh
+++ b/install.sh
@@ -626,6 +626,13 @@ fi
 # ── Run onboarding wizard ──
 
 ONBOARD_SCRIPT="$INSTALL_DIR/dist/cli/onboard.js"
+
+echo ""
+echo -e "${BLUE}  💬 Join the Buddy Community!${NC}"
+echo -e "  Connect with other rescuers on Slack:"
+echo -e "  ${DIM}https://join.slack.com/t/buddy-mcp/invite/enQtMTEwOTI4OTM1MzUzOTktMzVlMjc0YWRiZDllODgxMDQ1MzYwZDhhM2ZmNDRkNGEyNTBkZDU4MDQxNTM0N2EyYWQwNTBhN2QwMjFjYTBkZf${NC}"
+echo ""
+
 if [ -f "$ONBOARD_SCRIPT" ] && [ "$NO_ONBOARD" -eq 0 ]; then
   # Let onboard.ts detect TTY itself — don't force /dev/tty
   # (fails in headless SSH, CI, cron where no controlling terminal exists)

--- a/install.sh
+++ b/install.sh
@@ -630,7 +630,7 @@ ONBOARD_SCRIPT="$INSTALL_DIR/dist/cli/onboard.js"
 echo ""
 echo -e "${BLUE}  💬 Join the Buddy Community!${NC}"
 echo -e "  Connect with other rescuers on Slack:"
-echo -e "  ${DIM}https://join.slack.com/t/buddy-mcp/invite/enQtMTEwOTI4OTM1MzUzOTktMzVlMjc0YWRiZDllODgxMDQ1MzYwZDhhM2ZmNDRkNGEyNTBkZDU4MDQxNTM0N2EyYWQwNTBhN2QwMjFjYTBkZf${NC}"
+echo -e "  ${DIM}https://join.slack.com/t/buddy-mcp/shared_invite/zt-3xn6v1qza-R~fgkVCov9sCLZDXh9wErQ${NC}"
 echo ""
 
 if [ -f "$ONBOARD_SCRIPT" ] && [ "$NO_ONBOARD" -eq 0 ]; then


### PR DESCRIPTION
## Summary
- keep the install quickstart contiguous in the README
- move the Slack community CTA below the onboarding bullets and install note
- leave the installer Slack messaging from #120 intact

## Context
This replaces the docs-flow issue in #120 without changing the installer behavior.