### PR TITLE
Add Buddy graph CLI and skill

### DIFF
--- a/.claude/commands/buddy-graph.md
+++ b/.claude/commands/buddy-graph.md
@@ -4,14 +4,21 @@ description: Generate and open an interactive visualization of Buddy guard-mode 
 
 Run the Buddy graph CLI to visualize the reasoning graph.
 
-If a session ID is provided in `$ARGUMENTS`, pass it through to the command.
+If `$ARGUMENTS` is present, treat it as optional CLI arguments such as a session ID or `--out` path.
 
 ```bash
+set -euo pipefail
+
+args=()
+if [ -n "${ARGUMENTS:-}" ]; then
+  args+=($ARGUMENTS)
+fi
+
 if command -v buddy >/dev/null 2>&1; then
-  buddy graph $ARGUMENTS --open
+  buddy graph "${args[@]}" --open
 else
-  node dist/cli/buddy.js graph $ARGUMENTS --open
+  node dist/cli/buddy.js graph "${args[@]}" --open
 fi
 ```
 
-Execute the bash block above and then report the saved graph path and basic graph counts back to the user.
+Execute the bash block above, then report the saved graph path and basic graph counts back to the user.

--- a/.claude/commands/buddy-graph.md
+++ b/.claude/commands/buddy-graph.md
@@ -1,0 +1,17 @@
+---
+description: Generate and open an interactive visualization of Buddy guard-mode reasoning data using the Buddy CLI.
+---
+
+Run the Buddy graph CLI to visualize the reasoning graph.
+
+If a session ID is provided in `$ARGUMENTS`, pass it through to the command.
+
+```bash
+if command -v buddy >/dev/null 2>&1; then
+  buddy graph $ARGUMENTS --open
+else
+  node dist/cli/buddy.js graph $ARGUMENTS --open
+fi
+```
+
+Execute the bash block above and then report the saved graph path and basic graph counts back to the user.

--- a/.claude/commands/buddy-graph.md
+++ b/.claude/commands/buddy-graph.md
@@ -11,7 +11,7 @@ set -euo pipefail
 
 args=()
 if [ -n "${ARGUMENTS:-}" ]; then
-  args+=($ARGUMENTS)
+  read -r -a args <<< "$ARGUMENTS"
 fi
 
 if command -v buddy >/dev/null 2>&1; then

--- a/.codex/skills/buddy-graph/SKILL.md
+++ b/.codex/skills/buddy-graph/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: buddy-graph
+description: Generate and open an interactive visualization of Buddy guard-mode reasoning data using Buddy's local CLI command. Use when the user wants to inspect claims, edges, findings, sessions, or reasoning structure as a graph, including session-specific graph views for debugging or analysis. This skill should invoke the Buddy CLI rather than any MCP tool.
+---
+
+# Buddy Graph
+
+Use Buddy's CLI graph command to generate a local HTML visualization of the reasoning graph.
+
+## Quick Start
+
+Run one of these commands from the Buddy repo:
+
+```bash
+buddy graph
+buddy graph <session_id>
+buddy graph --open
+buddy graph <session_id> --out ./my-graph.html
+```
+
+If the packaged `buddy` binary is not available yet, run the built CLI directly:
+
+```bash
+node dist/cli/buddy.js graph
+node dist/cli/buddy.js graph <session_id>
+```
+
+## Expected Output
+
+The command writes an HTML file and prints the saved path plus graph counts.
+
+## Notes
+
+- This skill is intentionally CLI-backed, not MCP-backed.
+- It reads Buddy reasoning data from `~/.buddy/buddy.db` unless `BUDDY_DB_PATH` is set.
+- Use a `session_id` to isolate one workspace/day graph.

