### PR TITLE
fix(installer): re-clone stale/non-git dirs and verify the build emitted

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -83,13 +83,25 @@ catch {
   exit 1
 }
 
-# Clone or update
-if (Test-Path "$INSTALL_DIR") {
+# Clone or update. A prior install may have left a NON-git directory here
+# (e.g. an npm-package install): 'git pull' fails there and we would silently
+# build stale code. Detect that (and a failed pull) and re-clone. Safe to wipe:
+# the companion DB (~/.buddy/buddy.db) and world.json live in the PARENT dir,
+# not inside ~/.buddy/server.
+$needClone = $true
+if (Test-Path "$INSTALL_DIR\.git") {
   Write-Host "  Updating existing installation..."
   Push-Location "$INSTALL_DIR"
-  git pull origin master --quiet
+  try { git pull origin master --quiet; $pullOk = ($LASTEXITCODE -eq 0) }
+  catch { $pullOk = $false }
   Pop-Location
-} else {
+  if ($pullOk) { $needClone = $false }
+  else { Write-Host "  Update failed; re-cloning fresh..." -ForegroundColor Yellow }
+} elseif (Test-Path "$INSTALL_DIR") {
+  Write-Host "  Replacing a non-git install with a fresh clone..." -ForegroundColor Yellow
+}
+if ($needClone) {
+  if (Test-Path "$INSTALL_DIR") { Remove-Item -Recurse -Force "$INSTALL_DIR" }
   Write-Host "  Cloning Buddy MCP Server..."
   git clone --depth 1 $REPO "$INSTALL_DIR" --quiet
 }
@@ -122,7 +134,17 @@ if ("$abiProbe" -notmatch 'ABI_OK') {
 }
 
 Write-Host "  Building..."
-npm run build --quiet 2>$null
+npm run build --quiet
+# tsc can exit 0 without emitting (e.g. run where it finds no tsconfig), so
+# verify the build artifact exists rather than trusting the exit code — same
+# "verify, don't trust silent success" lesson as the ABI probe above.
+if (-not (Test-Path "$INSTALL_DIR\dist\server\index.js")) {
+  Write-Host ""
+  Write-Host "  X Build produced no output (tsc emitted nothing)." -ForegroundColor Red
+  Write-Host "    Run 'npm run build' in $INSTALL_DIR to see the compiler error." -ForegroundColor Yellow
+  Pop-Location
+  exit 1
+}
 
 # ── Add CLI binaries to PATH ──
 $BIN_DIR = "$INSTALL_DIR\dist\cli"

--- a/install.sh
+++ b/install.sh
@@ -106,12 +106,24 @@ if ! command -v git &> /dev/null; then
   exit 1
 fi
 
-# Clone or update
-if [ -d "$INSTALL_DIR" ]; then
+# Clone or update. A prior install may have left a NON-git directory here
+# (e.g. an npm-package install): 'git pull' fails there and we would silently
+# build stale code. Detect that (and a failed pull) and re-clone. Safe to wipe:
+# the companion DB (~/.buddy/buddy.db) and world.json live in the PARENT dir,
+# not inside ~/.buddy/server.
+need_clone=1
+if [ -d "$INSTALL_DIR/.git" ]; then
   echo "  Updating existing installation..."
-  cd "$INSTALL_DIR"
-  git pull origin master --quiet
-else
+  if git -C "$INSTALL_DIR" pull origin master --quiet; then
+    need_clone=0
+  else
+    echo "  Update failed; re-cloning fresh..."
+  fi
+elif [ -d "$INSTALL_DIR" ]; then
+  echo "  Replacing a non-git install with a fresh clone..."
+fi
+if [ "$need_clone" -eq 1 ]; then
+  rm -rf "$INSTALL_DIR"
   echo "  Cloning Buddy MCP Server..."
   git clone --depth 1 "$REPO" "$INSTALL_DIR" --quiet
 fi
@@ -137,7 +149,16 @@ if ! "$NODE_BIN" -e "require('better-sqlite3')" 2>/dev/null; then
 fi
 
 echo "  Building..."
-npm run build --quiet 2>/dev/null
+npm run build --quiet
+# tsc can exit 0 without emitting (e.g. run where it finds no tsconfig), so
+# verify the build artifact exists rather than trusting the exit code — same
+# "verify, don't trust silent success" lesson as the ABI probe above.
+if [ ! -f "$INSTALL_DIR/dist/server/index.js" ]; then
+  echo ""
+  echo -e "${YELLOW}  ✗ Build produced no output (tsc emitted nothing).${NC}"
+  echo -e "${YELLOW}    Run 'npm run build' in $INSTALL_DIR to see the compiler error.${NC}"
+  exit 1
+fi
 
 # ── Symlink CLI binaries onto PATH ──
 for bin_entry in buddy:buddy.js buddy-doctor:doctor-cli.js buddy-world:world-cli.js; do


### PR DESCRIPTION
Fixes two installer failure modes surfaced by a real Windows install log.

## A — stale / non-git install dir → re-clone
The updater only checked that `~/.buddy/server` *existed*, not that it was a git
checkout. A prior **npm-package install** (no `.git`) made `git pull` fail while
the script silently continued on **stale source** (log showed `fatal: not a git
repository` and version stuck at 1.0.5). Now it checks for `.git` and the pull's
exit code, and re-clones on a non-git dir or a failed pull. Safe to wipe
`~/.buddy/server` — the companion DB (`~/.buddy/buddy.db`) and `world.json` live
in the **parent** dir.

## B — build no-op read as success
`npm run build --quiet 2>$null` swallowed stderr and trusted tsc's exit code;
tsc **exits 0 while printing help** when it finds no tsconfig (as in an
npm-package layout), so a no-op build looked like success. Now it stops
swallowing stderr and asserts `dist/server/index.js` exists, failing loudly
otherwise. Same "verify the artifact, don't trust silent success" principle as
the existing ABI probe.

Applied identically to **install.ps1** and **install.sh**.

## Validation
- Functionally tested the re-clone decision with a stubbed `git` across all 4
  cases (git-ok→update, pull-fails→re-clone, non-git→re-clone, absent→clone).
- Confirmed a real build emits the `dist/server/index.js` sentinel.
- **Verified on real Windows / PowerShell 5.1** (commit 0daaba8): the fixed
  installer printed `Replacing a non-git install with a fresh clone...`,
  re-cloned to 1.0.6, built cleanly (no tsc help dump), ABI probe passed, and
  the install completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)