### PR TITLE
fix: use prebuilt binaries for better-sqlite3, never compile from source

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -48,24 +48,24 @@ Push-Location $INSTALL_DIR
 Write-Host "  Installing dependencies..."
 npm install --quiet 2>$null
 
-# Native addons (better-sqlite3) need compilation — rebuild explicitly
-# and let errors surface so failures aren't silent.
-Write-Host "  Building native modules..."
-$rebuildOutput = npm rebuild better-sqlite3 2>&1
-if ($LASTEXITCODE -ne 0) {
-  Write-Host "  ⚠ Native module rebuild failed. Retrying with full rebuild..." -ForegroundColor Yellow
-  npm rebuild 2>&1
-}
-
-# Verify the native binding actually loads before continuing
+# Verify the native binding loads. better-sqlite3 ships prebuilt binaries via
+# prebuild-install — never compile from source. If ABI mismatch, re-download.
 $verifyResult = node -e "require('better-sqlite3')" 2>&1
 if ($LASTEXITCODE -ne 0) {
-  Write-Host "  ⚠ better-sqlite3 native binding missing — attempting reinstall..." -ForegroundColor Yellow
-  npm rebuild better-sqlite3 2>&1
+  Write-Host "  ⚠ better-sqlite3 prebuilt missing or ABI mismatch — downloading correct prebuilt..." -ForegroundColor Yellow
+  $targetVersion = (node -v) -replace '^v', ''
+  $prebuildBin = "node_modules\prebuild-install\bin.js"
+  if (!(Test-Path $prebuildBin)) {
+    $prebuildBin = "node_modules\better-sqlite3\node_modules\.bin\prebuild-install"
+  }
+  if (Test-Path $prebuildBin) {
+    Push-Location "node_modules\better-sqlite3"
+    node "..\..\$prebuildBin" --target $targetVersion --runtime node 2>&1
+    Pop-Location
+  }
   $verifyResult = node -e "require('better-sqlite3')" 2>&1
   if ($LASTEXITCODE -ne 0) {
-    Write-Host "  ✗ Could not compile better-sqlite3. You may need to install build tools:" -ForegroundColor Yellow
-    Write-Host "    Windows: npm install --global windows-build-tools" -ForegroundColor DarkGray
+    Write-Host "  ✗ Could not load better-sqlite3. Try: npm rebuild better-sqlite3" -ForegroundColor Yellow
     Write-Host "    Or install Visual Studio Build Tools from https://visualstudio.microsoft.com/visual-cpp-build-tools/" -ForegroundColor DarkGray
     exit 1
   }

--- a/install.sh
+++ b/install.sh
@@ -98,22 +98,26 @@ cd "$INSTALL_DIR"
 echo "  Installing dependencies..."
 npm install --quiet 2>/dev/null
 
-# Native addons (better-sqlite3) need compilation — rebuild explicitly
-# and let errors surface so failures aren't silent.
-echo "  Building native modules..."
-if ! npm rebuild better-sqlite3 2>&1; then
-  echo -e "  ${YELLOW}⚠ Native module rebuild failed. Retrying with full rebuild...${NC}"
-  npm rebuild 2>&1 || true
-fi
-
-# Verify the native binding actually loads before continuing
-if ! "$NODE_BIN" -e "require('better-sqlite3')" 2>/dev/null; then
-  echo -e "  ${YELLOW}⚠ better-sqlite3 native binding missing — attempting reinstall...${NC}"
-  npm rebuild better-sqlite3 2>&1
-  if ! "$NODE_BIN" -e "require('better-sqlite3')" 2>/dev/null; then
-    echo -e "  ${YELLOW}✗ Could not compile better-sqlite3. You may need to install build tools:${NC}"
-    echo -e "    ${DIM}macOS: xcode-select --install${NC}"
-    echo -e "    ${DIM}Linux: sudo apt-get install build-essential python3${NC}"
+# Verify the native binding loads under the node that will actually run the server.
+# better-sqlite3 ships prebuilt binaries via prebuild-install — never compile from source.
+# If the prebuilt doesn't match (e.g. ABI mismatch from a node upgrade), re-download it.
+if ! "$CONFIG_NODE_BIN" -e "require('better-sqlite3')" 2>/dev/null; then
+  echo -e "  ${YELLOW}⚠ better-sqlite3 prebuilt missing or ABI mismatch — downloading correct prebuilt...${NC}"
+  TARGET_NODE_VERSION=$("$CONFIG_NODE_BIN" -v | tr -d 'v')
+  PREBUILD_BIN=""
+  if [ -f "node_modules/better-sqlite3/node_modules/.bin/prebuild-install" ]; then
+    PREBUILD_BIN="node_modules/better-sqlite3/node_modules/.bin/prebuild-install"
+  elif [ -f "node_modules/prebuild-install/bin.js" ]; then
+    PREBUILD_BIN="node_modules/prebuild-install/bin.js"
+  fi
+  if [ -n "$PREBUILD_BIN" ]; then
+    (cd node_modules/better-sqlite3 && "$NODE_BIN" "../../$PREBUILD_BIN" \
+      --target "$TARGET_NODE_VERSION" --runtime node 2>&1) || true
+  fi
+  # Final check
+  if ! "$CONFIG_NODE_BIN" -e "require('better-sqlite3')" 2>/dev/null; then
+    echo -e "  ${YELLOW}✗ Could not load better-sqlite3. Try: npm rebuild better-sqlite3${NC}"
+    echo -e "    ${DIM}Or ensure build tools are installed (xcode-select --install on macOS)${NC}"
     exit 1
   fi
 fi


### PR DESCRIPTION
## Summary
- Replaces the `npm rebuild` approach from #132 which destroys working prebuilt binaries and attempts compilation from source — fails on macOS when Gatekeeper kills `prebuild-install` (app-bundled node like Codex.app) and Python 3.14 has a broken `pyexpat` preventing `node-gyp` builds
- Verifies the binding under `CONFIG_NODE_BIN` (the node that will actually run the server), catching ABI mismatches between install-time and runtime node versions
- On failure, uses system node to run `prebuild-install --target <version>` to download the correct prebuilt — never compiles from source
- Tested: system node (v22) successfully downloads prebuilt for Codex app node (v24) via `prebuild-install --target 24.14.0`

## Test plan
- [ ] Fresh install on macOS with Codex.app node (v24) in PATH — verifies prebuilt, no compilation
- [ ] Install with homebrew node (v22) when settings.json points to Codex node (v24) — detects ABI mismatch, downloads v24 prebuilt using system node
- [ ] Install on system where prebuilt already matches — passes verification immediately
- [ ] Windows install via `install.ps1` — same prebuilt-download behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)