### PR TITLE
hotfix(installer): Windows node-pin/ABI fix + stale-dir re-clone + build verify

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -26,22 +26,38 @@ $NODE_BIN = (Get-Command node).Source
 # exposes node at C:\Program Files\nodejs (a junction it repoints on every
 # `nvm use`), so pinning that path silently swaps the runtime later and
 # crashes better-sqlite3 with an ABI mismatch. Pin the resolved target instead.
+# Only follow reparse points that actually redirect (SymbolicLink/Junction).
+# HardLink Targets are alternate names for the same file and must not be
+# followed — Target[0] could pin an arbitrary alias. Loop to unwind chained
+# links (nvm shim -> junction -> version dir), bounded to avoid cycles.
+$REDIRECT_LINK_TYPES = @('SymbolicLink', 'Junction')
 try {
-  $nodeItem = Get-Item $NODE_BIN -ErrorAction Stop
-  if ($nodeItem.LinkType -and $nodeItem.Target) {
-    $resolvedFile = @($nodeItem.Target)[0]
-    if (Test-Path $resolvedFile) { $NODE_BIN = $resolvedFile }
-  }
-  $nodeDirItem = Get-Item (Split-Path $NODE_BIN) -ErrorAction Stop
-  if ($nodeDirItem.LinkType -and $nodeDirItem.Target) {
-    $resolvedDir = @($nodeDirItem.Target)[0]
-    $resolvedNode = Join-Path $resolvedDir (Split-Path $NODE_BIN -Leaf)
-    if (Test-Path $resolvedNode) {
-      Write-Host "  Pinning node to resolved path: $resolvedNode" -ForegroundColor DarkGray
-      $NODE_BIN = $resolvedNode
+  $resolvedAny = $false
+  for ($hop = 0; $hop -lt 4; $hop++) {
+    $changed = $false
+
+    $nodeItem = Get-Item $NODE_BIN -ErrorAction Stop
+    if ($REDIRECT_LINK_TYPES -contains $nodeItem.LinkType -and $nodeItem.Target) {
+      $resolvedFile = @($nodeItem.Target)[0]
+      if (Test-Path $resolvedFile) { $NODE_BIN = $resolvedFile; $changed = $true }
     }
+
+    $nodeDirItem = Get-Item (Split-Path $NODE_BIN) -ErrorAction Stop
+    if ($REDIRECT_LINK_TYPES -contains $nodeDirItem.LinkType -and $nodeDirItem.Target) {
+      $resolvedDir = @($nodeDirItem.Target)[0]
+      $resolvedNode = Join-Path $resolvedDir (Split-Path $NODE_BIN -Leaf)
+      if (Test-Path $resolvedNode) { $NODE_BIN = $resolvedNode; $changed = $true }
+    }
+
+    if ($changed) { $resolvedAny = $true } else { break }
   }
-} catch {}
+  if ($resolvedAny) {
+    Write-Host "  Pinning node to resolved path: $NODE_BIN" -ForegroundColor DarkGray
+  }
+} catch {
+  Write-Host "  ! Could not resolve node's link target; pinning $NODE_BIN as-is." -ForegroundColor Yellow
+  Write-Host "    If you use nvm-windows, re-run this installer after 'nvm use' changes." -ForegroundColor Yellow
+}
 
 $nodeVersion = (& $NODE_BIN -v) -replace 'v(\d+)\..*', '$1'
 if ([int]$nodeVersion -lt 20) {

--- a/install.ps1
+++ b/install.ps1
@@ -83,13 +83,25 @@ catch {
   exit 1
 }
 
-# Clone or update
-if (Test-Path "$INSTALL_DIR") {
+# Clone or update. A prior install may have left a NON-git directory here
+# (e.g. an npm-package install): 'git pull' fails there and we would silently
+# build stale code. Detect that (and a failed pull) and re-clone. Safe to wipe:
+# the companion DB (~/.buddy/buddy.db) and world.json live in the PARENT dir,
+# not inside ~/.buddy/server.
+$needClone = $true
+if (Test-Path "$INSTALL_DIR\.git") {
   Write-Host "  Updating existing installation..."
   Push-Location "$INSTALL_DIR"
-  git pull origin master --quiet
+  try { git pull origin master --quiet; $pullOk = ($LASTEXITCODE -eq 0) }
+  catch { $pullOk = $false }
   Pop-Location
-} else {
+  if ($pullOk) { $needClone = $false }
+  else { Write-Host "  Update failed; re-cloning fresh..." -ForegroundColor Yellow }
+} elseif (Test-Path "$INSTALL_DIR") {
+  Write-Host "  Replacing a non-git install with a fresh clone..." -ForegroundColor Yellow
+}
+if ($needClone) {
+  if (Test-Path "$INSTALL_DIR") { Remove-Item -Recurse -Force "$INSTALL_DIR" }
   Write-Host "  Cloning Buddy MCP Server..."
   git clone --depth 1 $REPO "$INSTALL_DIR" --quiet
 }
@@ -122,7 +134,17 @@ if ("$abiProbe" -notmatch 'ABI_OK') {
 }
 
 Write-Host "  Building..."
-npm run build --quiet 2>$null
+npm run build --quiet
+# tsc can exit 0 without emitting (e.g. run where it finds no tsconfig), so
+# verify the build artifact exists rather than trusting the exit code — same
+# "verify, don't trust silent success" lesson as the ABI probe above.
+if (-not (Test-Path "$INSTALL_DIR\dist\server\index.js")) {
+  Write-Host ""
+  Write-Host "  X Build produced no output (tsc emitted nothing)." -ForegroundColor Red
+  Write-Host "    Run 'npm run build' in $INSTALL_DIR to see the compiler error." -ForegroundColor Yellow
+  Pop-Location
+  exit 1
+}
 
 # ── Add CLI binaries to PATH ──
 $BIN_DIR = "$INSTALL_DIR\dist\cli"

--- a/install.ps1
+++ b/install.ps1
@@ -30,7 +30,8 @@ $NODE_BIN = (Get-Command node).Source
 # HardLink Targets are alternate names for the same file and must not be
 # followed — Target[0] could pin an arbitrary alias. Loop to unwind chained
 # links (nvm shim -> junction -> version dir), bounded to avoid cycles.
-$REDIRECT_LINK_TYPES = @('SymbolicLink', 'Junction')
+# 'SymLink' included defensively: LinkType string varies across PS builds.
+$REDIRECT_LINK_TYPES = @('SymbolicLink', 'SymLink', 'Junction')
 try {
   $resolvedAny = $false
   for ($hop = 0; $hop -lt 4; $hop++) {
@@ -53,6 +54,12 @@ try {
   }
   if ($resolvedAny) {
     Write-Host "  Pinning node to resolved path: $NODE_BIN" -ForegroundColor DarkGray
+    # Verify the hop limit actually finished the job.
+    $finalItem = Get-Item $NODE_BIN -ErrorAction Stop
+    if ($REDIRECT_LINK_TYPES -contains $finalItem.LinkType) {
+      Write-Host "  ! node path is still a link after 4 hops; pinning it as-is." -ForegroundColor Yellow
+      Write-Host "    Re-run this installer if node version switches cause crashes." -ForegroundColor Yellow
+    }
   }
 } catch {
   Write-Host "  ! Could not resolve node's link target; pinning $NODE_BIN as-is." -ForegroundColor Yellow

--- a/install.ps1
+++ b/install.ps1
@@ -54,9 +54,11 @@ try {
   }
   if ($resolvedAny) {
     Write-Host "  Pinning node to resolved path: $NODE_BIN" -ForegroundColor DarkGray
-    # Verify the hop limit actually finished the job.
+    # Verify the hop limit actually finished the job — check both the
+    # file and its parent directory (a remaining dir junction is also unresolved).
     $finalItem = Get-Item $NODE_BIN -ErrorAction Stop
-    if ($REDIRECT_LINK_TYPES -contains $finalItem.LinkType) {
+    $finalDirItem = Get-Item (Split-Path $NODE_BIN) -ErrorAction Stop
+    if (($REDIRECT_LINK_TYPES -contains $finalItem.LinkType) -or ($REDIRECT_LINK_TYPES -contains $finalDirItem.LinkType)) {
       Write-Host "  ! node path is still a link after 4 hops; pinning it as-is." -ForegroundColor Yellow
       Write-Host "    Re-run this installer if node version switches cause crashes." -ForegroundColor Yellow
     }

--- a/install.ps1
+++ b/install.ps1
@@ -21,6 +21,28 @@ catch {
 }
 
 $NODE_BIN = (Get-Command node).Source
+
+# Resolve symlinks/junctions to the real versioned node binary. nvm-windows
+# exposes node at C:\Program Files\nodejs (a junction it repoints on every
+# `nvm use`), so pinning that path silently swaps the runtime later and
+# crashes better-sqlite3 with an ABI mismatch. Pin the resolved target instead.
+try {
+  $nodeItem = Get-Item $NODE_BIN -ErrorAction Stop
+  if ($nodeItem.LinkType -and $nodeItem.Target) {
+    $resolvedFile = @($nodeItem.Target)[0]
+    if (Test-Path $resolvedFile) { $NODE_BIN = $resolvedFile }
+  }
+  $nodeDirItem = Get-Item (Split-Path $NODE_BIN) -ErrorAction Stop
+  if ($nodeDirItem.LinkType -and $nodeDirItem.Target) {
+    $resolvedDir = @($nodeDirItem.Target)[0]
+    $resolvedNode = Join-Path $resolvedDir (Split-Path $NODE_BIN -Leaf)
+    if (Test-Path $resolvedNode) {
+      Write-Host "  Pinning node to resolved path: $resolvedNode" -ForegroundColor DarkGray
+      $NODE_BIN = $resolvedNode
+    }
+  }
+} catch {}
+
 $nodeVersion = (& $NODE_BIN -v) -replace 'v(\d+)\..*', '$1'
 if ([int]$nodeVersion -lt 20) {
   Write-Host "  Node.js 20+ required (better-sqlite3 dropped Node 18/19 support). You have $(& $NODE_BIN -v)." -ForegroundColor Yellow
@@ -52,14 +74,26 @@ Push-Location "$INSTALL_DIR"
 Write-Host "  Installing dependencies..."
 npm install --quiet 2>$null
 
-# Verify native module ABI matches current node. Stale binary from a prior
-# install with a different node version will crash at runtime. Rebuild if needed.
-try {
-  & $NODE_BIN -e "require('better-sqlite3')" 2>$null
-} catch {}
-if ($LASTEXITCODE -ne 0) {
-  Write-Host "  Rebuilding native module for $(& $NODE_BIN -v)..."
-  npm rebuild better-sqlite3 --quiet 2>$null
+# Verify native module ABI matches current node. A stale binary from a prior
+# install with a different node version will crash at runtime.
+# Probe via a stdout marker instead of $LASTEXITCODE: with EAP=Stop, PS 5.1
+# throws NativeCommandError on redirected native stderr and can leave
+# $LASTEXITCODE stale, which made the old check silently skip the rebuild.
+# The JS-side catch keeps stderr clean and the exit code 0 in both outcomes.
+$abiProbeJs = "try{require('better-sqlite3');console.log('ABI_OK')}catch(e){console.log('ABI_FAIL')}"
+$abiProbe = & $NODE_BIN -e $abiProbeJs
+if ("$abiProbe" -notmatch 'ABI_OK') {
+  Write-Host "  Rebuilding native module for node $(& $NODE_BIN -v)..."
+  npm rebuild better-sqlite3
+  $abiProbe = & $NODE_BIN -e $abiProbeJs
+  if ("$abiProbe" -notmatch 'ABI_OK') {
+    Write-Host ""
+    Write-Host "  X better-sqlite3 does not load under node $(& $NODE_BIN -v) ($NODE_BIN) and the rebuild failed." -ForegroundColor Red
+    Write-Host "    If you use nvm, switch to the node version Buddy should run under (nvm use <version>)," -ForegroundColor Yellow
+    Write-Host "    then re-run this installer. See the rebuild output above for details." -ForegroundColor Yellow
+    Pop-Location
+    exit 1
+  }
 }
 
 Write-Host "  Building..."
@@ -608,12 +642,6 @@ if ($COPILOT_CONFIGURED) {
 
 # ── Run onboarding wizard ──
 
-Write-Host ""
-Write-Host "  💬 Join the Buddy Community!" -ForegroundColor Blue
-Write-Host "  Connect with other rescuers on Slack:"
-Write-Host "  👉 https://join.slack.com/t/buddy-mcp/shared_invite/zt-3xn6v1qza-R~fgkVCov9sCLZDXh9wErQ" -ForegroundColor Gray
-Write-Host ""
-
 $ONBOARD_SCRIPT = "$INSTALL_DIR\dist\cli\onboard.js"
 if (Test-Path "$ONBOARD_SCRIPT") {
   try {
@@ -638,6 +666,10 @@ if ((-not $CODEX_CONFIGURED) -and (Get-Command codex -ErrorAction SilentlyContin
   Write-Host ""
   Write-Host "  ! Codex CLI prompt injection was skipped because Buddy MCP is not configured there yet." -ForegroundColor Yellow
 }
+Write-Host ""
+Write-Host "  💬 Join the Buddy Community!" -ForegroundColor Blue
+Write-Host "  Connect with other buddy rescuers, share your companion's evolution, and get help on Slack:"
+Write-Host "  👉 https://join.slack.com/t/buddy-mcp/shared_invite/zt-3xn6v1qza-R~fgkVCov9sCLZDXh9wErQ" -ForegroundColor Gray
 Write-Host ""
 Write-Host "  💛 If you like it, star the repo:"
 Write-Host "  github.com/fiorastudio/buddy"

--- a/install.sh
+++ b/install.sh
@@ -122,10 +122,18 @@ echo "  Installing dependencies..."
 npm install --quiet 2>/dev/null
 
 # Verify native module ABI matches current node. A stale binary from a prior
-# install with a different node version will crash at runtime. Rebuild if needed.
+# install with a different node version will crash at runtime. Rebuild if
+# needed, then re-verify — a silent half-broken install is worse than failing.
 if ! "$NODE_BIN" -e "require('better-sqlite3')" 2>/dev/null; then
-  echo "  Rebuilding native module for $(\"$NODE_BIN\" -v)..."
-  npm rebuild better-sqlite3 --quiet 2>/dev/null
+  echo "  Rebuilding native module for $("$NODE_BIN" -v)..."
+  npm rebuild better-sqlite3
+  if ! "$NODE_BIN" -e "require('better-sqlite3')" 2>/dev/null; then
+    echo ""
+    echo -e "${YELLOW}  ✗ better-sqlite3 does not load under node $("$NODE_BIN" -v) ($NODE_BIN) and the rebuild failed.${NC}"
+    echo -e "${YELLOW}    If you use nvm, switch to the node version Buddy should run under (nvm use <version>),${NC}"
+    echo -e "${YELLOW}    then re-run this installer. See the rebuild output above for details.${NC}"
+    exit 1
+  fi
 fi
 
 echo "  Building..."
@@ -724,12 +732,6 @@ fi
 
 ONBOARD_SCRIPT="$INSTALL_DIR/dist/cli/onboard.js"
 
-echo ""
-echo -e "${BLUE}  💬 Join the Buddy Community!${NC}"
-echo -e "  Connect with other rescuers on Slack:"
-echo -e "  ${DIM}👉 https://join.slack.com/t/buddy-mcp/shared_invite/zt-3xn6v1qza-R~fgkVCov9sCLZDXh9wErQ${NC}"
-echo ""
-
 if [ -f "$ONBOARD_SCRIPT" ] && [ "$NO_ONBOARD" -eq 0 ]; then
   # Let onboard.ts detect TTY itself — don't force /dev/tty
   # (fails in headless SSH, CI, cron where no controlling terminal exists)
@@ -753,6 +755,10 @@ if [ "$CODEX_CONFIGURED" -ne 1 ] && command -v codex &> /dev/null; then
   echo ""
   echo -e "  ${YELLOW}!${NC} Codex CLI prompt injection was skipped because Buddy MCP is not configured there yet."
 fi
+echo ""
+echo -e "${BLUE}  💬 Join the Buddy Community!${NC}"
+echo -e "  Connect with other buddy rescuers, share your companion's evolution, and get help on Slack:"
+echo -e "  ${DIM}👉 https://join.slack.com/t/buddy-mcp/shared_invite/zt-3xn6v1qza-R~fgkVCov9sCLZDXh9wErQ${NC}"
 echo ""
 echo -e "  💛 If you like it, star the repo:"
 echo "  github.com/fiorastudio/buddy"

--- a/install.sh
+++ b/install.sh
@@ -106,12 +106,24 @@ if ! command -v git &> /dev/null; then
   exit 1
 fi
 
-# Clone or update
-if [ -d "$INSTALL_DIR" ]; then
+# Clone or update. A prior install may have left a NON-git directory here
+# (e.g. an npm-package install): 'git pull' fails there and we would silently
+# build stale code. Detect that (and a failed pull) and re-clone. Safe to wipe:
+# the companion DB (~/.buddy/buddy.db) and world.json live in the PARENT dir,
+# not inside ~/.buddy/server.
+need_clone=1
+if [ -d "$INSTALL_DIR/.git" ]; then
   echo "  Updating existing installation..."
-  cd "$INSTALL_DIR"
-  git pull origin master --quiet
-else
+  if git -C "$INSTALL_DIR" pull origin master --quiet; then
+    need_clone=0
+  else
+    echo "  Update failed; re-cloning fresh..."
+  fi
+elif [ -d "$INSTALL_DIR" ]; then
+  echo "  Replacing a non-git install with a fresh clone..."
+fi
+if [ "$need_clone" -eq 1 ]; then
+  rm -rf "$INSTALL_DIR"
   echo "  Cloning Buddy MCP Server..."
   git clone --depth 1 "$REPO" "$INSTALL_DIR" --quiet
 fi
@@ -137,7 +149,16 @@ if ! "$NODE_BIN" -e "require('better-sqlite3')" 2>/dev/null; then
 fi
 
 echo "  Building..."
-npm run build --quiet 2>/dev/null
+npm run build --quiet
+# tsc can exit 0 without emitting (e.g. run where it finds no tsconfig), so
+# verify the build artifact exists rather than trusting the exit code — same
+# "verify, don't trust silent success" lesson as the ABI probe above.
+if [ ! -f "$INSTALL_DIR/dist/server/index.js" ]; then
+  echo ""
+  echo -e "${YELLOW}  ✗ Build produced no output (tsc emitted nothing).${NC}"
+  echo -e "${YELLOW}    Run 'npm run build' in $INSTALL_DIR to see the compiler error.${NC}"
+  exit 1
+fi
 
 # ── Symlink CLI binaries onto PATH ──
 for bin_entry in buddy:buddy.js buddy-doctor:doctor-cli.js; do


### PR DESCRIPTION
Backports the complete installer fix to **master** (the release channel that
new installs pull), decoupled from the 2.0.0 feature work. All 5 commits touch
**only** `install.ps1` / `install.sh` — no 2.0.0 source coupling.

## What's included
- **#142 — node-pin + ABI probe/rebuild** (the original `ERR_DLOPEN_FAILED` /
  `NODE_MODULE_VERSION` crash): resolves the real versioned node binary through
  nvm-windows junctions and rebuilds `better-sqlite3` if the ABI mismatches.
- **Re-clone stale/non-git dir**: the updater only checked that the dir existed,
  not that it was a git checkout — a prior npm-package install made `git pull`
  fail and the script silently built stale source. Now re-clones on a non-git
  dir or a failed pull. (Safe: the companion DB `~/.buddy/buddy.db` and
  `world.json` live in the parent dir.)
- **Verify the build emitted**: `tsc` exits 0 while printing help when it finds
  no tsconfig, so a no-op build read as success. Now asserts
  `dist/server/index.js` exists and stops swallowing stderr.

## Validation
Verified on real Windows / PowerShell 5.1: the fixed installer detected a stale
non-git `~/.buddy/server`, re-cloned to a fresh checkout, built cleanly (no tsc
help dump), the ABI probe passed, and `better-sqlite3` loaded — install
completed. (#142's node-pin/ABI code ran as part of that same successful run.)

Supersedes the open PR #142 (its commits are included here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)