### PR TITLE
Fix mute persistence, XP loss across sessions, and non-deterministic companion lookups

### DIFF
--- a/src/__tests__/created-at-parsing.test.ts
+++ b/src/__tests__/created-at-parsing.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { parseCreatedAt } from '../lib/companion.js';
+
+/**
+ * SQLite's DEFAULT CURRENT_TIMESTAMP writes 'YYYY-MM-DD HH:MM:SS' in UTC with
+ * no zone designator. `new Date(...)` on that string parses it as local time,
+ * so a normally-hatched companion's age was off by the UTC offset — and read
+ * as negative for the first N hours after hatching west of Greenwich.
+ *
+ * Rescued buddies were unaffected because createCompanionFromImport writes an
+ * explicit ISO 8601 'Z' string; both shapes must keep working.
+ */
+describe('parseCreatedAt', () => {
+  it('treats a bare SQLite timestamp as UTC', () => {
+    expect(parseCreatedAt('2026-04-12 21:48:08')).toBe(Date.parse('2026-04-12T21:48:08Z'));
+  });
+
+  it('agrees with the old parse only when the machine is on UTC', () => {
+    const raw = '2026-04-12 21:48:08';
+    const offsetMs = new Date(Date.parse('2026-04-12T21:48:08Z')).getTimezoneOffset() * 60_000;
+    expect(parseCreatedAt(raw) - new Date(raw).getTime()).toBe(-offsetMs);
+  });
+
+  it('round-trips the ISO form written by the rescue importer', () => {
+    const hatchedAt = 1775629556015;
+    const stored = new Date(hatchedAt).toISOString();
+    expect(parseCreatedAt(stored)).toBe(hatchedAt);
+  });
+
+  it('handles an explicit numeric offset', () => {
+    expect(parseCreatedAt('2026-04-12T21:48:08+02:00')).toBe(Date.parse('2026-04-12T21:48:08+02:00'));
+  });
+
+  it('passes through an epoch number unchanged', () => {
+    expect(parseCreatedAt(1775629556015)).toBe(1775629556015);
+  });
+
+  it('never returns NaN for junk, null or undefined', () => {
+    for (const bad of [undefined, null, '', 'not a date', {}, []]) {
+      expect(Number.isFinite(parseCreatedAt(bad as unknown))).toBe(true);
+    }
+  });
+
+  it('never reports a companion as hatched in the future', () => {
+    // A buddy created "now" by SQLite must not read as ahead of the clock.
+    const now = new Date();
+    const pad = (n: number) => String(n).padStart(2, '0');
+    const sqliteNow =
+      `${now.getUTCFullYear()}-${pad(now.getUTCMonth() + 1)}-${pad(now.getUTCDate())} ` +
+      `${pad(now.getUTCHours())}:${pad(now.getUTCMinutes())}:${pad(now.getUTCSeconds())}`;
+    expect(parseCreatedAt(sqliteNow)).toBeLessThanOrEqual(Date.now() + 1000);
+  });
+});

