### PR TITLE
Use the species finding voice in the template fallback

### DIFF
--- a/src/lib/observer.ts
+++ b/src/lib/observer.ts
@@ -3,7 +3,7 @@
 import { type Companion, type StatName, STAT_NAMES, getPeakStat, getDumpStat } from './types.js';
 import { claimSnippet } from './reasoning/index.js';
 import type { Finding } from './reasoning/index.js';
-import { phraseFinding } from './reasoning/phrasings.js';
+import { phraseFindingForCompanion } from './reasoning/phrasings.js';
 import { scrubReactionText } from './reasoning/scrub.js';
 
 // --- Reaction States ---
@@ -174,10 +174,10 @@ What happened: ${summary}`;
   // second line of defense beyond the phrasings-tone review-time test.
   let templateFallback = templateReaction(companion, mode, summary, reaction.state);
   if (guardInjection?.finding) {
-    const findingPhrase = phraseFinding(
+    const findingPhrase = phraseFindingForCompanion(
       guardInjection.finding.type,
-      reaction.state,
       guardInjection.finding.claim_text,
+      companion,
       summary.length,
     );
     templateFallback = `${templateFallback} ${findingPhrase}`;


### PR DESCRIPTION
While poking at the fallback bubbles I noticed phraseFindingForCompanion from #130 has no callers, so the species finding voices never actually reach users. Template-fallback findings still go through the generic phrasing table.

This wires it in. A Robot's fallback now reads like "Diagnostic: ... advanced without sufficient verification", geese honk, and the peak-stat lead comes through. Tests on the touched paths pass (observer, observer-integration, scrub-wiring, both phrasings suites).

If there's interest I also have a small species tic layer for the non-finding template lines (the Robot beeps once for approval, twice for concern, that sort of thing). Happy to send it as a follow-up.
