### PR TITLE
fix: make Windows node pin version-stable and ABI check reliable

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -26,22 +26,38 @@ $NODE_BIN = (Get-Command node).Source
 # exposes node at C:\Program Files\nodejs (a junction it repoints on every
 # `nvm use`), so pinning that path silently swaps the runtime later and
 # crashes better-sqlite3 with an ABI mismatch. Pin the resolved target instead.
+# Only follow reparse points that actually redirect (SymbolicLink/Junction).
+# HardLink Targets are alternate names for the same file and must not be
+# followed — Target[0] could pin an arbitrary alias. Loop to unwind chained
+# links (nvm shim -> junction -> version dir), bounded to avoid cycles.
+$REDIRECT_LINK_TYPES = @('SymbolicLink', 'Junction')
 try {
-  $nodeItem = Get-Item $NODE_BIN -ErrorAction Stop
-  if ($nodeItem.LinkType -and $nodeItem.Target) {
-    $resolvedFile = @($nodeItem.Target)[0]
-    if (Test-Path $resolvedFile) { $NODE_BIN = $resolvedFile }
-  }
-  $nodeDirItem = Get-Item (Split-Path $NODE_BIN) -ErrorAction Stop
-  if ($nodeDirItem.LinkType -and $nodeDirItem.Target) {
-    $resolvedDir = @($nodeDirItem.Target)[0]
-    $resolvedNode = Join-Path $resolvedDir (Split-Path $NODE_BIN -Leaf)
-    if (Test-Path $resolvedNode) {
-      Write-Host "  Pinning node to resolved path: $resolvedNode" -ForegroundColor DarkGray
-      $NODE_BIN = $resolvedNode
+  $resolvedAny = $false
+  for ($hop = 0; $hop -lt 4; $hop++) {
+    $changed = $false
+
+    $nodeItem = Get-Item $NODE_BIN -ErrorAction Stop
+    if ($REDIRECT_LINK_TYPES -contains $nodeItem.LinkType -and $nodeItem.Target) {
+      $resolvedFile = @($nodeItem.Target)[0]
+      if (Test-Path $resolvedFile) { $NODE_BIN = $resolvedFile; $changed = $true }
     }
+
+    $nodeDirItem = Get-Item (Split-Path $NODE_BIN) -ErrorAction Stop
+    if ($REDIRECT_LINK_TYPES -contains $nodeDirItem.LinkType -and $nodeDirItem.Target) {
+      $resolvedDir = @($nodeDirItem.Target)[0]
+      $resolvedNode = Join-Path $resolvedDir (Split-Path $NODE_BIN -Leaf)
+      if (Test-Path $resolvedNode) { $NODE_BIN = $resolvedNode; $changed = $true }
+    }
+
+    if ($changed) { $resolvedAny = $true } else { break }
   }
-} catch {}
+  if ($resolvedAny) {
+    Write-Host "  Pinning node to resolved path: $NODE_BIN" -ForegroundColor DarkGray
+  }
+} catch {
+  Write-Host "  ! Could not resolve node's link target; pinning $NODE_BIN as-is." -ForegroundColor Yellow
+  Write-Host "    If you use nvm-windows, re-run this installer after 'nvm use' changes." -ForegroundColor Yellow
+}
 
 $nodeVersion = (& $NODE_BIN -v) -replace 'v(\d+)\..*', '$1'
 if ([int]$nodeVersion -lt 20) {

--- a/install.ps1
+++ b/install.ps1
@@ -30,7 +30,8 @@ $NODE_BIN = (Get-Command node).Source
 # HardLink Targets are alternate names for the same file and must not be
 # followed — Target[0] could pin an arbitrary alias. Loop to unwind chained
 # links (nvm shim -> junction -> version dir), bounded to avoid cycles.
-$REDIRECT_LINK_TYPES = @('SymbolicLink', 'Junction')
+# 'SymLink' included defensively: LinkType string varies across PS builds.
+$REDIRECT_LINK_TYPES = @('SymbolicLink', 'SymLink', 'Junction')
 try {
   $resolvedAny = $false
   for ($hop = 0; $hop -lt 4; $hop++) {
@@ -53,6 +54,12 @@ try {
   }
   if ($resolvedAny) {
     Write-Host "  Pinning node to resolved path: $NODE_BIN" -ForegroundColor DarkGray
+    # Verify the hop limit actually finished the job.
+    $finalItem = Get-Item $NODE_BIN -ErrorAction Stop
+    if ($REDIRECT_LINK_TYPES -contains $finalItem.LinkType) {
+      Write-Host "  ! node path is still a link after 4 hops; pinning it as-is." -ForegroundColor Yellow
+      Write-Host "    Re-run this installer if node version switches cause crashes." -ForegroundColor Yellow
+    }
   }
 } catch {
   Write-Host "  ! Could not resolve node's link target; pinning $NODE_BIN as-is." -ForegroundColor Yellow

--- a/install.ps1
+++ b/install.ps1
@@ -54,9 +54,11 @@ try {
   }
   if ($resolvedAny) {
     Write-Host "  Pinning node to resolved path: $NODE_BIN" -ForegroundColor DarkGray
-    # Verify the hop limit actually finished the job.
+    # Verify the hop limit actually finished the job — check both the
+    # file and its parent directory (a remaining dir junction is also unresolved).
     $finalItem = Get-Item $NODE_BIN -ErrorAction Stop
-    if ($REDIRECT_LINK_TYPES -contains $finalItem.LinkType) {
+    $finalDirItem = Get-Item (Split-Path $NODE_BIN) -ErrorAction Stop
+    if (($REDIRECT_LINK_TYPES -contains $finalItem.LinkType) -or ($REDIRECT_LINK_TYPES -contains $finalDirItem.LinkType)) {
       Write-Host "  ! node path is still a link after 4 hops; pinning it as-is." -ForegroundColor Yellow
       Write-Host "    Re-run this installer if node version switches cause crashes." -ForegroundColor Yellow
     }

--- a/install.ps1
+++ b/install.ps1
@@ -21,6 +21,28 @@ catch {
 }
 
 $NODE_BIN = (Get-Command node).Source
+
+# Resolve symlinks/junctions to the real versioned node binary. nvm-windows
+# exposes node at C:\Program Files\nodejs (a junction it repoints on every
+# `nvm use`), so pinning that path silently swaps the runtime later and
+# crashes better-sqlite3 with an ABI mismatch. Pin the resolved target instead.
+try {
+  $nodeItem = Get-Item $NODE_BIN -ErrorAction Stop
+  if ($nodeItem.LinkType -and $nodeItem.Target) {
+    $resolvedFile = @($nodeItem.Target)[0]
+    if (Test-Path $resolvedFile) { $NODE_BIN = $resolvedFile }
+  }
+  $nodeDirItem = Get-Item (Split-Path $NODE_BIN) -ErrorAction Stop
+  if ($nodeDirItem.LinkType -and $nodeDirItem.Target) {
+    $resolvedDir = @($nodeDirItem.Target)[0]
+    $resolvedNode = Join-Path $resolvedDir (Split-Path $NODE_BIN -Leaf)
+    if (Test-Path $resolvedNode) {
+      Write-Host "  Pinning node to resolved path: $resolvedNode" -ForegroundColor DarkGray
+      $NODE_BIN = $resolvedNode
+    }
+  }
+} catch {}
+
 $nodeVersion = (& $NODE_BIN -v) -replace 'v(\d+)\..*', '$1'
 if ([int]$nodeVersion -lt 20) {
   Write-Host "  Node.js 20+ required (better-sqlite3 dropped Node 18/19 support). You have $(& $NODE_BIN -v)." -ForegroundColor Yellow
@@ -52,14 +74,26 @@ Push-Location "$INSTALL_DIR"
 Write-Host "  Installing dependencies..."
 npm install --quiet 2>$null
 
-# Verify native module ABI matches current node. Stale binary from a prior
-# install with a different node version will crash at runtime. Rebuild if needed.
-try {
-  & $NODE_BIN -e "require('better-sqlite3')" 2>$null
-} catch {}
-if ($LASTEXITCODE -ne 0) {
-  Write-Host "  Rebuilding native module for $(& $NODE_BIN -v)..."
-  npm rebuild better-sqlite3 --quiet 2>$null
+# Verify native module ABI matches current node. A stale binary from a prior
+# install with a different node version will crash at runtime.
+# Probe via a stdout marker instead of $LASTEXITCODE: with EAP=Stop, PS 5.1
+# throws NativeCommandError on redirected native stderr and can leave
+# $LASTEXITCODE stale, which made the old check silently skip the rebuild.
+# The JS-side catch keeps stderr clean and the exit code 0 in both outcomes.
+$abiProbeJs = "try{require('better-sqlite3');console.log('ABI_OK')}catch(e){console.log('ABI_FAIL')}"
+$abiProbe = & $NODE_BIN -e $abiProbeJs
+if ("$abiProbe" -notmatch 'ABI_OK') {
+  Write-Host "  Rebuilding native module for node $(& $NODE_BIN -v)..."
+  npm rebuild better-sqlite3
+  $abiProbe = & $NODE_BIN -e $abiProbeJs
+  if ("$abiProbe" -notmatch 'ABI_OK') {
+    Write-Host ""
+    Write-Host "  X better-sqlite3 does not load under node $(& $NODE_BIN -v) ($NODE_BIN) and the rebuild failed." -ForegroundColor Red
+    Write-Host "    If you use nvm, switch to the node version Buddy should run under (nvm use <version>)," -ForegroundColor Yellow
+    Write-Host "    then re-run this installer. See the rebuild output above for details." -ForegroundColor Yellow
+    Pop-Location
+    exit 1
+  }
 }
 
 Write-Host "  Building..."
@@ -570,12 +604,6 @@ if ($COPILOT_CONFIGURED) {
 
 # ── Run onboarding wizard ──
 
-Write-Host ""
-Write-Host "  💬 Join the Buddy Community!" -ForegroundColor Blue
-Write-Host "  Connect with other rescuers on Slack:"
-Write-Host "  👉 https://join.slack.com/t/buddy-mcp/shared_invite/zt-3xn6v1qza-R~fgkVCov9sCLZDXh9wErQ" -ForegroundColor Gray
-Write-Host ""
-
 $ONBOARD_SCRIPT = "$INSTALL_DIR\dist\cli\onboard.js"
 if (Test-Path "$ONBOARD_SCRIPT") {
   try {
@@ -600,6 +628,10 @@ if ((-not $CODEX_CONFIGURED) -and (Get-Command codex -ErrorAction SilentlyContin
   Write-Host ""
   Write-Host "  ! Codex CLI prompt injection was skipped because Buddy MCP is not configured there yet." -ForegroundColor Yellow
 }
+Write-Host ""
+Write-Host "  💬 Join the Buddy Community!" -ForegroundColor Blue
+Write-Host "  Connect with other buddy rescuers, share your companion's evolution, and get help on Slack:"
+Write-Host "  👉 https://join.slack.com/t/buddy-mcp/shared_invite/zt-3xn6v1qza-R~fgkVCov9sCLZDXh9wErQ" -ForegroundColor Gray
 Write-Host ""
 Write-Host "  💛 If you like it, star the repo:"
 Write-Host "  github.com/fiorastudio/buddy"

--- a/install.sh
+++ b/install.sh
@@ -122,10 +122,18 @@ echo "  Installing dependencies..."
 npm install --quiet 2>/dev/null
 
 # Verify native module ABI matches current node. A stale binary from a prior
-# install with a different node version will crash at runtime. Rebuild if needed.
+# install with a different node version will crash at runtime. Rebuild if
+# needed, then re-verify — a silent half-broken install is worse than failing.
 if ! "$NODE_BIN" -e "require('better-sqlite3')" 2>/dev/null; then
-  echo "  Rebuilding native module for $(\"$NODE_BIN\" -v)..."
-  npm rebuild better-sqlite3 --quiet 2>/dev/null
+  echo "  Rebuilding native module for $("$NODE_BIN" -v)..."
+  npm rebuild better-sqlite3
+  if ! "$NODE_BIN" -e "require('better-sqlite3')" 2>/dev/null; then
+    echo ""
+    echo -e "${YELLOW}  ✗ better-sqlite3 does not load under node $("$NODE_BIN" -v) ($NODE_BIN) and the rebuild failed.${NC}"
+    echo -e "${YELLOW}    If you use nvm, switch to the node version Buddy should run under (nvm use <version>),${NC}"
+    echo -e "${YELLOW}    then re-run this installer. See the rebuild output above for details.${NC}"
+    exit 1
+  fi
 fi
 
 echo "  Building..."
@@ -687,12 +695,6 @@ fi
 
 ONBOARD_SCRIPT="$INSTALL_DIR/dist/cli/onboard.js"
 
-echo ""
-echo -e "${BLUE}  💬 Join the Buddy Community!${NC}"
-echo -e "  Connect with other rescuers on Slack:"
-echo -e "  ${DIM}👉 https://join.slack.com/t/buddy-mcp/shared_invite/zt-3xn6v1qza-R~fgkVCov9sCLZDXh9wErQ${NC}"
-echo ""
-
 if [ -f "$ONBOARD_SCRIPT" ] && [ "$NO_ONBOARD" -eq 0 ]; then
   # Let onboard.ts detect TTY itself — don't force /dev/tty
   # (fails in headless SSH, CI, cron where no controlling terminal exists)
@@ -716,6 +718,10 @@ if [ "$CODEX_CONFIGURED" -ne 1 ] && command -v codex &> /dev/null; then
   echo ""
   echo -e "  ${YELLOW}!${NC} Codex CLI prompt injection was skipped because Buddy MCP is not configured there yet."
 fi
+echo ""
+echo -e "${BLUE}  💬 Join the Buddy Community!${NC}"
+echo -e "  Connect with other buddy rescuers, share your companion's evolution, and get help on Slack:"
+echo -e "  ${DIM}👉 https://join.slack.com/t/buddy-mcp/shared_invite/zt-3xn6v1qza-R~fgkVCov9sCLZDXh9wErQ${NC}"
 echo ""
 echo -e "  💛 If you like it, star the repo:"
 echo "  github.com/fiorastudio/buddy"


### PR DESCRIPTION
## Summary

Fixes the recurring Windows `ERR_DLOPEN_FAILED` (NODE_MODULE_VERSION mismatch) that survived PRs #109/#116/#132-#137. Two root causes, both Windows-specific:

- **nvm-windows junction pinning**: `(Get-Command node).Source` returns `C:\Program Files\nodejs\node.exe` — a junction that `nvm use` repoints. The pinned runtime silently swaps after install (e.g. binary built under Node 22 / ABI 127, runtime becomes Node 24 / ABI 137). Installer now resolves symlinks and parent-dir junctions to the real versioned `node.exe` before pinning.
- **Unreliable ABI check (#137)**: `$LASTEXITCODE` after a stderr-redirected native call under `$ErrorActionPreference=Stop` is untrustworthy in Windows PowerShell 5.1 (NativeCommandError swallowed by catch, stale exit code → rebuild silently skipped; see PowerShell/PowerShell#3996, #19848, #10512). Replaced with a stdout-marker probe (`ABI_OK`/`ABI_FAIL`, never writes stderr, always exits 0), rebuild runs unsuppressed, is re-verified, and the installer hard-fails with actionable guidance instead of printing "Buddy installed!" over a broken install.

Also: `install.sh` gets the same re-probe + hard-fail hardening, and the Slack community invite now shows in the final banner next to the star-the-repo message in both installers.

## Review status

- `bash -n install.sh` passes; probe logic verified against a live install (ABI_OK)
- PS 5.1 mechanism backed by documented PowerShell issues (linked above)
- ⚠ Codex adversarial review pending (local Codex CLI auth expired) — will attach results before merge
- No pwsh on the dev Mac — install.ps1 needs a Windows smoke test

## Test plan
- [ ] Windows + nvm-windows: install under `nvm use 22`, run `nvm use 24`, confirm hooks/server still run (resolved pin survives)
- [ ] Windows: re-run installer with a stale ABI binary in place — either heals via rebuild or fails loudly with the guidance message (never a silent broken install)
- [ ] PS 5.1 (`powershell.exe`) and PS 7 (`pwsh`) via `irm | iex` both complete
- [ ] macOS: `curl -fsSL ... | bash` still clean end-to-end
- [ ] Slack invite + star-repo both appear in the final banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)