### PR TITLE
hotfix(installer): ABI probe must instantiate a DB (fixes lingering ERR_DLOPEN on node-version change)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -117,7 +117,11 @@ npm install --quiet 2>$null
 # throws NativeCommandError on redirected native stderr and can leave
 # $LASTEXITCODE stale, which made the old check silently skip the rebuild.
 # The JS-side catch keeps stderr clean and the exit code 0 in both outcomes.
-$abiProbeJs = "try{require('better-sqlite3');console.log('ABI_OK')}catch(e){console.log('ABI_FAIL')}"
+# CRITICAL: `require('better-sqlite3')` only loads the JS wrapper — the native
+# .node binary (where the ABI version lives) loads LAZILY inside `new Database`.
+# So we must instantiate a DB to force the addon load, else a mismatched binary
+# passes the probe and crashes later at the app's first `new Database()`.
+$abiProbeJs = "try{const D=require('better-sqlite3');new D(':memory:').close();console.log('ABI_OK')}catch(e){console.log('ABI_FAIL')}"
 $abiProbe = & $NODE_BIN -e $abiProbeJs
 if ("$abiProbe" -notmatch 'ABI_OK') {
   Write-Host "  Rebuilding native module for node $(& $NODE_BIN -v)..."

--- a/install.sh
+++ b/install.sh
@@ -136,10 +136,13 @@ npm install --quiet 2>/dev/null
 # Verify native module ABI matches current node. A stale binary from a prior
 # install with a different node version will crash at runtime. Rebuild if
 # needed, then re-verify — a silent half-broken install is worse than failing.
-if ! "$NODE_BIN" -e "require('better-sqlite3')" 2>/dev/null; then
+# CRITICAL: `require('better-sqlite3')` only loads the JS wrapper; the native
+# .node binary (where the ABI lives) loads LAZILY inside `new Database`. Must
+# instantiate a DB to force the addon load, else a mismatched binary passes.
+if ! "$NODE_BIN" -e "const D=require('better-sqlite3');new D(':memory:').close()" 2>/dev/null; then
   echo "  Rebuilding native module for $("$NODE_BIN" -v)..."
   npm rebuild better-sqlite3
-  if ! "$NODE_BIN" -e "require('better-sqlite3')" 2>/dev/null; then
+  if ! "$NODE_BIN" -e "const D=require('better-sqlite3');new D(':memory:').close()" 2>/dev/null; then
     echo ""
     echo -e "${YELLOW}  ✗ better-sqlite3 does not load under node $("$NODE_BIN" -v) ($NODE_BIN) and the rebuild failed.${NC}"
     echo -e "${YELLOW}    If you use nvm, switch to the node version Buddy should run under (nvm use <version>),${NC}"


### PR DESCRIPTION
The node-pin/ABI fix still let the original `ERR_DLOPEN_FAILED` crash through
on an **update where node changed version** (e.g. nvm 22 → 24). Root cause:
the ABI probe used `require('better-sqlite3')`, which only loads the JS wrapper.
better-sqlite3 loads its native `.node` binary **lazily inside `new Database()`**
(lib/database.js:48), so a stale ABI-mismatched binary **passed the probe** and
the rebuild never ran — then the app crashed at its first real `new Database()`
(during the onboarding step).

**Fix:** probe now does `new (require('better-sqlite3'))(':memory:').close()` to
force the addon load, so a mismatch is detected and `npm rebuild better-sqlite3`
actually runs. Applied to `install.ps1` and `install.sh` (one line each).

**Validated on real Windows** by the coworker whose machine reproduced the crash
(nvm node 24 + stale 127 binary): the fixed installer now prints
"Rebuilding native module…", rebuilds, and completes with no ERR_DLOPEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)