--- a/src/__tests__/mute-persistence.test.ts
+++ b/src/__tests__/mute-persistence.test.ts
@@ -1,0 +1,123 @@
+import { existsSync, rmSync, writeFileSync } from 'fs';
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { db, initDb } from '../db/schema.js';
+import { calculateMood } from '../lib/species.js';
+import { writeBuddyStatus } from '../lib/companion.js';
+import { BUDDY_STATUS_PATH } from '../lib/constants.js';
+
+/**
+ * Regression tests for mute being stored in the `mood` column.
+ *
+ * calculateMood can only return happy/content/neutral/curious/grumpy, so every
+ * mood recompute overwrote 'muted'. Because clients call buddy_status at the
+ * start of every conversation, mute never survived a single session.
+ */
+
+const ID = 'mute-test-companion';
+
+function seed(muted = 0) {
+  db.prepare('DELETE FROM companions').run();
+  db.prepare(
+    `INSERT INTO companions (id, name, species, level, xp, mood, muted, user_id)
+     VALUES (?, 'Testy', 'Owl', 1, 0, 'happy', ?, 'anon')`,
+  ).run(ID, muted);
+}
+
+function muted(): number {
+  const row = db.prepare('SELECT muted FROM companions WHERE id = ?').get(ID) as { muted: number };
+  return row.muted;
+}
+
+beforeEach(() => {
+  initDb();
+  seed();
+  rmSync(BUDDY_STATUS_PATH, { force: true });
+});
+
+afterAll(() => {
+  db.prepare('DELETE FROM companions').run();
+  rmSync(BUDDY_STATUS_PATH, { force: true });
+});
+
+describe('mute is not representable as a mood', () => {
+  it('calculateMood never returns "muted" for any interaction count', () => {
+    for (const n of [0, 1, 4, 6, 11, 500]) {
+      expect(calculateMood(new Array(n), 0)).not.toBe('muted');
+    }
+  });
+});
+
+describe('mute persistence', () => {
+  it('stores mute in its own column, not in mood', () => {
+    db.prepare('UPDATE companions SET muted = 1 WHERE id = ?').run(ID);
+    expect(muted()).toBe(1);
+
+    // A mood recompute — what buddy_status does on every conversation start.
+    const recomputed = calculateMood([], 0);
+    db.prepare('UPDATE companions SET mood = ? WHERE id = ?').run(recomputed, ID);
+
+    expect(muted()).toBe(1);
+  });
+
+  it('migration backfills anyone muted under the old scheme', () => {
+    db.prepare("UPDATE companions SET mood = 'muted', muted = 0 WHERE id = ?").run(ID);
+    db.exec("UPDATE companions SET muted = 1 WHERE mood = 'muted'");
+    expect(muted()).toBe(1);
+  });
+
+  it('a muted companion defaults to muted = 0, not null', () => {
+    const row = db.prepare('SELECT muted FROM companions WHERE id = ?').get(ID) as { muted: number };
+    expect(row.muted).toBe(0);
+  });
+});
+
+describe('writeBuddyStatus respects the mute flag', () => {
+  const companion = {
+    name: 'Testy',
+    species: 'Owl',
+    level: 1,
+    xp: 0,
+    mood: 'happy',
+    rarity: 'common',
+    shiny: false,
+    eye: '.',
+    hat: '',
+    stats: { DEBUGGING: 1, PATIENCE: 1, CHAOS: 1, WISDOM: 1, SNARK: 1 },
+    personalityBio: '',
+    hatchedAt: Date.now(),
+  } as any;
+
+  it('writes the statusline file when not muted', () => {
+    writeBuddyStatus(companion);
+    expect(existsSync(BUDDY_STATUS_PATH)).toBe(true);
+  });
+
+  it('does not write the statusline file while muted', () => {
+    db.prepare('UPDATE companions SET muted = 1 WHERE id = ?').run(ID);
+    writeBuddyStatus(companion);
+    expect(existsSync(BUDDY_STATUS_PATH)).toBe(false);
+  });
+
+  it('does not resurrect a status file deleted by buddy_mute', () => {
+    db.prepare('UPDATE companions SET muted = 1 WHERE id = ?').run(ID);
+    writeFileSync(BUDDY_STATUS_PATH, '{}');
+    rmSync(BUDDY_STATUS_PATH, { force: true });
+
+    // Several observes in a row, as a working session would produce.
+    writeBuddyStatus(companion);
+    writeBuddyStatus(companion, {
+      state: 'excited', text: 'nice', expires: Date.now() + 1000,
+    });
+    expect(existsSync(BUDDY_STATUS_PATH)).toBe(false);
+  });
+
+  it('writes again once unmuted', () => {
+    db.prepare('UPDATE companions SET muted = 1 WHERE id = ?').run(ID);
+    writeBuddyStatus(companion);
+    expect(existsSync(BUDDY_STATUS_PATH)).toBe(false);
+
+    db.prepare('UPDATE companions SET muted = 0 WHERE id = ?').run(ID);
+    writeBuddyStatus(companion);
+    expect(existsSync(BUDDY_STATUS_PATH)).toBe(true);
+  });
+});

