### PR TITLE
Add species and stat driven finding voice

### DIFF
--- a/docs/edd/species-stat-finding-voice.feature
+++ b/docs/edd/species-stat-finding-voice.feature
@@ -1,0 +1,106 @@
+Feature: Species- and stat-driven guard-mode finding voice
+  As a Buddy user
+  I want caution and kudos findings to sound like my specific buddy
+  So that guard-mode nudges feel useful, memorable, and in-character
+
+  Background:
+    Given Buddy guard mode has selected a finding to surface
+    And the companion has one of the 21 supported species
+    And the companion has five stable stats: DEBUGGING, PATIENCE, CHAOS, WISDOM, and SNARK
+    And mood does not control finding phrasing
+
+  Rule: Phase 1 uses species + dominant stat for deterministic fallback phrasing
+
+    Scenario: Same caution finding sounds different across species
+      Given a selected finding of type "unchallenged_chain"
+      And a claim text "This premise kicked off a long line"
+      When the finding is phrased for species "Goose"
+      Then the output should differ from species "Shell Turtle"
+      And each output should remain collaborative rather than scolding
+
+    Scenario: Dominant stat changes the delivery lead-in
+      Given a selected finding of type "grounded_premise_adopted"
+      And a claim text "This measured premise held up"
+      When the finding is phrased for species "Data Drake" with dominant stat "DEBUGGING"
+      Then the output should include a DEBUGGING-flavored lead-in
+      When the same finding is phrased for species "Data Drake" with dominant stat "WISDOM"
+      Then the output should differ in its lead-in or delivery shape
+
+    Scenario: Unsupported species fall back safely
+      Given a selected finding of type "unverified_hedge"
+      And a claim text "This likely works"
+      When the finding is phrased for a species without a custom voice table
+      Then the phrasing should still be non-empty
+      And the phrasing should still avoid raw mechanism words
+
+    Scenario: Observer fallback uses companion-aware phrasing
+      Given Buddy is rendering a template fallback reaction
+      And guard mode has injected a selected finding
+      When the fallback text is built
+      Then the finding phrase should be generated from the companion species and dominant stat
+      And not from mood-specific finding templates
+
+  Rule: Phase 2 expands coverage and quality across the full species roster
+
+    Scenario Outline: Each supported species has a custom caution and kudos voice
+      Given species "<species>"
+      When a caution finding is phrased for that species
+      Then the output should use that species' custom voice
+      When a kudos finding is phrased for that species
+      Then the output should use that species' custom voice
+
+      Examples:
+        | species       |
+        | Void Cat      |
+        | Rust Hound    |
+        | Data Drake    |
+        | Log Golem     |
+        | Cache Crow    |
+        | Shell Turtle  |
+        | Duck          |
+        | Goose         |
+        | Blob          |
+        | Octopus       |
+        | Owl           |
+        | Penguin       |
+        | Snail         |
+        | Ghost         |
+        | Axolotl       |
+        | Capybara      |
+        | Cactus        |
+        | Robot         |
+        | Rabbit        |
+        | Mushroom      |
+        | Chonk         |
+
+    Scenario: Guard-mode findings stay concise and readable in the speech bubble
+      Given a long claim text over 120 characters
+      When a finding is phrased for any species
+      Then the claim should be truncated to a readable snippet
+      And the overall phrasing should fit naturally inside Buddy's speech bubble
+
+    Scenario: Species voice never breaks Buddy's collaboration contract
+      Given any supported species
+      When a caution finding is phrased
+      Then the output should not insult the user
+      And the output should not mention internal mechanism terms like "graph" or "claims"
+      And the output should still encourage stronger reasoning
+
+    Scenario: Species voice makes caution and kudos distinguishable
+      Given the same species and the same claim snippet
+      When a caution finding is phrased
+      And a kudos finding is phrased
+      Then the two outputs should feel meaningfully different in intent
+
+  Rule: EDD implementation discipline
+
+    Scenario: Phase 1 is implemented test-first
+      Given the phase 1 acceptance scenarios
+      When implementation begins
+      Then focused automated tests should exist for species variation, stat variation, fallback safety, and observer wiring
+
+    Scenario: Phase 2 is implemented with expanded coverage tests
+      Given the phase 2 acceptance scenarios
+      When implementation begins
+      Then automated tests should verify custom voice coverage across all 21 species
+      And verify concise, mechanism-free outputs

