### PR TITLE
Fix Windows Claude command installer path

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -161,6 +161,7 @@ $CLAUDE_CONFIGURED = $true
 $claudeSettings = "$claudeDir\settings.json"
 $commandsDir = Join-Path $claudeDir 'commands'
 $buddyGraphCommand = Join-Path $commandsDir 'buddy-graph.md'
+New-Item -ItemType Directory -Force -Path $commandsDir | Out-Null
 if (!(Test-Path $claudeSettings)) {
   '{}' | Set-Content $claudeSettings -Encoding UTF8
 }


### PR DESCRIPTION
## Summary
Fix a Windows installer bug in the new global Claude Code `/buddy-graph` command setup.

On some Windows machines, the installer attempted to write:
- `~/.claude/commands/buddy-graph.md`

before the `~/.claude/commands` directory existed, which caused `Set-Content` to fail with:
- `Could not find a part of the path ... .claude\commands\buddy-graph.md`

This PR fixes that by explicitly creating the Claude commands directory before writing the command file.

## Validation
- `npm run build`
- confirmed the fix is a minimal follow-up on top of current `master`
