### PR TITLE
fix(installer): ABI probe must instantiate a DB (backport of #148 to 2.0.0)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -117,7 +117,11 @@ npm install --quiet 2>$null
 # throws NativeCommandError on redirected native stderr and can leave
 # $LASTEXITCODE stale, which made the old check silently skip the rebuild.
 # The JS-side catch keeps stderr clean and the exit code 0 in both outcomes.
-$abiProbeJs = "try{require('better-sqlite3');console.log('ABI_OK')}catch(e){console.log('ABI_FAIL')}"
+# CRITICAL: `require('better-sqlite3')` only loads the JS wrapper — the native
+# .node binary (where the ABI version lives) loads LAZILY inside `new Database`.
+# So we must instantiate a DB to force the addon load, else a mismatched binary
+# passes the probe and crashes later at the app's first `new Database()`.
+$abiProbeJs = "try{const D=require('better-sqlite3');new D(':memory:').close();console.log('ABI_OK')}catch(e){console.log('ABI_FAIL')}"
 $abiProbe = & $NODE_BIN -e $abiProbeJs
 if ("$abiProbe" -notmatch 'ABI_OK') {
   Write-Host "  Rebuilding native module for node $(& $NODE_BIN -v)..."

--- a/install.sh
+++ b/install.sh
@@ -136,10 +136,13 @@ npm install --quiet 2>/dev/null
 # Verify native module ABI matches current node. A stale binary from a prior
 # install with a different node version will crash at runtime. Rebuild if
 # needed, then re-verify — a silent half-broken install is worse than failing.
-if ! "$NODE_BIN" -e "require('better-sqlite3')" 2>/dev/null; then
+# CRITICAL: `require('better-sqlite3')` only loads the JS wrapper; the native
+# .node binary (where the ABI lives) loads LAZILY inside `new Database`. Must
+# instantiate a DB to force the addon load, else a mismatched binary passes.
+if ! "$NODE_BIN" -e "const D=require('better-sqlite3');new D(':memory:').close()" 2>/dev/null; then
   echo "  Rebuilding native module for $("$NODE_BIN" -v)..."
   npm rebuild better-sqlite3
-  if ! "$NODE_BIN" -e "require('better-sqlite3')" 2>/dev/null; then
+  if ! "$NODE_BIN" -e "const D=require('better-sqlite3');new D(':memory:').close()" 2>/dev/null; then
     echo ""
     echo -e "${YELLOW}  ✗ better-sqlite3 does not load under node $("$NODE_BIN" -v) ($NODE_BIN) and the rebuild failed.${NC}"
     echo -e "${YELLOW}    If you use nvm, switch to the node version Buddy should run under (nvm use <version>),${NC}"


### PR DESCRIPTION
Backports the ABI-probe fix (#148, validated on real Windows) to the 2.0.0 line so the release carries it. The probe now instantiates a :memory: DB to force better-sqlite3's lazy native load, catching ABI mismatches the old `require()`-only probe missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)