### PR TITLE
fix: revert native module rebuild — npm install handles prebuilts

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -47,31 +47,6 @@ Push-Location $INSTALL_DIR
 
 Write-Host "  Installing dependencies..."
 npm install --quiet 2>$null
-
-# Verify the native binding loads. better-sqlite3 ships prebuilt binaries via
-# prebuild-install — never compile from source. If ABI mismatch, re-download.
-$verifyResult = node -e "require('better-sqlite3')" 2>&1
-if ($LASTEXITCODE -ne 0) {
-  Write-Host "  ⚠ better-sqlite3 prebuilt missing or ABI mismatch — downloading correct prebuilt..." -ForegroundColor Yellow
-  $targetVersion = (node -v) -replace '^v', ''
-  $prebuildBin = "node_modules\prebuild-install\bin.js"
-  if (!(Test-Path $prebuildBin)) {
-    $prebuildBin = "node_modules\better-sqlite3\node_modules\.bin\prebuild-install"
-  }
-  if (Test-Path $prebuildBin) {
-    Push-Location "node_modules\better-sqlite3"
-    node "..\..\$prebuildBin" --target $targetVersion --runtime node 2>&1
-    Pop-Location
-  }
-  $verifyResult = node -e "require('better-sqlite3')" 2>&1
-  if ($LASTEXITCODE -ne 0) {
-    Write-Host "  ✗ Could not load better-sqlite3. Try: npm rebuild better-sqlite3" -ForegroundColor Yellow
-    Write-Host "    Or install Visual Studio Build Tools from https://visualstudio.microsoft.com/visual-cpp-build-tools/" -ForegroundColor DarkGray
-    exit 1
-  }
-}
-Write-Host "  ✓ Native modules verified" -ForegroundColor Green
-
 Write-Host "  Building..."
 npm run build --quiet 2>$null
 

--- a/install.sh
+++ b/install.sh
@@ -97,32 +97,6 @@ cd "$INSTALL_DIR"
 
 echo "  Installing dependencies..."
 npm install --quiet 2>/dev/null
-
-# Verify the native binding loads under the node that will actually run the server.
-# better-sqlite3 ships prebuilt binaries via prebuild-install — never compile from source.
-# If the prebuilt doesn't match (e.g. ABI mismatch from a node upgrade), re-download it.
-if ! "$CONFIG_NODE_BIN" -e "require('better-sqlite3')" 2>/dev/null; then
-  echo -e "  ${YELLOW}⚠ better-sqlite3 prebuilt missing or ABI mismatch — downloading correct prebuilt...${NC}"
-  TARGET_NODE_VERSION=$("$CONFIG_NODE_BIN" -v | tr -d 'v')
-  PREBUILD_BIN=""
-  if [ -f "node_modules/better-sqlite3/node_modules/.bin/prebuild-install" ]; then
-    PREBUILD_BIN="node_modules/better-sqlite3/node_modules/.bin/prebuild-install"
-  elif [ -f "node_modules/prebuild-install/bin.js" ]; then
-    PREBUILD_BIN="node_modules/prebuild-install/bin.js"
-  fi
-  if [ -n "$PREBUILD_BIN" ]; then
-    (cd node_modules/better-sqlite3 && "$NODE_BIN" "../../$PREBUILD_BIN" \
-      --target "$TARGET_NODE_VERSION" --runtime node 2>&1) || true
-  fi
-  # Final check
-  if ! "$CONFIG_NODE_BIN" -e "require('better-sqlite3')" 2>/dev/null; then
-    echo -e "  ${YELLOW}✗ Could not load better-sqlite3. Try: npm rebuild better-sqlite3${NC}"
-    echo -e "    ${DIM}Or ensure build tools are installed (xcode-select --install on macOS)${NC}"
-    exit 1
-  fi
-fi
-echo -e "  ${GREEN}✓${NC} Native modules verified"
-
 echo "  Building..."
 npm run build --quiet 2>/dev/null
 


### PR DESCRIPTION
## Summary
- Reverts the rebuild/verification logic from #132 and #133
- `npm install` already downloads the correct prebuilt via `prebuild-install` — no extra steps needed
- The added logic was causing failures on macOS: Gatekeeper kills prebuild-install when run from app-bundled node (Codex.app), and Python 3.14 breaks node-gyp compilation
- Back to the simple approach that worked in 1.0.5: `npm install` + `npm run build`

## Root cause
The real issue was `settings.json` getting configured with `/Applications/Codex.app/Contents/Resources/node` (which has code signing restrictions that reject `.node` files with different Team IDs). The installer should always pin system node.

## Test plan
- [ ] `curl | bash` on macOS — installs cleanly, no rebuild errors
- [ ] `irm | iex` on Windows — same

🤖 Generated with [Claude Code](https://claude.com/claude-code)