### PR TITLE
feat: add buddy-share CLI symlink and /buddy-share slash command

### DIFF
--- a/.claude/commands/buddy-share.md
+++ b/.claude/commands/buddy-share.md
@@ -1,0 +1,32 @@
+---
+description: Generate a shareable PNG card of your Buddy's current status.
+---
+
+Generate a snapshot PNG of the current Buddy companion card.
+
+If `$ARGUMENTS` is present, treat it as an optional output file path.
+
+```bash
+set -euo pipefail
+
+args=()
+if [ -n "${ARGUMENTS:-}" ]; then
+  read -r -a args <<< "$ARGUMENTS"
+fi
+
+if command -v buddy-share >/dev/null 2>&1; then
+  buddy-share "${args[@]}"
+else
+  BUDDY_SERVER="$HOME/.buddy/server/dist/cli/snapshot-cli.js"
+  NODE_BIN="$(command -v node)"
+  for candidate in /opt/homebrew/bin/node /usr/local/bin/node; do
+    if [ -x "$candidate" ] && [[ "$NODE_BIN" == /Applications/*.app/* ]]; then
+      NODE_BIN="$candidate"
+      break
+    fi
+  done
+  "$NODE_BIN" "$BUDDY_SERVER" "${args[@]}"
+fi
+```
+
+Execute the bash block above, then report the saved PNG path back to the user.

--- a/install.sh
+++ b/install.sh
@@ -132,7 +132,7 @@ echo "  Building..."
 npm run build --quiet 2>/dev/null
 
 # ── Symlink CLI binaries onto PATH ──
-for bin_entry in buddy:buddy.js buddy-doctor:doctor-cli.js; do
+for bin_entry in buddy:buddy.js buddy-doctor:doctor-cli.js buddy-share:snapshot-cli.js; do
   bin_name="${bin_entry%%:*}"
   bin_file="$INSTALL_DIR/dist/cli/${bin_entry##*:}"
   if [ -f "$bin_file" ]; then


### PR DESCRIPTION
## Summary

- `install.sh` now symlinks `buddy-share` to `/usr/local/bin` alongside `buddy` and `buddy-doctor`, so users get the binary on PATH after running the installer
- Adds `.claude/commands/buddy-share.md` — a `/buddy-share` slash command that generates a snapshot PNG of the current buddy card, with a fallback to `~/.buddy/server/dist/cli/snapshot-cli.js` for environments where the binary isn't on PATH (e.g. app-bundled Node like Codex)

## Test plan

- [ ] Run `install.sh` and confirm `which buddy-share` resolves to `/usr/local/bin/buddy-share`
- [ ] Run `/buddy-share` in Claude Code and confirm a PNG is generated and sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)