--- a/src/__tests__/reasoning/phrasings-companion.test.ts
+++ b/src/__tests__/reasoning/phrasings-companion.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { phraseFindingForCompanion } from '../../lib/reasoning/phrasings.js';
+import type { Companion } from '../../lib/types.js';
+
+function makeCompanion(species: string, peak: 'DEBUGGING' | 'PATIENCE' | 'CHAOS' | 'WISDOM' | 'SNARK'): Companion {
+  const stats = { DEBUGGING: 10, PATIENCE: 10, CHAOS: 10, WISDOM: 10, SNARK: 10 } as any;
+  stats[peak] = 95;
+  return {
+    name: 'Buddy',
+    species,
+    rarity: 'common',
+    eye: '·',
+    hat: 'none',
+    shiny: false,
+    stats,
+    personalityBio: 'test',
+    level: 1,
+    xp: 0,
+    mood: 'happy',
+    availablePoints: 0,
+    hatchedAt: 0,
+  };
+}
+
+describe('phraseFindingForCompanion', () => {
+  it('varies wording by species for the same caution finding', () => {
+    const goose = phraseFindingForCompanion('unchallenged_chain', 'This claim is doing a lot.', makeCompanion('Goose', 'CHAOS'), 0);
+    const turtle = phraseFindingForCompanion('unchallenged_chain', 'This claim is doing a lot.', makeCompanion('Shell Turtle', 'WISDOM'), 0);
+    expect(goose).not.toEqual(turtle);
+    expect(goose).toContain('Honk');
+  });
+
+  it('adds stat-driven lead-in for kudos', () => {
+    const drake = phraseFindingForCompanion('grounded_premise_adopted', 'Measured premise', makeCompanion('Data Drake', 'DEBUGGING'), 0);
+    expect(drake).toContain('Nice catch:');
+  });
+
+  it('falls back safely for species without a custom table', () => {
+    const out = phraseFindingForCompanion('unverified_hedge', 'This likely works.', makeCompanion('Penguin', 'PATIENCE'), 0);
+    expect(out.length).toBeGreaterThan(0);
+  });
+});

--- a/src/__tests__/reasoning/phrasings-phase2.test.ts
+++ b/src/__tests__/reasoning/phrasings-phase2.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { phraseFindingForCompanion } from '../../lib/reasoning/phrasings.js';
+import type { Companion } from '../../lib/types.js';
+
+const SPECIES = [
+  'Void Cat','Rust Hound','Data Drake','Log Golem','Cache Crow','Shell Turtle','Duck','Goose','Blob','Octopus','Owl','Penguin','Snail','Ghost','Axolotl','Capybara','Cactus','Robot','Rabbit','Mushroom','Chonk'
+] as const;
+
+function makeCompanion(species: string): Companion {
+  return {
+    name: 'Buddy', species, rarity: 'common', eye: '·', hat: 'none', shiny: false,
+    stats: { DEBUGGING: 20, PATIENCE: 30, CHAOS: 10, WISDOM: 95, SNARK: 15 },
+    personalityBio: 'test', level: 1, xp: 0, mood: 'happy', availablePoints: 0, hatchedAt: 0,
+  };
+}
+
+describe('phase 2 species voice coverage', () => {
+  for (const species of SPECIES) {
+    it(`${species} has custom caution and kudos voice`, () => {
+      const companion = makeCompanion(species);
+      const caution = phraseFindingForCompanion('unchallenged_chain', 'This premise kicked off a long line of reasoning and nobody pressure-tested it after that point.', companion, 0);
+      const kudos = phraseFindingForCompanion('grounded_premise_adopted', 'This measured user premise anchored the rest of the solution cleanly.', companion, 0);
+      expect(caution.length).toBeGreaterThan(0);
+      expect(kudos.length).toBeGreaterThan(0);
+      expect(caution).not.toEqual(kudos);
+      expect(caution.toLowerCase()).not.toContain('graph');
+      expect(caution.toLowerCase()).not.toContain('claims');
+      expect(kudos.toLowerCase()).not.toContain('graph');
+      expect(kudos.toLowerCase()).not.toContain('claims');
+    });
+  }
+
+  it('keeps long claim snippets concise', () => {
+    const companion = makeCompanion('Goose');
+    const out = phraseFindingForCompanion('unchallenged_chain', 'A'.repeat(200), companion, 0);
+    expect(out.length).toBeLessThan(220);
+    expect(out).toContain('…');
+  });
+});

