### PR TITLE
fix: prefer system node over app-bundled node in installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -68,6 +68,20 @@ if ! command -v node &> /dev/null; then
 fi
 
 NODE_BIN="$(command -v node)"
+
+# Prefer system node over app-bundled node (e.g. /Applications/Codex.app/Contents/Resources/node).
+# App-bundled node has macOS code signing restrictions that reject .node native addons
+# compiled/downloaded outside the app bundle (different Team IDs).
+if [[ "$NODE_BIN" == /Applications/*.app/* ]]; then
+  for candidate in /opt/homebrew/bin/node /usr/local/bin/node; do
+    if [ -x "$candidate" ]; then
+      echo -e "  ${DIM}Preferring system node ($candidate) over app-bundled ($NODE_BIN)${NC}"
+      NODE_BIN="$candidate"
+      break
+    fi
+  done
+fi
+
 NODE_VERSION=$("$NODE_BIN" -v | cut -d'v' -f2 | cut -d'.' -f1)
 # Always pin the absolute Node path in generated configs so GUI-launched clients
 # (e.g. Claude desktop on macOS) find the correct binary regardless of shell init.


### PR DESCRIPTION
## Summary
- App-bundled node (`/Applications/Codex.app/Contents/Resources/node`) has macOS code signing restrictions that reject `.node` native addons with different Team IDs
- `npm install` downloads the prebuilt fine, but the pinned node can't `dlopen` it at runtime
- Installer now detects `/Applications/*.app/*` node and prefers `/opt/homebrew/bin/node` or `/usr/local/bin/node` instead
- This is the actual root cause of the install failures — the previous PRs (#132, #133, #134) were treating symptoms

## Test plan
- [ ] `curl | bash` with Codex.app node first in PATH — should print "Preferring system node" and pin homebrew node
- [ ] `curl | bash` with only homebrew node in PATH — no change in behavior
- [ ] MCP server starts successfully after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)