### PR TITLE
Fix doctor check count and stop failing manual installs

### DIFF
--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -6,7 +6,7 @@ describe('Doctor — runDiagnostics', () => {
   it('returns an array of checks', () => {
     const checks = runDiagnostics();
     expect(Array.isArray(checks)).toBe(true);
-    expect(checks.length).toBe(23);
+    expect(checks.length).toBe(24);
   });
 
   it('every check has required fields', () => {
@@ -98,7 +98,7 @@ describe('Doctor — formatReport', () => {
   it('includes check count in header', () => {
     const checks = runDiagnostics();
     const report = formatReport(checks);
-    expect(report).toContain('23 checks:');
+    expect(report).toContain('24 checks:');
   });
 
   it('includes ISO timestamp', () => {

--- a/src/lib/doctor.ts
+++ b/src/lib/doctor.ts
@@ -228,6 +228,20 @@ function checkInstallLayout(): DiagnosticCheck {
     };
   }
 
+  // Manual/from-clone installs register the MCP entry outside
+  // ~/.buddy/server. If any registered buddy entry path exists on disk,
+  // the install is healthy \u2014 report where it actually lives instead of
+  // failing on the canonical location.
+  const registered = getRegisteredBuddyMcpEntryPaths().find(r => fileExists(r.resolved));
+  if (registered) {
+    return {
+      id: 'install.server',
+      status: 'ok',
+      label: 'Server install',
+      detail: `\u2713 ${registered.resolved} (registered in ${registered.source})`,
+    };
+  }
+
   // Only fail hard when the *default* data file on disk exists (user has state but no
   // install). Custom BUDDY_DB_PATH in tests/CI should not trip this.
   const homeDefaultDb = join(homedir(), '.buddy', 'buddy.db');


### PR DESCRIPTION
Two small doctor fixes:

- `runDiagnostics` returns 24 checks but the test still expects 23 (looks like the edge-quality check added in #123 didn't bump it), so `doctor.test.ts` fails on a fresh clone.
- `checkInstallLayout` only accepts `~/.buddy/server`, so anyone who installed manually from a clone (the README's manual-install path) gets a permanent failed check even though their registered MCP entry works fine. It now accepts any registered buddy entry path that exists on disk and reports where the server actually lives.