--- a/.codex/skills/buddy-graph/scripts/run-buddy-graph.sh
+++ b/.codex/skills/buddy-graph/scripts/run-buddy-graph.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v buddy >/dev/null 2>&1; then
+  buddy graph "$@"
+else
+  node dist/cli/buddy.js graph "$@"
+fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will follow [Semantic Versioning](https://semver.org/).
 
+## [1.1.0] - Unreleased
+
+### Added
+- **Buddy reasoning graph CLI** (PR #124) — new `buddy graph` command generates an interactive HTML visualization of Buddy's guard-mode reasoning graph from `~/.buddy/buddy.db`. Supports full-graph and session-scoped output, optional `--out` paths, and `--open` browser launch.
+- **Codex skill for graph generation** — added `.codex/skills/buddy-graph` so Codex can invoke the graph workflow through the Buddy CLI instead of adding an MCP tool.
+- **Claude Code project command** — added `.claude/commands/buddy-graph.md` so Buddy contributors can run `/project:buddy-graph` inside the Buddy repo.
+- **Claude Code global `/buddy-graph` install** — Buddy installers now write `~/.claude/commands/buddy-graph.md` (macOS/Linux and Windows), so installed Buddy users can invoke `/buddy-graph` from any project in Claude Code.
+
+### Changed
+- **Cross-host graph workflow is CLI-backed, not MCP-backed** — graph visualization ships as a Buddy CLI + host wrappers (Codex skill and Claude commands), avoiding any new MCP tool/schema overhead.
+
+### Upgrade notes
+- Re-run the Buddy installer to get the global Claude Code `/buddy-graph` command and the latest `buddy graph` CLI:
+```bash
+# macOS/Linux
+curl -fsSL https://raw.githubusercontent.com/fiorastudio/buddy/master/install.sh | bash
+
+# Windows
+irm https://raw.githubusercontent.com/fiorastudio/buddy/master/install.ps1 | iex
+```
+- After reinstalling, Claude Code users can run `/buddy-graph` from any project, and Buddy users can also call `buddy graph` directly from the shell.
+
 ## [1.0.6] - 2026-04-29
 
 ### Added

--- a/install.ps1
+++ b/install.ps1
@@ -273,6 +273,30 @@ if (changed) {
 process.stdout.write(result.join(','));
 '@ 2>$null
 
+@'
+---
+description: Generate and open an interactive visualization of Buddy guard-mode reasoning data using the Buddy CLI.
+---
+
+Run the Buddy graph CLI to visualize the reasoning graph.
+
+If `$ARGUMENTS` is present, treat it as optional CLI arguments such as a session ID or `--out` path.
+
+```bash
+set -euo pipefail
+
+args=()
+if [ -n "${ARGUMENTS:-}" ]; then
+  read -r -a args <<< "$ARGUMENTS"
+fi
+
+buddy graph "${args[@]}" --open
+```
+
+Execute the bash block above, then report the saved graph path and basic graph counts back to the user.
+'@ | Set-Content -Path $buddyGraphCommand -Encoding UTF8
+Write-Host "  ✓ Claude Code global /buddy-graph command installed ($buddyGraphCommand)" -ForegroundColor Green
+
 if ($settingsResult -match 'mcp:updated') {
   Write-Host "  ✓ MCP server registered in settings.json" -ForegroundColor Green
 } else {

--- a/install.ps1
+++ b/install.ps1
@@ -159,6 +159,8 @@ $CLAUDE_CONFIGURED = $true
 # Configure hooks + statusline in settings.json via node (avoids PowerShell
 # ConvertFrom-Json flattening single-element arrays into bare objects).
 $claudeSettings = "$claudeDir\settings.json"
+$commandsDir = Join-Path $claudeDir 'commands'
+$buddyGraphCommand = Join-Path $commandsDir 'buddy-graph.md'
 if (!(Test-Path $claudeSettings)) {
   '{}' | Set-Content $claudeSettings -Encoding UTF8
 }
@@ -290,7 +292,11 @@ if [ -n "${ARGUMENTS:-}" ]; then
   read -r -a args <<< "$ARGUMENTS"
 fi
 
-buddy graph "${args[@]}" --open
+if command -v buddy >/dev/null 2>&1; then
+  buddy graph "${args[@]}" --open
+else
+  node "$HOME/.buddy/server/dist/cli/buddy.js" graph "${args[@]}" --open
+fi
 ```
 
 Execute the bash block above, then report the saved graph path and basic graph counts back to the user.

--- a/install.sh
+++ b/install.sh
@@ -140,6 +140,34 @@ configure_claude_code() {
 
   mkdir -p "$config_dir" "$commands_dir"
 
+  cat > "$buddy_graph_command" <<EOF
+---
+description: Generate and open an interactive visualization of Buddy guard-mode reasoning data using the Buddy CLI.
+---
+
+Run the Buddy graph CLI to visualize the reasoning graph.
+
+If \`$ARGUMENTS\` is present, treat it as optional CLI arguments such as a session ID or \`--out\` path.
+
+\`\`\`bash
+set -euo pipefail
+
+args=()
+if [ -n "${ARGUMENTS:-}" ]; then
+  read -r -a args <<< "$ARGUMENTS"
+fi
+
+if command -v buddy >/dev/null 2>&1; then
+  buddy graph "${args[@]}" --open
+else
+  "$CONFIG_NODE_BIN" "$INSTALL_DIR/dist/cli/buddy.js" graph "${args[@]}" --open
+fi
+\`\`\`
+
+Execute the bash block above, then report the saved graph path and basic graph counts back to the user.
+EOF
+  echo -e "  ${GREEN}✓${NC} Claude Code global /buddy-graph command installed ${DIM}($buddy_graph_command)${NC}"
+
   local registered=0
   if command -v claude &> /dev/null; then
     if claude mcp get buddy >/dev/null 2>&1; then

--- a/install.sh
+++ b/install.sh
@@ -132,11 +132,13 @@ configure_claude_code() {
   local stop_hook_command
   local prompt_hook_command
   local statusline_command
+  local commands_dir="$config_dir/commands"
+  local buddy_graph_command="$commands_dir/buddy-graph.md"
   stop_hook_command=$(printf '%q %q' "$CONFIG_NODE_BIN" "$stop_hook_path")
   prompt_hook_command=$(printf '%q %q' "$CONFIG_NODE_BIN" "$prompt_hook_path")
   statusline_command=$(printf '%q %q' "$CONFIG_NODE_BIN" "$INSTALL_DIR/dist/statusline-wrapper.js")
 
-  mkdir -p "$config_dir"
+  mkdir -p "$config_dir" "$commands_dir"
 
   local registered=0
   if command -v claude &> /dev/null; then

--- a/src/cli/buddy.ts
+++ b/src/cli/buddy.ts
@@ -7,12 +7,15 @@ if (!subcommand || subcommand === '--help' || subcommand === '-h') {
 
 Commands:
   doctor    Run diagnostics on your Buddy installation
+  graph     Generate an interactive reasoning graph
   onboard   Interactive onboarding wizard`);
   process.exit(0);
 }
 
 if (subcommand === 'doctor') {
   await import('./doctor-cli.js');
+} else if (subcommand === 'graph') {
+  await import('./graph-cli.js');
 } else if (subcommand === 'onboard') {
   await import('./onboard.js');
 } else {

--- a/src/cli/buddy.ts
+++ b/src/cli/buddy.ts
@@ -15,7 +15,8 @@ Commands:
 if (subcommand === 'doctor') {
   await import('./doctor-cli.js');
 } else if (subcommand === 'graph') {
-  await import('./graph-cli.js');
+  const { runGraphCommand } = await import('./graph-cli.js');
+  process.exit(runGraphCommand(process.argv.slice(3)));
 } else if (subcommand === 'onboard') {
   await import('./onboard.js');
 } else {

--- a/src/cli/graph-cli.ts
+++ b/src/cli/graph-cli.ts
@@ -2,17 +2,23 @@
 import { initDb } from '../db/schema.js';
 import { runBuddyGraphCli } from '../lib/reasoning/graph-viz.js';
 
-try {
-  initDb();
-} catch (error) {
-  console.error(`Failed to initialize Buddy database: ${error instanceof Error ? error.message : String(error)}`);
-  process.exit(1);
+export function runGraphCommand(argv: string[]): number {
+  try {
+    initDb();
+  } catch (error) {
+    console.error(`Failed to initialize Buddy database: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+
+  try {
+    return runBuddyGraphCli(argv);
+  } catch (error) {
+    console.error(`Failed to generate Buddy graph: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
 }
 
-try {
-  const code = runBuddyGraphCli(process.argv.slice(2));
-  process.exit(code);
-} catch (error) {
-  console.error(`Failed to generate Buddy graph: ${error instanceof Error ? error.message : String(error)}`);
-  process.exit(1);
+const invokedPath = process.argv[1] || '';
+if (invokedPath.endsWith('/graph-cli.js') || invokedPath.endsWith('\\graph-cli.js')) {
+  process.exit(runGraphCommand(process.argv.slice(2)));
 }

--- a/src/cli/graph-cli.ts
+++ b/src/cli/graph-cli.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+import { initDb } from '../db/schema.js';
+import { runBuddyGraphCli } from '../lib/reasoning/graph-viz.js';
+
+try {
+  initDb();
+} catch (error) {
+  console.error(`Failed to initialize Buddy database: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+}
+
+try {
+  const code = runBuddyGraphCli(process.argv.slice(2));
+  process.exit(code);
+} catch (error) {
+  console.error(`Failed to generate Buddy graph: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+}

--- a/src/lib/reasoning/graph-viz.ts
+++ b/src/lib/reasoning/graph-viz.ts
@@ -1,0 +1,502 @@
+import { writeFileSync } from 'fs';
+import { join, resolve } from 'path';
+import { exec } from 'child_process';
+import { homedir } from 'os';
+import Database from 'better-sqlite3';
+import { resolveSessionTrace } from './session-trace.js';
+import { CAUTION_FINDINGS, KUDOS_FINDINGS } from './types.js';
+
+const DB_PATH = process.env.BUDDY_DB_PATH || join(homedir(), '.buddy', 'buddy.db');
+
+const BASIS_COLORS: Record<string, string> = {
+  research: '#2196F3',
+  empirical: '#4CAF50',
+  deduction: '#9C27B0',
+  analogy: '#FF9800',
+  definition: '#607D8B',
+  llm_output: '#FFC107',
+  assumption: '#F44336',
+  vibes: '#E91E63',
+};
+
+const EDGE_COLORS: Record<string, string> = {
+  supports: '#2196F3',
+  depends_on: '#9E9E9E',
+  contradicts: '#F44336',
+  questions: '#FF9800',
+};
+
+type StoredClaimRow = {
+  id: string;
+  session_id: string;
+  speaker: string;
+  text: string;
+  basis: string;
+  confidence: string;
+  created_at: number;
+};
+
+type StoredEdgeRow = {
+  id: string;
+  session_id: string;
+  from_claim: string;
+  to_claim: string;
+  type: string;
+  created_at: number;
+};
+
+type FindingLogRow = {
+  id: number;
+  companion_id: string;
+  session_id: string;
+  finding_type: string;
+  anchor_claim_id: string;
+  observe_seq: number;
+  created_at: number;
+};
+
+function openPath(targetPath: string): Promise<void> {
+  const command = process.platform === 'darwin'
+    ? `open ${JSON.stringify(targetPath)}`
+    : process.platform === 'win32'
+      ? `start "" ${JSON.stringify(targetPath)}`
+      : `xdg-open ${JSON.stringify(targetPath)}`;
+
+  return new Promise((resolvePromise, rejectPromise) => {
+    exec(command, (error) => {
+      if (error) rejectPromise(error);
+      else resolvePromise();
+    });
+  });
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function parseArgs(args: string[]): { sessionId: string | null; outPath: string | null; open: boolean } {
+  let sessionId: string | null = null;
+  let outPath: string | null = null;
+  let open = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--open') {
+      open = true;
+      continue;
+    }
+    if (arg === '--out') {
+      outPath = args[index + 1] ?? null;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--out=')) {
+      outPath = arg.slice('--out='.length);
+      continue;
+    }
+    if (!sessionId) sessionId = arg;
+  }
+
+  return { sessionId, outPath, open };
+}
+
+function buildOutputPath(sessionId: string | null, outPath: string | null): string {
+  if (outPath) return resolve(outPath);
+  const fileName = sessionId ? `buddy-graph-${sessionId}.html` : 'buddy-graph.html';
+  return join(process.cwd(), fileName);
+}
+
+function buildProjectLabel(sessionId: string): string {
+  const trace = resolveSessionTrace(sessionId);
+  if (trace.projectLabel) return trace.projectLabel;
+  if (trace.cwdHash) return `${trace.cwdHash.slice(0, 8)}…`;
+  return sessionId;
+}
+
+function toScriptJson(value: unknown): string {
+  return JSON.stringify(value).replace(/<\/script>/gi, '<\\/script>');
+}
+
+function buildHtml(params: {
+  outputPath: string;
+  sessions: string[];
+  sessionMeta: Array<{ session_id: string; hash: string; date: string; projectName: string }>;
+  projects: Array<{ hash: string; name: string }>;
+  datesByProject: Record<string, string[]>;
+  visNodes: unknown[];
+  visEdges: unknown[];
+  stats: { claims: number; edges: number; findings: number; sessions: number };
+}): string {
+  const { outputPath, sessionMeta, projects, datesByProject, visNodes, visEdges, stats } = params;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Buddy Reasoning Graph</title>
+  <script src="https://unpkg.com/vis-network@9.1.9/dist/vis-network.min.js"></script>
+  <style>
+    body { margin: 0; font-family: Inter, system-ui, sans-serif; display: flex; height: 100vh; background: #f6f8fb; color: #111; }
+    #sidebar { width: 360px; overflow-y: auto; border-right: 1px solid #dde3ea; background: #fff; padding: 16px; box-sizing: border-box; }
+    #graph { flex: 1; min-width: 0; }
+    h1 { margin: 0 0 12px; font-size: 22px; }
+    .section { margin-bottom: 18px; }
+    h3 { margin: 0 0 8px; font-size: 14px; color: #445; text-transform: uppercase; letter-spacing: 0.04em; }
+    select, input { width: 100%; padding: 8px 10px; border: 1px solid #ccd3db; border-radius: 10px; box-sizing: border-box; }
+    .filters { display: flex; flex-wrap: wrap; gap: 8px; }
+    .filter-chip { border: 1px solid #ccd3db; border-radius: 999px; padding: 6px 10px; font-size: 12px; cursor: pointer; display: inline-flex; align-items: center; gap: 6px; background: #fff; }
+    .filter-chip.active { background: #111; color: #fff; border-color: #111; }
+    .dot { width: 10px; height: 10px; border-radius: 50%; display: inline-block; }
+    #detail { font-size: 13px; line-height: 1.45; color: #223; }
+    .empty { color: #667; }
+    .stat-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+    .stat-card { background: #f6f8fb; border: 1px solid #dde3ea; border-radius: 12px; padding: 12px; }
+    .num { font-size: 24px; font-weight: 700; }
+    .lbl, .meta { font-size: 12px; color: #667; }
+    .meta { margin-top: 8px; }
+  </style>
+</head>
+<body>
+  <div id="sidebar">
+    <h1>Buddy Reasoning Graph</h1>
+    <div class="meta">DB: ${escapeHtml(DB_PATH)}</div>
+    <div class="meta">Output: ${escapeHtml(outputPath)}</div>
+
+    <div class="section">
+      <h3>Project</h3>
+      <select id="projectFilter">
+        <option value="all">All Projects</option>
+        ${projects.map((project) => `<option value="${escapeHtml(project.hash)}">${escapeHtml(project.name)}</option>`).join('')}
+      </select>
+    </div>
+
+    <div class="section">
+      <h3>Date</h3>
+      <select id="dateFilter">
+        <option value="all">All Dates</option>
+      </select>
+    </div>
+
+    <div class="section">
+      <h3>Search Claims</h3>
+      <input id="searchBox" type="text" placeholder="Type to filter claims..." />
+    </div>
+
+    <div class="section">
+      <h3>Isolate by Basis</h3>
+      <div class="filters">
+        ${Object.entries(BASIS_COLORS).map(([basis, color]) => `<div class="filter-chip" data-basis="${basis}"><span class="dot" style="background:${color}"></span>${basis}</div>`).join('')}
+      </div>
+    </div>
+
+    <div class="section">
+      <h3>Filter by Edge Type</h3>
+      <div class="filters">
+        ${Object.entries(EDGE_COLORS).map(([edgeType, color]) => `<div class="filter-chip" data-edge="${edgeType}"><span class="dot" style="background:${color}"></span>${edgeType}</div>`).join('')}
+      </div>
+    </div>
+
+    <div class="section">
+      <h3>Node Detail</h3>
+      <div id="detail"><div class="empty">Click a node to see details</div></div>
+    </div>
+
+    <div class="section">
+      <h3>Stats</h3>
+      <div class="stat-grid">
+        <div class="stat-card"><div class="num">${stats.claims}</div><div class="lbl">Claims</div></div>
+        <div class="stat-card"><div class="num">${stats.edges}</div><div class="lbl">Edges</div></div>
+        <div class="stat-card"><div class="num">${stats.findings}</div><div class="lbl">Findings</div></div>
+        <div class="stat-card"><div class="num">${stats.sessions}</div><div class="lbl">Sessions</div></div>
+      </div>
+    </div>
+  </div>
+
+  <div id="graph"></div>
+
+  <script>
+    const RAW_NODES = ${toScriptJson(visNodes)};
+    const RAW_EDGES = ${toScriptJson(visEdges)};
+    const SESSION_META = ${toScriptJson(sessionMeta)};
+    const DATES_BY_PROJECT = ${toScriptJson(datesByProject)};
+
+    const nodes = new vis.DataSet(RAW_NODES);
+    const edges = new vis.DataSet(RAW_EDGES);
+    const network = new vis.Network(document.getElementById('graph'), { nodes, edges }, {
+      physics: {
+        enabled: true,
+        solver: 'forceAtlas2Based',
+        forceAtlas2Based: {
+          gravitationalConstant: -200,
+          centralGravity: 0.008,
+          springLength: 250,
+          springConstant: 0.03,
+          damping: 0.5,
+          avoidOverlap: 1.0,
+        },
+        stabilization: { iterations: 400, fit: true },
+        minVelocity: 0.75,
+      },
+      interaction: {
+        hover: true,
+        tooltipDelay: 100,
+        navigationButtons: true,
+        keyboard: { enabled: true },
+        multiselect: true,
+      },
+      edges: {
+        smooth: { type: 'curvedCW', roundness: 0.15 },
+        length: 250,
+      },
+      layout: { improvedLayout: true, clusterThreshold: 150 },
+      nodes: { font: { size: 18 } },
+    });
+
+    network.on('stabilizationIterationsDone', () => {
+      network.setOptions({ physics: { enabled: false } });
+      network.fit({ animation: false });
+    });
+
+    const projectFilter = document.getElementById('projectFilter');
+    const dateFilter = document.getElementById('dateFilter');
+    const searchBox = document.getElementById('searchBox');
+    const detail = document.getElementById('detail');
+    const activeBases = new Set();
+    const activeEdges = new Set();
+
+    function refreshDates() {
+      const project = projectFilter.value;
+      const dates = project === 'all'
+        ? [...new Set(SESSION_META.map((item) => item.date))]
+        : (DATES_BY_PROJECT[project] || []);
+      const current = dateFilter.value;
+      dateFilter.innerHTML = '<option value="all">All Dates</option>' + dates.map((date) => '<option value="' + date + '">' + date + '</option>').join('');
+      if (dates.includes(current)) dateFilter.value = current;
+    }
+
+    function matchesNode(node) {
+      const project = projectFilter.value;
+      const date = dateFilter.value;
+      const search = searchBox.value.trim().toLowerCase();
+      const meta = SESSION_META.find((item) => item.session_id === node.session_id);
+      if (project !== 'all' && meta?.hash !== project) return false;
+      if (date !== 'all' && meta?.date !== date) return false;
+      if (activeBases.size > 0 && !activeBases.has(node.basis)) return false;
+      if (search && !String(node.fullText || '').toLowerCase().includes(search)) return false;
+      return true;
+    }
+
+    function applyFilters() {
+      const visibleNodeIds = new Set();
+      RAW_NODES.forEach((node) => {
+        const hidden = !matchesNode(node);
+        nodes.update({ ...node, hidden });
+        if (!hidden) visibleNodeIds.add(node.id);
+      });
+      RAW_EDGES.forEach((edge) => {
+        const hiddenByType = activeEdges.size > 0 && !activeEdges.has(edge.type);
+        const hiddenByNode = !visibleNodeIds.has(edge.from) || !visibleNodeIds.has(edge.to);
+        edges.update({ ...edge, hidden: hiddenByType || hiddenByNode });
+      });
+    }
+
+    projectFilter.addEventListener('change', () => { refreshDates(); applyFilters(); });
+    dateFilter.addEventListener('change', applyFilters);
+    searchBox.addEventListener('input', applyFilters);
+
+    document.querySelectorAll('[data-basis]').forEach((element) => {
+      element.addEventListener('click', () => {
+        const basis = element.getAttribute('data-basis');
+        if (!basis) return;
+        if (activeBases.has(basis)) activeBases.delete(basis);
+        else activeBases.add(basis);
+        element.classList.toggle('active');
+        applyFilters();
+      });
+    });
+
+    document.querySelectorAll('[data-edge]').forEach((element) => {
+      element.addEventListener('click', () => {
+        const edgeType = element.getAttribute('data-edge');
+        if (!edgeType) return;
+        if (activeEdges.has(edgeType)) activeEdges.delete(edgeType);
+        else activeEdges.add(edgeType);
+        element.classList.toggle('active');
+        applyFilters();
+      });
+    });
+
+    network.on('click', (params) => {
+      if (!params.nodes.length) {
+        detail.innerHTML = '<div class="empty">Click a node to see details</div>';
+        return;
+      }
+      const node = nodes.get(params.nodes[0]);
+      if (!node) return;
+      const safeText = String(node.fullText)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+      detail.innerHTML = '<div><strong>' + node.speaker + '</strong> · ' + node.basis + ' · ' + node.confidence + '</div>'
+        + '<div class="meta">session: ' + node.session_id + '</div>'
+        + '<div style="margin-top:8px">' + safeText + '</div>'
+        + '<div class="meta">findings: ' + ((node.findings || []).join(', ') || 'none') + '</div>';
+    });
+
+    refreshDates();
+    applyFilters();
+  </script>
+</body>
+</html>`;
+}
+
+export function generateBuddyGraph(options: {
+  sessionId?: string | null;
+  outPath?: string | null;
+  open?: boolean;
+}): { outPath: string; claims: number; edges: number; findings: number; sessions: number } {
+  const sessionId = options.sessionId ?? null;
+  const outputPath = buildOutputPath(sessionId, options.outPath ?? null);
+  const db = new Database(DB_PATH, { readonly: true });
+  const sessionClause = sessionId ? 'WHERE session_id = ?' : '';
+  const params = sessionId ? [sessionId] : [];
+
+  const claims = db.prepare(`SELECT * FROM reasoning_claims ${sessionClause} ORDER BY created_at`).all(...params) as StoredClaimRow[];
+  const edges = db.prepare(`SELECT * FROM reasoning_edges ${sessionClause} ORDER BY created_at`).all(...params) as StoredEdgeRow[];
+  const findings = db.prepare(`SELECT * FROM reasoning_findings_log ${sessionClause} ORDER BY created_at`).all(...params) as FindingLogRow[];
+  db.close();
+
+  const findingMap = new Map<string, string[]>();
+  for (const finding of findings) {
+    const list = findingMap.get(finding.anchor_claim_id) || [];
+    list.push(finding.finding_type);
+    findingMap.set(finding.anchor_claim_id, list);
+  }
+
+  const degreeMap = new Map<string, number>();
+  for (const edge of edges) {
+    degreeMap.set(edge.from_claim, (degreeMap.get(edge.from_claim) || 0) + 1);
+    degreeMap.set(edge.to_claim, (degreeMap.get(edge.to_claim) || 0) + 1);
+  }
+
+  const sessions = [...new Set(claims.map((claim) => claim.session_id))].sort();
+  const sessionMeta = sessions.map((currentSessionId) => {
+    const date = currentSessionId.split('-').slice(-1)[0] ?? '';
+    const hash = currentSessionId.split('-').slice(0, -1).join('-');
+    return {
+      session_id: currentSessionId,
+      hash,
+      date,
+      projectName: buildProjectLabel(currentSessionId),
+    };
+  });
+
+  const projects = [...new Map(sessionMeta.map((meta) => [meta.hash, meta.projectName])).entries()].map(
+    ([hash, name]) => ({ hash, name })
+  );
+
+  const datesByProject = new Map<string, string[]>();
+  for (const meta of sessionMeta) {
+    const list = datesByProject.get(meta.hash) || [];
+    if (!list.includes(meta.date)) list.push(meta.date);
+    datesByProject.set(meta.hash, list.sort());
+  }
+
+  const visNodes = claims.map((claim) => {
+    const claimFindings = findingMap.get(claim.id) || [];
+    const hasCaution = claimFindings.some((finding) => CAUTION_FINDINGS.includes(finding as any));
+    const hasKudos = claimFindings.some((finding) => KUDOS_FINDINGS.includes(finding as any));
+    const degree = degreeMap.get(claim.id) || 0;
+    const borderColor = hasCaution ? '#C62828' : hasKudos ? '#2E7D32' : '#999';
+
+    return {
+      id: claim.id,
+      label: claim.text.length > 90 ? `${claim.text.slice(0, 87)}…` : claim.text,
+      title: claim.text,
+      fullText: claim.text,
+      basis: claim.basis,
+      confidence: claim.confidence,
+      speaker: claim.speaker,
+      session_id: claim.session_id,
+      findings: claimFindings,
+      degree,
+      shape: claim.speaker === 'user' ? 'diamond' : 'dot',
+      color: {
+        background: BASIS_COLORS[claim.basis] || '#999999',
+        border: borderColor,
+        highlight: {
+          background: BASIS_COLORS[claim.basis] || '#999999',
+          border: borderColor,
+        },
+      },
+      borderWidth: hasCaution || hasKudos ? 3 : 1,
+      font: { color: '#111', size: 18, face: 'Inter, system-ui, sans-serif' },
+      size: Math.max(18, Math.min(44, 18 + degree * 2)),
+    };
+  });
+
+  const claimIds = new Set(claims.map((claim) => claim.id));
+  const visEdges = edges
+    .filter((edge) => claimIds.has(edge.from_claim) && claimIds.has(edge.to_claim))
+    .map((edge) => ({
+      id: edge.id,
+      from: edge.from_claim,
+      to: edge.to_claim,
+      type: edge.type,
+      session_id: edge.session_id,
+      color: { color: EDGE_COLORS[edge.type] || '#999999' },
+      dashes: edge.type === 'contradicts' || edge.type === 'questions',
+      width: edge.type === 'supports' ? 3 : 2,
+      arrows: 'to',
+      title: edge.type,
+    }));
+
+  const stats = {
+    claims: claims.length,
+    edges: visEdges.length,
+    findings: findings.length,
+    sessions: sessions.length,
+  };
+
+  const html = buildHtml({
+    outputPath,
+    sessions,
+    sessionMeta,
+    projects,
+    datesByProject: Object.fromEntries(datesByProject),
+    visNodes,
+    visEdges,
+    stats,
+  });
+
+  writeFileSync(outputPath, html, 'utf-8');
+
+  if (options.open) {
+    void openPath(outputPath).catch((error) => {
+      console.warn(`Failed to open graph automatically: ${error instanceof Error ? error.message : String(error)}`);
+    });
+  }
+
+  return {
+    outPath: outputPath,
+    claims: claims.length,
+    edges: visEdges.length,
+    findings: findings.length,
+    sessions: sessions.length,
+  };
+}
+
+export function runBuddyGraphCli(argv: string[]): number {
+  const { sessionId, outPath, open } = parseArgs(argv);
+  const result = generateBuddyGraph({ sessionId, outPath, open });
+  console.log(`Buddy graph written to ${result.outPath}`);
+  console.log(`Claims: ${result.claims} | Edges: ${result.edges} | Findings: ${result.findings} | Sessions: ${result.sessions}`);
+  if (open) console.log('Opening graph in browser...');
+  return 0;
+}


### PR DESCRIPTION
## Summary
This PR builds directly on the `1.0.6` guard-mode release. In `1.0.6`, Buddy introduced **guard mode** as a reasoning-audit layer for LLM coding sessions: it records claims, edges, and findings into `buddy.db` so Buddy can inspect the structure of an agent’s reasoning trace over time.

This PR adds the missing visualization layer on top of that foundation.

What ships here:
- `buddy graph` — a new Buddy-native CLI command that generates an interactive HTML graph from stored guard-mode reasoning data
- Codex support via `.codex/skills/buddy-graph`
- Claude Code repo-local support via `.claude/commands/buddy-graph.md` (`/project:buddy-graph`)
- Claude Code global support via installer-written `~/.claude/commands/buddy-graph.md` (`/buddy-graph` from any project)

A key design choice here is that this remains **CLI-backed, not MCP-backed**. We intentionally avoid adding a new MCP tool or schema surface, which keeps token overhead down and makes the feature usable through host-specific command/skill wrappers instead.

So the progression is:
- `1.0.6` = record and audit reasoning traces with guard mode
- `1.1` = visualize and explore those traces with `buddy graph`

## Validation
- `npm run build`
- Claude Code review (`claude -p`) on CLI routing, skill/command packaging, and installer wiring
