### PR TITLE
fix: use pinned node/npm everywhere in installers, bump minimum to Node 20

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -20,11 +20,15 @@ catch {
   exit 1
 }
 
-$nodeVersion = (node -v) -replace 'v(\d+)\..*', '$1'
-if ([int]$nodeVersion -lt 18) {
-  Write-Host "  Node.js 18+ required. You have $(node -v)." -ForegroundColor Yellow
+$NODE_BIN = (Get-Command node).Source
+$nodeVersion = (& $NODE_BIN -v) -replace 'v(\d+)\..*', '$1'
+if ([int]$nodeVersion -lt 20) {
+  Write-Host "  Node.js 20+ required (better-sqlite3 dropped Node 18/19 support). You have $(& $NODE_BIN -v)." -ForegroundColor Yellow
   exit 1
 }
+
+# Prepend pinned node's directory to PATH so bare npm resolves to the same runtime
+$env:Path = (Split-Path $NODE_BIN) + ";" + $env:Path
 
 try { $null = Get-Command git -ErrorAction Stop }
 catch {
@@ -78,7 +82,7 @@ function Add-BuddyToConfig($configPath, $cliName) {
 
   $buddyConfig = @{
     type = "stdio"
-    command = "node"
+    command = $NODE_BIN
     args = @($SERVER_PATH_UNIX)
   }
 
@@ -125,7 +129,7 @@ if (Get-Command claude -ErrorAction SilentlyContinue) {
     Write-Host "  ✓ Claude Code MCP already registered" -ForegroundColor Green
     $claudeRegistered = $true
   } else {
-    claude mcp add buddy -s user -- node "$SERVER_PATH_UNIX" 1>$null 2>$null
+    claude mcp add buddy -s user -- "$NODE_BIN" "$SERVER_PATH_UNIX" 1>$null 2>$null
     if ($LASTEXITCODE -eq 0) {
       Write-Host "  ✓ Claude Code MCP registered via claude CLI" -ForegroundColor Green
       $claudeRegistered = $true
@@ -147,7 +151,7 @@ if (-not $claudeRegistered) {
   }
   $userConfig.mcpServers | Add-Member -NotePropertyName "buddy" -NotePropertyValue @{
     type = "stdio"
-    command = "node"
+    command = $NODE_BIN
     args = @($SERVER_PATH_UNIX)
   } -Force
   $userConfig | ConvertTo-Json -Depth 8 | Set-Content $claudeUserFile -Encoding UTF8
@@ -165,15 +169,15 @@ if (!(Test-Path $claudeSettings)) {
   '{}' | Set-Content $claudeSettings -Encoding UTF8
 }
 
-$statuslineCommand = "node $STATUSLINE_PATH_UNIX"
+$statuslineCommand = "`"$NODE_BIN`" $STATUSLINE_PATH_UNIX"
 $env:CLAUDE_SETTINGS = $claudeSettings
-$env:HOOK_COMMAND = "node $HOOK_PATH_UNIX"
-$env:STOP_HOOK_COMMAND = "node $STOP_HOOK_PATH_UNIX"
-$env:PROMPT_HOOK_COMMAND = "node $PROMPT_HOOK_PATH_UNIX"
+$env:HOOK_COMMAND = "`"$NODE_BIN`" $HOOK_PATH_UNIX"
+$env:STOP_HOOK_COMMAND = "`"$NODE_BIN`" $STOP_HOOK_PATH_UNIX"
+$env:PROMPT_HOOK_COMMAND = "`"$NODE_BIN`" $PROMPT_HOOK_PATH_UNIX"
 $env:STATUSLINE_COMMAND = $statuslineCommand
 $env:SERVER_PATH = $SERVER_PATH_UNIX
-$env:NODE_BIN = "node"
-$settingsResult = node -e @'
+$env:NODE_BIN = $NODE_BIN
+$settingsResult = & $NODE_BIN -e @'
 const fs = require('fs');
 const settingsPath = process.env.CLAUDE_SETTINGS;
 const hookCommand = process.env.HOOK_COMMAND;
@@ -337,8 +341,8 @@ if (Test-Path "$env:USERPROFILE\.cursor") {
 $cursorHooks = "$env:USERPROFILE\.cursor\hooks.json"
 if (Test-Path "$env:USERPROFILE\.cursor") {
   $env:CURSOR_HOOKS_FILE = $cursorHooks
-  $env:HOOK_COMMAND = "node $HOOK_PATH_UNIX"
-  $cursorResult = node -e @'
+  $env:HOOK_COMMAND = "`"$NODE_BIN`" $HOOK_PATH_UNIX"
+  $cursorResult = & $NODE_BIN -e @'
 const fs = require('fs');
 const path = process.env.CURSOR_HOOKS_FILE;
 const hookCommand = process.env.HOOK_COMMAND;
@@ -375,9 +379,9 @@ if (Test-Path "$env:USERPROFILE\.copilot") {
   if ($COPILOT_CONFIGURED) {
     $copilotSettings = "$env:USERPROFILE\.copilot\settings.json"
     $env:COPILOT_SETTINGS = $copilotSettings
-    $env:BASH_COMMAND = "node $HOOK_PATH_UNIX"
-    $env:POWERSHELL_COMMAND = "node $HOOK_PATH_UNIX"
-    $copilotResult = node -e @'
+    $env:BASH_COMMAND = "`"$NODE_BIN`" $HOOK_PATH_UNIX"
+    $env:POWERSHELL_COMMAND = "`"$NODE_BIN`" $HOOK_PATH_UNIX"
+    $copilotResult = & $NODE_BIN -e @'
 const fs = require('fs');
 const path = require('path');
 const settingsPath = process.env.COPILOT_SETTINGS;
@@ -420,7 +424,7 @@ if (Get-Command codex -ErrorAction SilentlyContinue) {
     Write-Host "  ✓ Codex CLI already configured" -ForegroundColor Green
     $CODEX_CONFIGURED = $true
   } else {
-    codex mcp add buddy -- node "$SERVER_PATH_UNIX" 1>$null 2>$null
+    codex mcp add buddy -- "$NODE_BIN" "$SERVER_PATH_UNIX" 1>$null 2>$null
     if ($LASTEXITCODE -eq 0) {
       Write-Host "  ✓ Codex CLI configured" -ForegroundColor Green
       $CODEX_CONFIGURED = $true
@@ -432,8 +436,8 @@ if (Get-Command codex -ErrorAction SilentlyContinue) {
   if ($CODEX_CONFIGURED) {
     $codexHooks = "$env:USERPROFILE\.codex\hooks.json"
     $env:CODEX_HOOKS_FILE = $codexHooks
-    $env:HOOK_COMMAND = "node $HOOK_PATH_UNIX"
-    $codexResult = node -e @'
+    $env:HOOK_COMMAND = "`"$NODE_BIN`" $HOOK_PATH_UNIX"
+    $codexResult = & $NODE_BIN -e @'
 const fs = require('fs');
 const path = require('path');
 const hooksPath = process.env.CODEX_HOOKS_FILE;
@@ -564,7 +568,7 @@ Write-Host ""
 $ONBOARD_SCRIPT = "$INSTALL_DIR\dist\cli\onboard.js"
 if (Test-Path $ONBOARD_SCRIPT) {
   try {
-    node $ONBOARD_SCRIPT
+    & $NODE_BIN $ONBOARD_SCRIPT
   } catch {
     # Non-fatal — wizard is optional
   }

--- a/install.ps1
+++ b/install.ps1
@@ -205,9 +205,9 @@ if (!existing || existing.command !== nodeBin || !Array.isArray(existing.args) |
 if (!config.hooks) config.hooks = {};
 
 // Match on script path suffix to recognise legacy "node <path>" entries from older installs.
-const hookScript = hookCommand.split(/\s+/).slice(-1)[0].replace(/"/g, '');
-const stopHookScript = stopHookCommand.split(/\s+/).slice(-1)[0].replace(/"/g, '');
-const promptHookScript = promptHookCommand.split(/\s+/).slice(-1)[0].replace(/"/g, '');
+const hookScript = hookCommand.match(/"([^"]+)"\s*$/)?.[1] || hookCommand.split(/\s+/).slice(-1)[0];
+const stopHookScript = stopHookCommand.match(/"([^"]+)"\s*$/)?.[1] || stopHookCommand.split(/\s+/).slice(-1)[0];
+const promptHookScript = promptHookCommand.match(/"([^"]+)"\s*$/)?.[1] || promptHookCommand.split(/\s+/).slice(-1)[0];
 const matchesHook = (cmd, current, script) => cmd === current || (cmd && cmd.endsWith(script));
 
 // PostToolUse — error detection (Bash only)
@@ -352,7 +352,7 @@ if (!config.version) config.version = 1;
 if (!config.hooks || typeof config.hooks !== 'object') config.hooks = {};
 if (!Array.isArray(config.hooks.afterShellExecution)) config.hooks.afterShellExecution = [];
 const hooks = config.hooks.afterShellExecution;
-const hookScript = hookCommand.split(/\s+/).slice(-1)[0].replace(/"/g, '');
+const hookScript = hookCommand.match(/"([^"]+)"\s*$/)?.[1] || hookCommand.split(/\s+/).slice(-1)[0];
 const matchesHook = (cmd) => cmd === hookCommand || (typeof cmd === 'string' && cmd.endsWith(hookScript));
 const hasHook = hooks.some(h => typeof h?.command === 'string' && matchesHook(h.command));
 if (!hasHook) {
@@ -392,7 +392,7 @@ try { config = JSON.parse(fs.readFileSync(settingsPath, 'utf-8')); } catch {}
 if (!config.hooks || typeof config.hooks !== 'object') config.hooks = {};
 if (!Array.isArray(config.hooks.postToolUse)) config.hooks.postToolUse = [];
 const hooks = config.hooks.postToolUse;
-const hookScript = bashCommand.split(/\s+/).slice(-1)[0].replace(/"/g, '');
+const hookScript = bashCommand.match(/"([^"]+)"\s*$/)?.[1] || bashCommand.split(/\s+/).slice(-1)[0];
 const matchesHook = (cmd) => cmd === bashCommand || (typeof cmd === 'string' && cmd.endsWith(hookScript));
 const hasHook = hooks.some(h => matchesHook(h?.bash) || matchesHook(h?.powershell));
 if (!hasHook) {
@@ -452,7 +452,7 @@ if (!group) {
   group = { matcher: 'Bash', hooks: [] };
   groups.push(group);
 }
-const hookScript = hookCommand.split(/\s+/).slice(-1)[0].replace(/"/g, '');
+const hookScript = hookCommand.match(/"([^"]+)"\s*$/)?.[1] || hookCommand.split(/\s+/).slice(-1)[0];
 const matchesHook = (cmd) => cmd === hookCommand || (typeof cmd === 'string' && cmd.endsWith(hookScript));
 const hasHook = group.hooks.some(h => typeof h?.command === 'string' && matchesHook(h.command));
 if (!hasHook) {

--- a/install.ps1
+++ b/install.ps1
@@ -169,11 +169,11 @@ if (!(Test-Path $claudeSettings)) {
   '{}' | Set-Content $claudeSettings -Encoding UTF8
 }
 
-$statuslineCommand = "`"$NODE_BIN`" $STATUSLINE_PATH_UNIX"
+$statuslineCommand = "`"$NODE_BIN`" `"$STATUSLINE_PATH_UNIX`""
 $env:CLAUDE_SETTINGS = $claudeSettings
-$env:HOOK_COMMAND = "`"$NODE_BIN`" $HOOK_PATH_UNIX"
-$env:STOP_HOOK_COMMAND = "`"$NODE_BIN`" $STOP_HOOK_PATH_UNIX"
-$env:PROMPT_HOOK_COMMAND = "`"$NODE_BIN`" $PROMPT_HOOK_PATH_UNIX"
+$env:HOOK_COMMAND = "`"$NODE_BIN`" `"$HOOK_PATH_UNIX`""
+$env:STOP_HOOK_COMMAND = "`"$NODE_BIN`" `"$STOP_HOOK_PATH_UNIX`""
+$env:PROMPT_HOOK_COMMAND = "`"$NODE_BIN`" `"$PROMPT_HOOK_PATH_UNIX`""
 $env:STATUSLINE_COMMAND = $statuslineCommand
 $env:SERVER_PATH = $SERVER_PATH_UNIX
 $env:NODE_BIN = $NODE_BIN
@@ -205,9 +205,9 @@ if (!existing || existing.command !== nodeBin || !Array.isArray(existing.args) |
 if (!config.hooks) config.hooks = {};
 
 // Match on script path suffix to recognise legacy "node <path>" entries from older installs.
-const hookScript = hookCommand.split(/\s+/).slice(-1)[0];
-const stopHookScript = stopHookCommand.split(/\s+/).slice(-1)[0];
-const promptHookScript = promptHookCommand.split(/\s+/).slice(-1)[0];
+const hookScript = hookCommand.split(/\s+/).slice(-1)[0].replace(/"/g, '');
+const stopHookScript = stopHookCommand.split(/\s+/).slice(-1)[0].replace(/"/g, '');
+const promptHookScript = promptHookCommand.split(/\s+/).slice(-1)[0].replace(/"/g, '');
 const matchesHook = (cmd, current, script) => cmd === current || (cmd && cmd.endsWith(script));
 
 // PostToolUse — error detection (Bash only)
@@ -341,7 +341,7 @@ if (Test-Path "$env:USERPROFILE\.cursor") {
 $cursorHooks = "$env:USERPROFILE\.cursor\hooks.json"
 if (Test-Path "$env:USERPROFILE\.cursor") {
   $env:CURSOR_HOOKS_FILE = $cursorHooks
-  $env:HOOK_COMMAND = "`"$NODE_BIN`" $HOOK_PATH_UNIX"
+  $env:HOOK_COMMAND = "`"$NODE_BIN`" `"$HOOK_PATH_UNIX`""
   $cursorResult = & $NODE_BIN -e @'
 const fs = require('fs');
 const path = process.env.CURSOR_HOOKS_FILE;
@@ -352,7 +352,7 @@ if (!config.version) config.version = 1;
 if (!config.hooks || typeof config.hooks !== 'object') config.hooks = {};
 if (!Array.isArray(config.hooks.afterShellExecution)) config.hooks.afterShellExecution = [];
 const hooks = config.hooks.afterShellExecution;
-const hookScript = hookCommand.split(/\s+/).slice(-1)[0];
+const hookScript = hookCommand.split(/\s+/).slice(-1)[0].replace(/"/g, '');
 const matchesHook = (cmd) => cmd === hookCommand || (typeof cmd === 'string' && cmd.endsWith(hookScript));
 const hasHook = hooks.some(h => typeof h?.command === 'string' && matchesHook(h.command));
 if (!hasHook) {
@@ -379,8 +379,8 @@ if (Test-Path "$env:USERPROFILE\.copilot") {
   if ($COPILOT_CONFIGURED) {
     $copilotSettings = "$env:USERPROFILE\.copilot\settings.json"
     $env:COPILOT_SETTINGS = $copilotSettings
-    $env:BASH_COMMAND = "`"$NODE_BIN`" $HOOK_PATH_UNIX"
-    $env:POWERSHELL_COMMAND = "`"$NODE_BIN`" $HOOK_PATH_UNIX"
+    $env:BASH_COMMAND = "`"$NODE_BIN`" `"$HOOK_PATH_UNIX`""
+    $env:POWERSHELL_COMMAND = "`"$NODE_BIN`" `"$HOOK_PATH_UNIX`""
     $copilotResult = & $NODE_BIN -e @'
 const fs = require('fs');
 const path = require('path');
@@ -392,7 +392,7 @@ try { config = JSON.parse(fs.readFileSync(settingsPath, 'utf-8')); } catch {}
 if (!config.hooks || typeof config.hooks !== 'object') config.hooks = {};
 if (!Array.isArray(config.hooks.postToolUse)) config.hooks.postToolUse = [];
 const hooks = config.hooks.postToolUse;
-const hookScript = bashCommand.split(/\s+/).slice(-1)[0];
+const hookScript = bashCommand.split(/\s+/).slice(-1)[0].replace(/"/g, '');
 const matchesHook = (cmd) => cmd === bashCommand || (typeof cmd === 'string' && cmd.endsWith(hookScript));
 const hasHook = hooks.some(h => matchesHook(h?.bash) || matchesHook(h?.powershell));
 if (!hasHook) {
@@ -436,7 +436,7 @@ if (Get-Command codex -ErrorAction SilentlyContinue) {
   if ($CODEX_CONFIGURED) {
     $codexHooks = "$env:USERPROFILE\.codex\hooks.json"
     $env:CODEX_HOOKS_FILE = $codexHooks
-    $env:HOOK_COMMAND = "`"$NODE_BIN`" $HOOK_PATH_UNIX"
+    $env:HOOK_COMMAND = "`"$NODE_BIN`" `"$HOOK_PATH_UNIX`""
     $codexResult = & $NODE_BIN -e @'
 const fs = require('fs');
 const path = require('path');
@@ -452,7 +452,7 @@ if (!group) {
   group = { matcher: 'Bash', hooks: [] };
   groups.push(group);
 }
-const hookScript = hookCommand.split(/\s+/).slice(-1)[0];
+const hookScript = hookCommand.split(/\s+/).slice(-1)[0].replace(/"/g, '');
 const matchesHook = (cmd) => cmd === hookCommand || (typeof cmd === 'string' && cmd.endsWith(hookScript));
 const hasHook = group.hooks.some(h => typeof h?.command === 'string' && matchesHook(h.command));
 if (!hasHook) {

--- a/install.ps1
+++ b/install.ps1
@@ -37,17 +37,17 @@ catch {
 }
 
 # Clone or update
-if (Test-Path $INSTALL_DIR) {
+if (Test-Path "$INSTALL_DIR") {
   Write-Host "  Updating existing installation..."
-  Push-Location $INSTALL_DIR
+  Push-Location "$INSTALL_DIR"
   git pull origin master --quiet
   Pop-Location
 } else {
   Write-Host "  Cloning Buddy MCP Server..."
-  git clone --depth 1 $REPO $INSTALL_DIR --quiet
+  git clone --depth 1 $REPO "$INSTALL_DIR" --quiet
 }
 
-Push-Location $INSTALL_DIR
+Push-Location "$INSTALL_DIR"
 
 Write-Host "  Installing dependencies..."
 npm install --quiet 2>$null
@@ -566,9 +566,9 @@ Write-Host "  👉 https://join.slack.com/t/buddy-mcp/shared_invite/zt-3xn6v1qza
 Write-Host ""
 
 $ONBOARD_SCRIPT = "$INSTALL_DIR\dist\cli\onboard.js"
-if (Test-Path $ONBOARD_SCRIPT) {
+if (Test-Path "$ONBOARD_SCRIPT") {
   try {
-    & $NODE_BIN $ONBOARD_SCRIPT
+    & $NODE_BIN "$ONBOARD_SCRIPT"
   } catch {
     # Non-fatal — wizard is optional
   }

--- a/install.sh
+++ b/install.sh
@@ -73,13 +73,19 @@ NODE_BIN="$(command -v node)"
 # App-bundled node has macOS code signing restrictions that reject .node native addons
 # compiled/downloaded outside the app bundle (different Team IDs).
 if [[ "$NODE_BIN" == /Applications/*.app/* ]]; then
+  FOUND_SYSTEM_NODE=0
   for candidate in /opt/homebrew/bin/node /usr/local/bin/node; do
     if [ -x "$candidate" ]; then
       echo -e "  ${DIM}Preferring system node ($candidate) over app-bundled ($NODE_BIN)${NC}"
       NODE_BIN="$candidate"
+      FOUND_SYSTEM_NODE=1
       break
     fi
   done
+  if [ "$FOUND_SYSTEM_NODE" -eq 0 ]; then
+    echo -e "  ${YELLOW}Warning: only app-bundled node found ($NODE_BIN). Native addons may fail due to code signing restrictions.${NC}"
+    echo -e "  ${YELLOW}Install Node.js via Homebrew (brew install node) or from https://nodejs.org for best results.${NC}"
+  fi
 fi
 
 NODE_VERSION=$("$NODE_BIN" -v | cut -d'v' -f2 | cut -d'.' -f1)
@@ -87,8 +93,11 @@ NODE_VERSION=$("$NODE_BIN" -v | cut -d'v' -f2 | cut -d'.' -f1)
 # (e.g. Claude desktop on macOS) find the correct binary regardless of shell init.
 # nvm/asdf/fnm users: re-run the installer after upgrading Node.
 CONFIG_NODE_BIN="$NODE_BIN"
-if [ "$NODE_VERSION" -lt 18 ]; then
-  echo -e "${YELLOW}Node.js 18+ required. You have $("$NODE_BIN" -v). Please upgrade.${NC}"
+# Prepend pinned node's directory to PATH so bare `npm` and npm's internal
+# node shebang both resolve to the same runtime as $NODE_BIN.
+export PATH="$(dirname "$NODE_BIN"):$PATH"
+if [ "$NODE_VERSION" -lt 20 ]; then
+  echo -e "${YELLOW}Node.js 20+ required (better-sqlite3 dropped Node 18/19 support). You have $("$NODE_BIN" -v). Please upgrade.${NC}"
   exit 1
 fi
 
@@ -122,7 +131,7 @@ for bin_entry in buddy:buddy.js buddy-doctor:doctor-cli.js; do
     chmod +x "$bin_file"
     ln -sf "$bin_file" "/usr/local/bin/$bin_name" 2>/dev/null \
       || sudo ln -sf "$bin_file" "/usr/local/bin/$bin_name" 2>/dev/null \
-      || echo "  ${YELLOW}Could not symlink $bin_name to /usr/local/bin — add $INSTALL_DIR/dist/cli to your PATH${NC}"
+      || echo -e "  ${YELLOW}Could not symlink $bin_name to /usr/local/bin — add $INSTALL_DIR/dist/cli to your PATH${NC}"
   fi
 done
 
@@ -679,7 +688,7 @@ echo ""
 if [ -f "$ONBOARD_SCRIPT" ] && [ "$NO_ONBOARD" -eq 0 ]; then
   # Let onboard.ts detect TTY itself — don't force /dev/tty
   # (fails in headless SSH, CI, cron where no controlling terminal exists)
-  node "$ONBOARD_SCRIPT" || true
+  "$NODE_BIN" "$ONBOARD_SCRIPT" || true
 elif [ "$NO_ONBOARD" -eq 1 ]; then
   echo -e "  ${DIM}Onboarding skipped (--no-onboard). Run buddy-onboard later to set up.${NC}"
 fi

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "release:minor": "npm version minor",
     "release:major": "npm version major"
   },
+  "engines": {
+    "node": ">=20"
+  },
   "keywords": [],
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- **Pin `$NODE_BIN` everywhere** in both `install.sh` and `install.ps1` — bare `node`/`npm` calls that bypassed the pinned runtime were causing `ERR_DLOPEN_FAILED` crashes (macOS code signature Team ID mismatch when app-bundled node loaded native modules)
- **PATH prepend** `$NODE_BIN`'s directory before running npm, so npm's internal shebang resolves to the correct node binary
- **Bump minimum Node from 18 to 20** — `better-sqlite3@12.8.0` dropped Node 18/19 support
- **Quote all paths** in PowerShell hook/statusline commands and install paths for spaces-in-paths safety
- **Fix duplicate detection** to use regex extraction of quoted paths instead of whitespace splitting

Closes the root cause behind PRs #116, #132, #133, #134, #135 which were all chasing symptoms of the same bare-node gap left by PR #109.

## Test plan
- [ ] `curl -fsSL https://raw.githubusercontent.com/fiorastudio/buddy/master/install.sh | bash` — no `ERR_DLOPEN_FAILED`
- [ ] App-bundled node in PATH → detects and warns, uses system node
- [ ] Node 18/19 → clear error message saying Node 20+ required
- [ ] Generated MCP configs contain absolute node path, not bare `node`
- [ ] Windows: `irm ... | iex` installs cleanly with quoted paths
- [ ] Paths with spaces don't break hook commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)