### PR TITLE
chore: add emoji before Slack invite URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The installer will guide you through onboarding:
 
 Connect with other buddy rescuers, share your companion's evolution, and get help in our Slack community:
 
-[**Join Buddy Slack Workspace**](https://join.slack.com/t/buddy-mcp/shared_invite/zt-3xn6v1qza-R~fgkVCov9sCLZDXh9wErQ)
+👉 [**Join Buddy Slack Workspace**](https://join.slack.com/t/buddy-mcp/shared_invite/zt-3xn6v1qza-R~fgkVCov9sCLZDXh9wErQ)
 
 | Client | Status |
 |---|---|

--- a/install.ps1
+++ b/install.ps1
@@ -528,7 +528,7 @@ if ($COPILOT_CONFIGURED) {
 Write-Host ""
 Write-Host "  💬 Join the Buddy Community!" -ForegroundColor Blue
 Write-Host "  Connect with other rescuers on Slack:"
-Write-Host "  https://join.slack.com/t/buddy-mcp/shared_invite/zt-3xn6v1qza-R~fgkVCov9sCLZDXh9wErQ" -ForegroundColor Gray
+Write-Host "  👉 https://join.slack.com/t/buddy-mcp/shared_invite/zt-3xn6v1qza-R~fgkVCov9sCLZDXh9wErQ" -ForegroundColor Gray
 Write-Host ""
 
 $ONBOARD_SCRIPT = "$INSTALL_DIR\dist\cli\onboard.js"

--- a/install.sh
+++ b/install.sh
@@ -630,7 +630,7 @@ ONBOARD_SCRIPT="$INSTALL_DIR/dist/cli/onboard.js"
 echo ""
 echo -e "${BLUE}  💬 Join the Buddy Community!${NC}"
 echo -e "  Connect with other rescuers on Slack:"
-echo -e "  ${DIM}https://join.slack.com/t/buddy-mcp/shared_invite/zt-3xn6v1qza-R~fgkVCov9sCLZDXh9wErQ${NC}"
+echo -e "  ${DIM}👉 https://join.slack.com/t/buddy-mcp/shared_invite/zt-3xn6v1qza-R~fgkVCov9sCLZDXh9wErQ${NC}"
 echo ""
 
 if [ -f "$ONBOARD_SCRIPT" ] && [ "$NO_ONBOARD" -eq 0 ]; then


### PR DESCRIPTION
## Summary
- add a pointing emoji before the Slack invite URL in the README
- add the same emoji in the macOS/Linux and Windows installer output

Tiny follow-up to #121 for a slightly clearer CTA.