--- a/src/lib/reasoning/phrasings.ts
+++ b/src/lib/reasoning/phrasings.ts
@@ -11,8 +11,28 @@
 
 import type { FindingType } from './types.js';
 import type { ReactionState } from '../observer.js';
+import type { Companion, StatName } from '../types.js';
+import { getPeakStat } from '../types.js';
 
 type PhrasingTable = Record<FindingType, Partial<Record<ReactionState, string[]>>>;
+
+type FindingTone = 'caution' | 'kudos';
+
+type SpeciesVoice = {
+  caution: string[];
+  kudos: string[];
+};
+
+const CAUTION_TYPES: FindingType[] = [
+  'load_bearing_vibes',
+  'unchallenged_chain',
+  'echo_chamber',
+  'unverified_hedge',
+];
+
+function toneForFinding(type: FindingType): FindingTone {
+  return CAUTION_TYPES.includes(type) ? 'caution' : 'kudos';
+}
 
 // Claim snippet helper — keep short so the template stays readable.
 export function claimSnippet(text: string, max: number = 60): string {
@@ -21,7 +41,6 @@ export function claimSnippet(text: string, max: number = 60): string {
 }
 
 const PHRASINGS: PhrasingTable = {
-  // ── Caution ─────────────────────────────────────────────────────────────
   load_bearing_vibes: {
     concerned: [
       `That "{claim}" is doing a lot of work. Worth pinning down — the rest would get sturdier.`,
@@ -69,8 +88,6 @@ const PHRASINGS: PhrasingTable = {
       `"{claim}" reads like an assumption. A quick verification would lock it in.`,
     ],
   },
-
-  // ── Kudos ───────────────────────────────────────────────────────────────
   well_sourced_load_bearer: {
     impressed: [
       `"{claim}" is holding up the rest, and you've got it anchored. Solid.`,
@@ -109,9 +126,112 @@ const PHRASINGS: PhrasingTable = {
   },
 };
 
-// Fallback phrasing if the (type, state) pair has no entry. Every finding
-// type has at least one phrasing somewhere so we can always produce a
-// template — we pick the first available state's first phrasing.
+const SPECIES_VOICES: Record<string, SpeciesVoice> = {
+  'Void Cat': {
+    caution: ['Mm. {claim} slipped through the dark without resistance. Interrogate it.', 'A shadow like {claim} grows teeth when nobody challenges it.'],
+    kudos: ['{claim} has real footing. Even the dark likes a grounded landing.', 'Nice. {claim} held because it was anchored, not merely wished for.'],
+  },
+  'Rust Hound': {
+    caution: ['{claim} smells a little off. Sniff the seam before you trust it.', 'Rust says {claim} has a weak spot. Scratch at it now.'],
+    kudos: ['Good hound-work — {claim} has a solid trail and the rest followed cleanly.', '{claim} tracked true. Nice grounded scent.'],
+  },
+  'Data Drake': {
+    caution: ['{claim} is being treated as stable without enough adversarial pressure. Validate before scaling.', '{claim} propagated cleanly, but nobody attempted falsification. That is still a gap.'],
+    kudos: ['{claim} had real grounding, so the downstream logic stayed stable. Good line.', 'Nice. {claim} compiled into the rest of the reasoning without wobble.'],
+  },
+  'Log Golem': {
+    caution: ['{claim} is carrying load without enough stress on the joint. Test the seam.', '{claim} is bearing weight quietly. Better to tap the beam now than after the next layer.'],
+    kudos: ['{claim} is good timber — grounded enough for the rest to rest on.', '{claim} took the load properly. Solid joinery.'],
+  },
+  'Cache Crow': {
+    caution: ['{claim} got tucked away too fast. Peck it back into daylight.', 'Crow says {claim} was cached before it was checked.'],
+    kudos: ['Shiny. {claim} was grounded first, so it is worth keeping.', '{claim} earned its place in the nest.'],
+  },
+  'Shell Turtle': {
+    caution: ['{claim} has been carrying the rest without much testing. One calm check would steady the shell.', '{claim} feels a little too trusted. Slow down and press on it once.'],
+    kudos: ['{claim} gave the rest somewhere safe to stand. Nice, steady footing.', 'Slow and solid — {claim} held because you grounded it first.'],
+  },
+  'Duck': {
+    caution: ['Quack. {claim} is gliding along a bit too confidently. Give it a nudge.', '{claim} looks smooth on the surface. Check the paddling underneath.'],
+    kudos: ['Quack yes — {claim} kept the whole float moving cleanly.', '{claim} had good footing, so the rest stayed buoyant.'],
+  },
+  'Goose': {
+    caution: ['Honk. {claim} is waddling around unchallenged. Peck it once before the flock follows.', 'Honk — {claim} got a free pass. Make it earn the runway.'],
+    kudos: ['Honk, there we go — {claim} had receipts, so the rest could march.', '{claim} was grounded. Good. Makes the whole flock less embarrassing.'],
+  },
+  'Blob': {
+    caution: ['{claim} is getting squishy around the edges. Poke it.', '{claim} is wobbling through without enough shape. Give it structure.'],
+    kudos: ['{claim} held its shape nicely. Rare blob win.', 'Pleasantly surprised: {claim} stayed coherent and the rest could ooze from there.'],
+  },
+  'Octopus': {
+    caution: ['One arm of {claim} is doing too much without a second grip. Test it.', '{claim} has too many implications for how little resistance it got.'],
+    kudos: ['{claim} gave the rest of the arms something solid to hold onto.', '{claim} was grounded and coordinated the rest neatly.'],
+  },
+  'Owl': {
+    caution: ['{claim} deserves one more quiet look before the night accepts it.', 'Owl-note: {claim} moved ahead without enough scrutiny.'],
+    kudos: ['Wise start — {claim} anchored the rest cleanly.', '{claim} saw true, and the rest followed from there.'],
+  },
+  'Penguin': {
+    caution: ['{claim} is sliding farther than it should without a traction check.', '{claim} looks tidy, but it still needs one firm step.'],
+    kudos: ['Nice footing — {claim} kept the whole waddle upright.', '{claim} had enough grip for the rest to move safely.'],
+  },
+  'Snail': {
+    caution: ['Slow down on {claim}. The trail is longer than the evidence.', '{claim} is carrying a lot for something nobody paused on.'],
+    kudos: ['Patient work — {claim} made a stable path for the rest.', '{claim} is slow-solid. Good base.'],
+  },
+  'Ghost': {
+    caution: ['{claim} drifted through the walls without anyone stopping it.', 'A whisper like {claim} should not become doctrine unchecked.'],
+    kudos: ['{claim} is one of the good hauntings — grounded enough to linger usefully.', '{claim} landed with more substance than specter.'],
+  },
+  'Axolotl': {
+    caution: ['{claim} is cute, but it still needs to regenerate under pressure.', '{claim} got through untouched. Give it one little stress test.'],
+    kudos: ['Aw, nice — {claim} healed the whole line by being grounded first.', '{claim} kept the rest bright and stable.'],
+  },
+  'Capybara': {
+    caution: ['{claim} could use one gentle push before everyone relaxes around it.', 'This is calm, maybe too calm — {claim} still wants a check.'],
+    kudos: ['{claim} made the whole thing feel steady. Capybara-approved footing.', 'Good grounding on {claim}. The rest can sit with that.'],
+  },
+  'Cactus': {
+    caution: ['{claim} needs a sharper poke before it gets comfortable.', '{claim} is a little too soft for how much work it is doing.'],
+    kudos: ['Nice. {claim} had enough spine for the rest to lean on.', '{claim} held up under the sun. Good tough grounding.'],
+  },
+  'Robot': {
+    caution: ['Diagnostic: {claim} advanced without sufficient verification.', 'Warning: {claim} is over-trusted relative to observed support.'],
+    kudos: ['Confirmed: {claim} provided stable support for downstream reasoning.', '{claim} met grounding requirements. Subsequent logic benefited.'],
+  },
+  'Rabbit': {
+    caution: ['{claim} sprinted ahead before anybody checked its shoes.', 'Fast take: {claim} needs one sharp question before it multiplies.'],
+    kudos: ['Quick and clean — {claim} gave the rest a proper springboard.', '{claim} landed well, so the follow-through stayed nimble.'],
+  },
+  'Mushroom': {
+    caution: ['{claim} spread into the network a bit too easily. Probe the roots.', '{claim} has threads everywhere now. Worth checking the substrate.'],
+    kudos: ['{claim} had a healthy substrate, so the rest could fruit from it.', 'Nice hidden structure under {claim}. The network holds.'],
+  },
+  'Chonk': {
+    caution: ['{claim} is throwing its weight around without enough checking.', '{claim} is big for how little resistance it got. Lean on it first.'],
+    kudos: ['Oh, that is sturdy. {claim} had enough heft for the rest to sit on.', '{claim} carried the weight and did not complain. Respect.'],
+  },
+};
+
+function statLead(peakStat: StatName, tone: FindingTone): string {
+  if (tone === 'caution') {
+    switch (peakStat) {
+      case 'DEBUGGING': return 'Debug pass:';
+      case 'PATIENCE': return 'Easy does it:';
+      case 'CHAOS': return 'Tiny chaos check:';
+      case 'WISDOM': return 'Worth noticing:';
+      case 'SNARK': return 'Cute, but:';
+    }
+  }
+  switch (peakStat) {
+    case 'DEBUGGING': return 'Nice catch:';
+    case 'PATIENCE': return 'Steady work:';
+    case 'CHAOS': return 'Heh, nice:';
+    case 'WISDOM': return 'Good grounding:';
+    case 'SNARK': return 'Okay, yes:';
+  }
+}
+
 function fallbackPhrasing(type: FindingType): string {
   const table = PHRASINGS[type];
   for (const state of Object.keys(table) as ReactionState[]) {
@@ -126,4 +246,20 @@ export function phraseFinding(type: FindingType, state: ReactionState, claimText
   const pool = table[state];
   const chosen = (pool && pool.length > 0) ? pool[seed % pool.length] : fallbackPhrasing(type);
   return chosen.replaceAll('{claim}', claimSnippet(claimText));
+}
+
+export function phraseFindingForCompanion(type: FindingType, claimText: string, companion: Companion, seed: number = 0): string {
+  const tone = toneForFinding(type);
+  const speciesVoice = SPECIES_VOICES[companion.species];
+  const peakStat = getPeakStat(companion.stats);
+  const claim = claimSnippet(claimText);
+
+  if (!speciesVoice) {
+    const fallbackState: ReactionState = tone === 'caution' ? 'thinking' : 'impressed';
+    return phraseFinding(type, fallbackState, claimText, seed);
+  }
+
+  const pool = tone === 'caution' ? speciesVoice.caution : speciesVoice.kudos;
+  const body = pool[seed % pool.length].replaceAll('{claim}', claim);
+  return `${statLead(peakStat, tone)} ${body}`;
 }


### PR DESCRIPTION
## Summary
Add species- and stat-driven guard-mode finding voice so Buddy's caution and kudos nudges feel more in-character.

## What changed
- add Gherkin/EDD acceptance spec for Phase 1 and Phase 2
- replace mood-driven fallback finding phrasing with species + dominant-stat phrasing
- add custom caution and kudos voice coverage for all 21 species
- keep generic fallback phrasing for safety
- add focused tests for species variation, stat modulation, fallback safety, observer wiring, and full species coverage

## Validation
- `npm test -- --run src/__tests__/reasoning/phrasings-companion.test.ts src/__tests__/reasoning/phrasings-phase2.test.ts src/__tests__/observer.test.ts`
- Claude Code / Claude review completed with no actionable findings
