### PR TITLE
fix: auto-rebuild better-sqlite3 when native binary ABI mismatches runtime

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -51,6 +51,17 @@ Push-Location "$INSTALL_DIR"
 
 Write-Host "  Installing dependencies..."
 npm install --quiet 2>$null
+
+# Verify native module ABI matches current node. Stale binary from a prior
+# install with a different node version will crash at runtime. Rebuild if needed.
+try {
+  & $NODE_BIN -e "require('better-sqlite3')" 2>$null
+} catch {}
+if ($LASTEXITCODE -ne 0) {
+  Write-Host "  Rebuilding native module for $(& $NODE_BIN -v)..."
+  npm rebuild better-sqlite3 --quiet 2>$null
+}
+
 Write-Host "  Building..."
 npm run build --quiet 2>$null
 

--- a/install.sh
+++ b/install.sh
@@ -120,6 +120,14 @@ cd "$INSTALL_DIR"
 
 echo "  Installing dependencies..."
 npm install --quiet 2>/dev/null
+
+# Verify native module ABI matches current node. A stale binary from a prior
+# install with a different node version will crash at runtime. Rebuild if needed.
+if ! "$NODE_BIN" -e "require('better-sqlite3')" 2>/dev/null; then
+  echo "  Rebuilding native module for $(\"$NODE_BIN\" -v)..."
+  npm rebuild better-sqlite3 --quiet 2>/dev/null
+fi
+
 echo "  Building..."
 npm run build --quiet 2>/dev/null
 


### PR DESCRIPTION
## Summary

- After `npm install`, verify `better-sqlite3` loads under the current node runtime
- If it fails (stale binary from a prior install with different Node ABI), automatically run `npm rebuild better-sqlite3`
- Fixes the case where a user previously installed with Node 24 (Codex.app bundled, ABI 137) but now runs Node 22 (ABI 127) — `npm install` is a no-op since the package version hasn't changed, leaving the wrong binary in place

Root cause: `npm install` skips reinstalling packages when the version matches, preserving a native binary compiled for a different Node ABI. PR #136 fixed the PATH/node-pinning, but didn't handle pre-existing stale binaries.

## Test plan
- [ ] Install with Node 22, then switch to Node 24 and reinstall — binary should auto-rebuild
- [ ] Fresh install — rebuild check passes silently, no extra output
- [ ] `curl -fsSL ... | bash` on a machine with stale `.buddy/server` — no ERR_DLOPEN_FAILED

🤖 Generated with [Claude Code](https://claude.com/claude-code)