--- a/src/__tests__/reasoning/instruction-reinjection.test.ts
+++ b/src/__tests__/reasoning/instruction-reinjection.test.ts
@@ -12,7 +12,9 @@ const SID = 'abc0123456789def-20260604';
 
 function memDb(guard = 1, mood = 'happy'): Database.Database {
   const db = new Database(':memory:');
-  db.exec(`CREATE TABLE companions (id TEXT PRIMARY KEY, name TEXT, guard_mode INTEGER, mood TEXT);`);
+  // Mirrors the real companions table closely enough for companion lookups,
+  // which order by created_at so the resolved row is deterministic.
+  db.exec(`CREATE TABLE companions (id TEXT PRIMARY KEY, name TEXT, guard_mode INTEGER, mood TEXT, muted INTEGER DEFAULT 0, created_at DATETIME DEFAULT CURRENT_TIMESTAMP);`);
   initReasoningSchema(db);
   db.prepare(`INSERT INTO companions (id, name, guard_mode, mood) VALUES (?, 't', ?, ?)`).run(CID, guard, mood);
   return db;

--- a/src/__tests__/xp-atomicity.test.ts
+++ b/src/__tests__/xp-atomicity.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { db, initDb } from '../db/schema.js';
+
+/**
+ * awardXp used to do a read-modify-write:
+ *
+ *   SELECT xp FROM companions   -> newXp = xp + reward
+ *   UPDATE companions SET xp = ?
+ *
+ * Two Claude Code sessions run two server processes against the same
+ * ~/.buddy/buddy.db. Both read the same total, both write their own sum, and
+ * one award is lost. The xp_events row is still inserted, so companions.xp
+ * drifts permanently below sum(xp_events.xp_gained).
+ *
+ * awardXp itself lives in src/server/index.ts, which starts a stdio server on
+ * import and so cannot be imported here. These tests pin the storage invariant
+ * and contrast the two UPDATE strategies directly.
+ */
+
+const ID = 'xp-test-companion';
+const REWARD = 5;
+
+function seed() {
+  db.prepare('DELETE FROM xp_events').run();
+  db.prepare('DELETE FROM companions').run();
+  db.prepare(
+    `INSERT INTO companions (id, name, species, level, xp, mood, user_id)
+     VALUES (?, 'Testy', 'Owl', 1, 0, 'happy', 'anon')`,
+  ).run(ID);
+}
+
+const xp = () => (db.prepare('SELECT xp FROM companions WHERE id = ?').get(ID) as { xp: number }).xp;
+const eventSum = () =>
+  (db.prepare('SELECT COALESCE(sum(xp_gained), 0) AS s FROM xp_events WHERE companion_id = ?').get(ID) as { s: number }).s;
+
+let seq = 0;
+function insertEvent() {
+  db.prepare('INSERT INTO xp_events (id, companion_id, event_type, xp_gained) VALUES (?, ?, ?, ?)')
+    .run(`xp-evt-${seq++}`, ID, 'observe', REWARD);
+}
+
+/** The old strategy: read the total, then write an absolute value back. */
+function awardReadModifyWrite() {
+  insertEvent();
+  const row = db.prepare('SELECT xp FROM companions WHERE id = ?').get(ID) as { xp: number };
+  const newXp = row.xp + REWARD;
+  db.prepare('UPDATE companions SET xp = ? WHERE id = ?').run(newXp, ID);
+}
+
+/** The fixed strategy: let SQLite do the addition. */
+const awardSelfReferential = db.transaction(() => {
+  insertEvent();
+  db.prepare('UPDATE companions SET xp = xp + ? WHERE id = ?').run(REWARD, ID);
+});
+
+beforeEach(() => {
+  initDb();
+  seed();
+});
+
+afterAll(() => {
+  db.prepare('DELETE FROM xp_events').run();
+  db.prepare('DELETE FROM companions').run();
+});
+
+describe('XP award atomicity', () => {
+  it('read-modify-write loses an award when two sessions interleave', () => {
+    // Session A and session B both read 0 before either writes.
+    insertEvent();
+    const readA = (db.prepare('SELECT xp FROM companions WHERE id = ?').get(ID) as { xp: number }).xp;
+    insertEvent();
+    const readB = (db.prepare('SELECT xp FROM companions WHERE id = ?').get(ID) as { xp: number }).xp;
+
+    db.prepare('UPDATE companions SET xp = ? WHERE id = ?').run(readA + REWARD, ID);
+    db.prepare('UPDATE companions SET xp = ? WHERE id = ?').run(readB + REWARD, ID);
+
+    expect(eventSum()).toBe(2 * REWARD);
+    expect(xp()).toBe(REWARD);
+    expect(xp()).toBeLessThan(eventSum()); // the drift this fix removes
+  });
+
+  it('self-referential update survives the same interleaving', () => {
+    insertEvent();
+    db.prepare('UPDATE companions SET xp = xp + ? WHERE id = ?').run(REWARD, ID);
+    insertEvent();
+    db.prepare('UPDATE companions SET xp = xp + ? WHERE id = ?').run(REWARD, ID);
+
+    expect(xp()).toBe(eventSum());
+  });
+
+  it('keeps companions.xp equal to sum(xp_events) across many awards', () => {
+    for (let i = 0; i < 50; i++) awardSelfReferential();
+    expect(xp()).toBe(50 * REWARD);
+    expect(xp()).toBe(eventSum());
+  });
+
+  it('drifts under the old strategy only when reads interleave, never under the new one', () => {
+    for (let i = 0; i < 10; i++) awardReadModifyWrite();
+    // Sequential calls are fine; the bug needs concurrency. Documented so the
+    // absence of drift here is not mistaken for the bug being absent.
+    expect(xp()).toBe(eventSum());
+
+    seed();
+    for (let i = 0; i < 10; i++) awardSelfReferential();
+    expect(xp()).toBe(eventSum());
+  });
+
+  it('never lets xp go backwards', () => {
+    let last = xp();
+    for (let i = 0; i < 20; i++) {
+      awardSelfReferential();
+      const now = xp();
+      expect(now).toBeGreaterThan(last);
+      last = now;
+    }
+  });
+});

--- a/src/cli/snapshot-cli.ts
+++ b/src/cli/snapshot-cli.ts
@@ -14,7 +14,7 @@ async function main() {
     console.error("Failed to initialize database:", error);
     process.exit(1);
   }
-  const row = db.prepare("SELECT * FROM companions LIMIT 1").get() as any;
+  const row = db.prepare("SELECT * FROM companions ORDER BY created_at ASC, id ASC LIMIT 1").get() as any;
   if (!row) {
     console.error("No buddy found. Hatch one first!");
     process.exit(1);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -29,6 +29,7 @@ export function initDb() {
       level INTEGER DEFAULT 1,
       xp INTEGER DEFAULT 0,
       mood TEXT DEFAULT 'happy',
+      muted INTEGER DEFAULT 0,
       personality_bio TEXT DEFAULT '',
       user_id TEXT,
       stat_debugging INTEGER,
@@ -93,6 +94,17 @@ export function initDb() {
   try {
     db.exec(`ALTER TABLE companions ADD COLUMN cc_rescue INTEGER DEFAULT 0`);
   } catch { /* column already exists */ }
+
+  // Migration: mute is its own flag rather than a value parked in `mood`.
+  // calculateMood never returns 'muted', so every mood recompute overwrote it.
+  try {
+    db.exec(`ALTER TABLE companions ADD COLUMN muted INTEGER DEFAULT 0`);
+  } catch { /* column already exists */ }
+
+  // Backfill: anyone currently muted under the old scheme stays muted.
+  try {
+    db.exec(`UPDATE companions SET muted = 1 WHERE mood = 'muted'`);
+  } catch { /* column not present yet on a failed migration */ }
 
   // Migration: add stat columns for growth
   try { db.exec(`ALTER TABLE companions ADD COLUMN stat_debugging INTEGER`); } catch {}

--- a/src/hooks/prompt-handler.ts
+++ b/src/hooks/prompt-handler.ts
@@ -178,7 +178,7 @@ export async function reinjectExtractionInstructionIfLapsed(
       db = schema.db;
     }
 
-    const companion = db.prepare("SELECT id FROM companions LIMIT 1").get() as
+    const companion = db.prepare("SELECT id FROM companions ORDER BY created_at ASC, id ASC LIMIT 1").get() as
       { id: string } | undefined;
     if (!companion) return false;
 

--- a/src/lib/companion.ts
+++ b/src/lib/companion.ts
@@ -67,10 +67,30 @@ export function loadCompanion(row: any, userIdOverride?: string): Companion | nu
 }
 
 /**
+ * Reads the mute flag straight from the DB. Cheap (single indexed row) and
+ * always current, so it cannot drift from what buddy_mute wrote.
+ */
+function isMuted(): boolean {
+  try {
+    const row = db
+      .prepare("SELECT muted FROM companions ORDER BY created_at ASC, id ASC LIMIT 1")
+      .get() as { muted?: number } | undefined;
+    return (row?.muted ?? 0) === 1;
+  } catch {
+    // Column missing (pre-migration) or DB unavailable — fail open, as before.
+    return false;
+  }
+}
+
+/**
  * Write buddy status JSON for the statusline wrapper.
  */
 export function writeBuddyStatus(companion: Companion, reaction?: { state: string; text: string; expires: number; eyeOverride?: string; indicator?: string; bubbleLines?: string[]; petActiveUntil?: number }) {
   try {
+    // Muted buddies never write the statusline file. Guarding here rather than
+    // at each of the six call sites means a new caller can't silently un-mute.
+    if (isMuted()) return;
+
     if (!statusDirEnsured) {
       mkdirSync(dirname(BUDDY_STATUS_PATH), { recursive: true });
       statusDirEnsured = true;

--- a/src/lib/companion.ts
+++ b/src/lib/companion.ts
@@ -19,7 +19,7 @@ let statusDirEnsured = false;
  * Returns the row if found, null otherwise.
  */
 export function companionExists(): any | null {
-  return db.prepare('SELECT * FROM companions LIMIT 1').get() || null;
+  return db.prepare('SELECT * FROM companions ORDER BY created_at ASC, id ASC LIMIT 1').get() || null;
 }
 
 /**
@@ -61,9 +61,27 @@ export function loadCompanion(row: any, userIdOverride?: string): Companion | nu
     xp,
     mood: row.mood,
     availablePoints: row.stat_points_available || 0,
-    hatchedAt: new Date(row.created_at).getTime(),
+    hatchedAt: parseCreatedAt(row.created_at),
     guardMode: row.guard_mode ?? 0,
   };
+}
+
+/**
+ * created_at arrives in two shapes. Rescued buddies get an explicit ISO 8601
+ * string with a 'Z', which parses correctly. Everyone else gets SQLite's
+ * DEFAULT CURRENT_TIMESTAMP — 'YYYY-MM-DD HH:MM:SS', UTC but with no zone
+ * designator, which JavaScript reads as *local* time. Left alone that makes a
+ * normally-hatched companion's age wrong by the UTC offset, and negative for
+ * the first N hours after hatching anywhere west of Greenwich.
+ */
+export function parseCreatedAt(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (!value) return Date.now();
+
+  const raw = String(value).trim();
+  const iso = /[TZ]|[+-]\d{2}:?\d{2}$/.test(raw) ? raw : raw.replace(' ', 'T') + 'Z';
+  const ms = Date.parse(iso);
+  return Number.isFinite(ms) ? ms : Date.now();
 }
 
 /**

--- a/src/lib/doctor.ts
+++ b/src/lib/doctor.ts
@@ -319,7 +319,7 @@ function checkMcpEntryPaths(): DiagnosticCheck {
 
 function checkCompanionActive(): DiagnosticCheck {
   try {
-    const row = db.prepare('SELECT * FROM companions LIMIT 1').get() as any;
+    const row = db.prepare('SELECT * FROM companions ORDER BY created_at ASC, id ASC LIMIT 1').get() as any;
     if (!row) {
       return { id: 'companion.active', status: 'warn', label: 'Active companion', detail: 'None', suggestion: 'Use buddy_hatch to create a companion' };
     }
@@ -340,7 +340,7 @@ function checkCompanionCount(): DiagnosticCheck {
 
 function checkCompanionDetails(): DiagnosticCheck {
   try {
-    const row = db.prepare('SELECT * FROM companions LIMIT 1').get() as any;
+    const row = db.prepare('SELECT * FROM companions ORDER BY created_at ASC, id ASC LIMIT 1').get() as any;
     if (!row) {
       return { id: 'companion.details', status: 'skip', label: 'Companion details', detail: 'No companion' };
     }
@@ -587,7 +587,7 @@ function checkPromptInjection(): DiagnosticCheck {
 
 function checkReasoningGuardMode(): DiagnosticCheck {
   try {
-    const row = db.prepare('SELECT id, guard_mode FROM companions LIMIT 1').get() as any;
+    const row = db.prepare('SELECT id, guard_mode FROM companions ORDER BY created_at ASC, id ASC LIMIT 1').get() as any;
     if (!row) {
       return { id: 'reasoning.guard', status: 'skip', label: 'Guard mode', detail: 'No companion' };
     }
@@ -662,7 +662,7 @@ function checkReasoningStorage(): DiagnosticCheck {
 
 function checkReasoningRootResolution(): DiagnosticCheck {
   try {
-    const row = db.prepare('SELECT guard_mode FROM companions LIMIT 1').get() as any;
+    const row = db.prepare('SELECT guard_mode FROM companions ORDER BY created_at ASC, id ASC LIMIT 1').get() as any;
     if (!row || (row.guard_mode ?? 0) === 0) {
       return { id: 'reasoning.root', status: 'skip', label: 'Workspace root', detail: 'Guard mode off' };
     }
@@ -694,7 +694,7 @@ function checkReasoningRootResolution(): DiagnosticCheck {
 
 function checkReasoningBasisQuality(): DiagnosticCheck {
   try {
-    const row = db.prepare('SELECT guard_mode FROM companions LIMIT 1').get() as any;
+    const row = db.prepare('SELECT guard_mode FROM companions ORDER BY created_at ASC, id ASC LIMIT 1').get() as any;
     if (!row || (row.guard_mode ?? 0) === 0) {
       return { id: 'reasoning.quality', status: 'skip', label: 'Extraction quality', detail: 'Guard mode off' };
     }
@@ -719,7 +719,7 @@ function checkReasoningBasisQuality(): DiagnosticCheck {
 
 function checkReasoningEdgeQuality(): DiagnosticCheck {
   try {
-    const row = db.prepare('SELECT guard_mode FROM companions LIMIT 1').get() as any;
+    const row = db.prepare('SELECT guard_mode FROM companions ORDER BY created_at ASC, id ASC LIMIT 1').get() as any;
     if (!row || (row.guard_mode ?? 0) === 0) {
       return { id: 'reasoning.edges', status: 'skip', label: 'Edge diversity', detail: 'Guard mode off' };
     }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -81,8 +81,12 @@ function awardXp(companionId: string, eventType: string): { newXp: number; newLe
  */
 function awardXpAndRefresh(row: any, eventType: string, userIdOverride?: string) {
   const xpResult = awardXp(row.id, eventType);
-  const newMood = recalcMood(row.id, xpResult.leveledUp);
-  db.prepare("UPDATE companions SET mood = ? WHERE id = ?").run(newMood, row.id);
+  // A muted buddy keeps earning XP quietly, but its mood is left alone —
+  // overwriting it here was the second path that silently un-muted.
+  const newMood = row.muted ? row.mood : recalcMood(row.id, xpResult.leveledUp);
+  if (!row.muted) {
+    db.prepare("UPDATE companions SET mood = ? WHERE id = ?").run(newMood, row.id);
+  }
   const companion = loadCompanion({ ...row, mood: newMood, xp: xpResult.newXp, level: xpResult.newLevel }, userIdOverride)!;
   return { companion, xpResult };
 }
@@ -345,6 +349,17 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     const userId = user_id || row.user_id || 'anon';
 
+    // A muted buddy stays muted. Recomputing mood and rewriting the status file
+    // here is what used to resurrect it at the start of every conversation.
+    if (row.muted) {
+      return {
+        content: [{
+          type: "text",
+          text: `${row.name} is muted. Use buddy_unmute to bring it back.`,
+        }],
+      };
+    }
+
     const newMood = recalcMood(row.id, false);
     db.prepare("UPDATE companions SET mood = ? WHERE id = ?").run(newMood, row.id);
 
@@ -582,7 +597,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return { content: [{ type: "text", text: "No companion to mute! Use buddy_hatch first." }] };
     }
 
-    db.prepare("UPDATE companions SET mood = 'muted' WHERE id = ?").run(row.id);
+    // Tracked in its own column. Parking 'muted' in `mood` did not survive:
+    // calculateMood never returns 'muted', so the next mood recompute — which
+    // buddy_status does on every conversation start — silently un-muted.
+    db.prepare("UPDATE companions SET muted = 1 WHERE id = ?").run(row.id);
 
     // Remove status file so statusline goes blank
     try { unlinkSync(BUDDY_STATUS_PATH); } catch { /* already gone */ }
@@ -596,7 +614,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return { content: [{ type: "text", text: "No companion to unmute! Use buddy_hatch first." }] };
     }
 
-    db.prepare("UPDATE companions SET mood = 'happy' WHERE id = ?").run(row.id);
+    db.prepare("UPDATE companions SET muted = 0, mood = 'happy' WHERE id = ?").run(row.id);
     const companion = loadCompanion({ ...row, mood: 'happy' })!;
     writeBuddyStatus(companion);
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -60,21 +60,28 @@ export function recalcMood(companionId: string, leveledUp: boolean): Mood {
   return calculateMood(new Array(xpCount), memCount);
 }
 
-function awardXp(companionId: string, eventType: string): { newXp: number; newLevel: number; leveledUp: boolean } {
+/**
+ * One transaction, with a self-referential UPDATE rather than a
+ * read-modify-write. Two Claude Code sessions run two server processes against
+ * the same file: both would read the same old total, both write their own sum,
+ * and one award would vanish — leaving companions.xp permanently below
+ * sum(xp_events.xp_gained) and potentially skipping a level-up boundary.
+ */
+const awardXp = db.transaction((companionId: string, eventType: string): { newXp: number; newLevel: number; leveledUp: boolean } => {
   const xp = XP_REWARDS[eventType] || 1;
-  const id = randomUUID();
-  db.prepare("INSERT INTO xp_events (id, companion_id, event_type, xp_gained) VALUES (?, ?, ?, ?)").run(id, companionId, eventType, xp);
+  const before = db.prepare("SELECT level FROM companions WHERE id = ?").get(companionId) as any;
 
-  // Get current total XP
-  const row = db.prepare("SELECT xp, level FROM companions WHERE id = ?").get(companionId) as any;
-  const newXp = (row?.xp || 0) + xp;
+  db.prepare("INSERT INTO xp_events (id, companion_id, event_type, xp_gained) VALUES (?, ?, ?, ?)")
+    .run(randomUUID(), companionId, eventType, xp);
+  db.prepare("UPDATE companions SET xp = xp + ? WHERE id = ?").run(xp, companionId);
+
+  const after = db.prepare("SELECT xp FROM companions WHERE id = ?").get(companionId) as any;
+  const newXp = after?.xp ?? xp;
   const newLevel = levelFromXp(newXp);
-  const leveledUp = newLevel > (row?.level || 1);
+  db.prepare("UPDATE companions SET level = ? WHERE id = ?").run(newLevel, companionId);
 
-  db.prepare("UPDATE companions SET xp = ?, level = ? WHERE id = ?").run(newXp, newLevel, companionId);
-
-  return { newXp, newLevel, leveledUp };
-}
+  return { newXp, newLevel, leveledUp: newLevel > (before?.level || 1) };
+});
 
 /**
  * Award XP, recalculate mood, update DB, and load companion — shared by observe + pet.
@@ -342,7 +349,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
   if (name === "buddy_status") {
     const { user_id } = args as { user_id?: string };
-    const row = db.prepare("SELECT * FROM companions LIMIT 1").get() as any;
+    const row = db.prepare("SELECT * FROM companions ORDER BY created_at ASC, id ASC LIMIT 1").get() as any;
     if (!row) {
       return { content: [{ type: "text", text: "No companion hatched yet! Use buddy_hatch to start." }] };
     }
@@ -374,7 +381,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
   if (name === "buddy_remember") {
     const { content, importance = 1 } = args as { content: string, importance?: number };
-    const companion = db.prepare("SELECT id FROM companions LIMIT 1").get() as any;
+    const companion = db.prepare("SELECT id FROM companions ORDER BY created_at ASC, id ASC LIMIT 1").get() as any;
     if (!companion) return { content: [{ type: "text", text: "Hatch a companion first!" }] };
 
     const id = randomUUID();
@@ -395,7 +402,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   }
 
   if (name === "buddy_respawn") {
-    const companion = db.prepare("SELECT * FROM companions LIMIT 1").get() as any;
+    const companion = db.prepare("SELECT * FROM companions ORDER BY created_at ASC, id ASC LIMIT 1").get() as any;
     if (!companion) {
       return {
         content: [{ type: "text", text: "No companion to release. Use buddy_hatch to get started!" }],
@@ -439,7 +446,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       cwd?: string;
     };
 
-    const row = db.prepare("SELECT * FROM companions LIMIT 1").get() as any;
+    const row = db.prepare("SELECT * FROM companions ORDER BY created_at ASC, id ASC LIMIT 1").get() as any;
     if (!row) {
       return { content: [{ type: "text", text: "No companion hatched yet! Use buddy_hatch first." }] };
     }
@@ -535,7 +542,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   }
 
   if (name === "buddy_pet") {
-    const row = db.prepare("SELECT * FROM companions LIMIT 1").get() as any;
+    const row = db.prepare("SELECT * FROM companions ORDER BY created_at ASC, id ASC LIMIT 1").get() as any;
     if (!row) {
       return { content: [{ type: "text", text: "No companion to pet! Use buddy_hatch first." }] };
     }
@@ -592,7 +599,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   }
 
   if (name === "buddy_mute") {
-    const row = db.prepare("SELECT * FROM companions LIMIT 1").get() as any;
+    const row = db.prepare("SELECT * FROM companions ORDER BY created_at ASC, id ASC LIMIT 1").get() as any;
     if (!row) {
       return { content: [{ type: "text", text: "No companion to mute! Use buddy_hatch first." }] };
     }
@@ -609,7 +616,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   }
 
   if (name === "buddy_unmute") {
-    const row = db.prepare("SELECT * FROM companions LIMIT 1").get() as any;
+    const row = db.prepare("SELECT * FROM companions ORDER BY created_at ASC, id ASC LIMIT 1").get() as any;
     if (!row) {
       return { content: [{ type: "text", text: "No companion to unmute! Use buddy_hatch first." }] };
     }
@@ -622,7 +629,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   }
 
   if (name === "buddy_mode") {
-    const row = db.prepare("SELECT * FROM companions LIMIT 1").get() as any;
+    const row = db.prepare("SELECT * FROM companions ORDER BY created_at ASC, id ASC LIMIT 1").get() as any;
     if (!row) {
       return { content: [{ type: "text", text: "No companion yet! Use buddy_hatch first." }] };
     }
@@ -682,7 +689,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   }
 
   if (name === "buddy_reasoning_status") {
-    const row = db.prepare("SELECT * FROM companions LIMIT 1").get() as any;
+    const row = db.prepare("SELECT * FROM companions ORDER BY created_at ASC, id ASC LIMIT 1").get() as any;
     const totalClaims = (db.prepare("SELECT count(*) as n FROM reasoning_claims").get() as any)?.n ?? 0;
     const totalEdges = (db.prepare("SELECT count(*) as n FROM reasoning_edges").get() as any)?.n ?? 0;
     const totalFindings = (db.prepare("SELECT count(*) as n FROM reasoning_findings_log").get() as any)?.n ?? 0;
@@ -750,7 +757,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
   if (name === "buddy_share") {
     const { user_id } = args as { user_id?: string };
-    const row = db.prepare("SELECT * FROM companions LIMIT 1").get() as any;
+    const row = db.prepare("SELECT * FROM companions ORDER BY created_at ASC, id ASC LIMIT 1").get() as any;
     if (!row) return { content: [{ type: "text", text: "Hatch a buddy first!" }] };
 
     const companion = loadCompanion(row, user_id || row.user_id || 'anon')!;
@@ -815,7 +822,7 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
   const { uri } = request.params;
 
   if (uri === "buddy://companion") {
-    const row = db.prepare("SELECT * FROM companions LIMIT 1").get() as any;
+    const row = db.prepare("SELECT * FROM companions ORDER BY created_at ASC, id ASC LIMIT 1").get() as any;
     if (!row) {
       return { contents: [{ uri, mimeType: "application/json", text: JSON.stringify({ message: "No companion hatched" }) }] };
     }
@@ -824,7 +831,7 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
   }
 
   if (uri === "buddy://status") {
-    const row = db.prepare("SELECT * FROM companions LIMIT 1").get() as any;
+    const row = db.prepare("SELECT * FROM companions ORDER BY created_at ASC, id ASC LIMIT 1").get() as any;
     if (!row) {
       return { contents: [{ uri, mimeType: "text/plain", text: "No companion hatched yet." }] };
     }
@@ -837,7 +844,7 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
   }
 
   if (uri === "buddy://intro") {
-    const row = db.prepare("SELECT * FROM companions LIMIT 1").get() as any;
+    const row = db.prepare("SELECT * FROM companions ORDER BY created_at ASC, id ASC LIMIT 1").get() as any;
     if (!row) {
       return { contents: [{ uri, mimeType: "text/plain", text: "No companion hatched yet. Use buddy_hatch to get started." }] };
     }
@@ -869,7 +876,7 @@ When the user addresses ${companion.name} by name, respond briefly in character 
 
 async function main() {
   // Write status file on startup if a companion exists
-  const existing = db.prepare("SELECT * FROM companions LIMIT 1").get() as any;
+  const existing = db.prepare("SELECT * FROM companions ORDER BY created_at ASC, id ASC LIMIT 1").get() as any;
   if (existing) {
     const companion = loadCompanion(existing);
     if (companion) writeBuddyStatus(companion);


### PR DESCRIPTION
Three independent correctness fixes, one commit each so they can be cherry-picked or dropped separately. All three are long-standing and still present on `master` (`b2452e6`).

### 1. Mute never survived a conversation

`buddy_mute` recorded mute by writing `'muted'` into the `mood` column, but `calculateMood` only ever returns `happy | content | neutral | curious | grumpy`. Every mood recompute overwrote it — and since clients are instructed to call `buddy_status` at the start of each conversation, mute was gone within one turn. `buddy_unmute` was effectively a no-op relative to it.

Two paths did the overwrite: `buddy_status`, and `awardXpAndRefresh` (so `buddy_observe` and `buddy_pet` too). Six separate `writeBuddyStatus` calls could also put the buddy back on screen.

This also silently defeated the reasoning reinjection guard — `hooks/prompt-handler.ts` skips work when `status.mood === "muted"`, which could no longer be true for long.

Mute now lives in a `muted` column, with a backfill so anyone currently muted stays muted. `writeBuddyStatus` checks the flag itself rather than relying on each call site remembering to, so a new caller can't regress it. A muted buddy still earns XP quietly.

### 2. XP awards lost when two sessions interleave

`awardXp` did a read-modify-write:

```
SELECT xp FROM companions   -> newXp = xp + reward
UPDATE companions SET xp = ?
```

Two Claude Code sessions run two server processes against the same `~/.buddy/buddy.db`. Both read the same total, both write their own sum, one award vanishes. The `xp_events` row is inserted either way, so `companions.xp` drifts permanently below `sum(xp_events.xp_gained)`. Because `leveledUp` compares against the stale level, a level-up can also be crossed without being reported.

Now a single `db.transaction()` with `UPDATE ... SET xp = xp + ?`.

Also in this commit: 23 companion lookups across five files used a bare `LIMIT 1` with no `ORDER BY`. SQLite doesn't guarantee row order without one, so which companion is resolved is unspecified once a second row exists. All now order by `created_at`.

### 3. Companion age off by the UTC offset

`loadCompanion` did `new Date(row.created_at).getTime()`. Rescued buddies are fine — `createCompanionFromImport` writes an explicit ISO 8601 `Z` string. But everyone else gets SQLite's `DEFAULT CURRENT_TIMESTAMP`, `'YYYY-MM-DD HH:MM:SS'`, which is UTC with no zone designator and which JavaScript parses as *local* time.

East of Greenwich `hatchedAt` reads too early; west of it the companion appears to have hatched in the future, so `Date.now() - hatchedAt` is negative for the first N hours. `parseCreatedAt` handles both shapes and falls back to now rather than `NaN`.

---

### Tests

Adds 20 tests across three files. The mute tests fail on current behaviour (3 of 8) and pass with the fix — verified by disabling the guard and re-running.

One existing fixture changed: the in-memory `companions` stub in `instruction-reinjection.test.ts` declared fewer columns than the real table, so it couldn't satisfy an ordered lookup. It now carries `created_at` and `muted`.

`awardXp` isn't importable from tests — `index.ts` opens a stdio server on import — so those tests pin the `companions.xp == sum(xp_events.xp_gained)` invariant and exercise the two UPDATE strategies rather than the function itself. Happy to extract it into `lib/` if you'd prefer it directly covered.

### Test baseline

`master` at `b2452e6` has 9 pre-existing failures (897 passed): `animation-stability` (Penguin width), `doctor` (2), `species` (Penguin motion), `reasoning/detectors` (3), `reasoning/pipeline-per-detector` (2). This branch has the **same 9** and 917 passing — no new failures. None of them are in the areas touched here.

Found while debugging why a companion had gone quiet after a Node upgrade; the mute bug turned up on the way.
