### PR TITLE
fix: green the plaza-smoke headless tests (sit-drop + parked stalls)

### DIFF
--- a/src/__tests__/world/plaza-smoke.test.ts
+++ b/src/__tests__/world/plaza-smoke.test.ts
@@ -275,8 +275,10 @@ describe('plaza smoke test (headless browser)', () => {
     }))()`)) as { porings: number; stalls: number; stallOwner: string; sitting: number; ticker: string; bubbles: number };
 
     expect(ro.porings).toBeGreaterThanOrEqual(2); // ambient jellies
-    expect(ro.stalls).toBeGreaterThanOrEqual(1); // achievement vendor
-    expect(ro.stallOwner).toBeTruthy();
+    // Vending stalls are intentionally parked (plaza.js: rebuildStalls is not
+    // called) pending the future buddy-marketplace/job-board idea, so no stall
+    // renders today. Pin the parked state so unparking re-enables this check.
+    expect(ro.stalls).toBe(0);
     // fixture: buddies 3..7 have last_seen ~2h ago -> they sit
     // Sitting is now a brief transient pose (not a permanent freeze), so
     // any count >= 0 is valid — the plaza wanders by default.

--- a/world/public/plaza.js
+++ b/world/public/plaza.js
@@ -660,8 +660,10 @@
       ctx.restore();
     }
 
-    // test instrumentation: bottom row must sit at a constant offset
-    const bottomOffset = Math.round(lastLineY - actor.y);
+    // test instrumentation: bottom row must sit at a constant offset.
+    // Exclude the intentional seated drop (sitDrop) — that's a deliberate
+    // posture change, not the variable-line-count jitter this guards against.
+    const bottomOffset = Math.round(lastLineY - actor.y - sitDrop);
     const rec = state.spriteBottoms[c.slug] || { min: bottomOffset, max: bottomOffset };
     rec.min = Math.min(rec.min, bottomOffset);
     rec.max = Math.max(rec.max, bottomOffset);


### PR DESCRIPTION
Fixes the 2 pre-existing `plaza-smoke.test.ts` failures inherited from `integration/2.0.0` (JWU-62), at the root — no quarantine.

**1. Bottom-anchor drift (6px):** the render loop already bottom-anchors every frame correctly; the drift was the intentional seated drop (`sitDrop = 6`, `plaza.js:646`) leaking into the *test instrumentation* (`bottomOffset`, `plaza.js:664`). A sit↔stand transition mid-measurement read as vertical jitter. `bottomOffset` now subtracts `sitDrop`.

**2. Stalls = 0:** `rebuildStalls()` is intentionally never called ("Vending stalls parked for now", `plaza.js:815`), so the RO-essence test's `stalls >= 1` could never pass. Pinned to `stalls === 0` to match the parked state (fails loudly if unparked).

**Suite: 1061 passing, 0 failing.** `release/2.0` goes fully green with this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)