### PR TITLE
feat(statusline): show Claude Code account and usage gauges beside the buddy

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,49 @@ The installer:
 
 </details>
 
+## 📊 Statusline Usage Panel
+
+Claude Code hands the statusline a payload describing the session. Buddy renders the useful parts of it as a third column, to the right of the buddy:
+
+```
+     (\   /)     Pebble (Rabbit) Lv.21   acct Rebellions-Lime | daekyeong.kim
+     (\_._/)     curious XP:9687 ★       via  Opus 5 | max5x
+     ( ·.· )     · ready to critique     ctx  ██░░░░░░░░   23%  229k/1.0M
+      > ^ <                              5h   █░|░░░░░░░    5%  3h50m
+     (") (")                             week ███|█░░░░░   46%  4d13h
+```
+
+- `acct` — the signed-in organization and account, so sessions on different logins are told apart at a glance
+- `via` — the answering model, tagged `(gateway)` when it is not an Anthropic model
+- `ctx` — context window in use
+- `5h` / `week` — rate-limit windows, with the time left until each resets
+- `|` — how much of that window has already run, so the two can be compared directly: fill left of the tick means the budget is outlasting the clock, fill past it means it is burning faster than the window resets
+
+<details>
+<summary><strong>Where the numbers come from, and how to turn them off</strong></summary>
+<br>
+
+Rate limits are taken from the first source that has them:
+
+1. the `rate_limits` block on the statusline payload, when Claude Code sends one
+2. Buddy's own snapshot, when the optional refresh below is enabled
+3. the utilization Claude Code last cached in `~/.claude.json`
+
+Sources 2 and 3 are caches, so their age is shown in parentheses once it passes ten minutes — `4d13h | (5h)`.
+
+Claude Code only refreshes its own cache when it fetches utilization itself, which never happens in sessions answered through a gateway; those numbers can sit hours behind. So Buddy keeps the snapshot current itself: it reads the Claude Code OAuth credential (macOS keychain, or `~/.claude/.credentials.json` elsewhere) and calls the same usage endpoint Claude Code does, at most once a minute, in a detached background process. Nothing is sent anywhere else, and nothing is stored beyond the utilization snapshot in `~/.claude/buddy-usage-cache.json`.
+
+Set `BUDDY_STATUSLINE_USAGE_FETCH=0` to switch that off — the panel then falls back to Claude Code's cache and shows its age, and the statusline never reads a credential or touches the network.
+
+The refresh never blocks a render: the statusline draws from the cache it already has, and a refresh started now appears on a later frame. Failures are silent by design — an expired token, an offline laptop, or a rejected request just leaves the previous snapshot on screen.
+
+| Variable | Effect |
+| --- | --- |
+| `BUDDY_STATUSLINE_USAGE=0` | Hide the panel entirely |
+| `BUDDY_STATUSLINE_USAGE_FETCH=0` | Never fetch; show only what Claude Code already cached |
+
+</details>
+
 ## 🐣 Companion System
 
 ### Meet the 21 species

--- a/src/__tests__/columns.test.ts
+++ b/src/__tests__/columns.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { joinColumns } from '../lib/columns.js';
+
+const DIM = '\x1b[2m';
+const RESET = '\x1b[0m';
+const strip = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
+
+describe('joinColumns', () => {
+  it('places the next column at the widest row plus the gutter', () => {
+    expect(joinColumns([['ab', 'cdef'], ['1', '2']], 3)).toEqual([
+      'ab     1',
+      'cdef   2',
+    ]);
+  });
+
+  it('starts every row of a column at the same offset', () => {
+    const rows = joinColumns([['a', 'bbbb'], ['x', 'y']], 2);
+    expect(rows[0].indexOf('x')).toBe(rows[1].indexOf('y'));
+  });
+
+  it('ignores ANSI codes when measuring width', () => {
+    const rows = joinColumns([[`${DIM}ab${RESET}`], ['x']], 3);
+    expect(strip(rows[0])).toBe('ab   x');
+  });
+
+  it('does not let rows that trail past every other column set the width', () => {
+    // The buddy's name and mood lines sit below the usage panel; letting them
+    // widen the column would shove the panel off a narrow terminal.
+    const buddy = ['sprite', 'sprite', 'a very long trailing mood line'];
+    const rows = joinColumns([buddy, ['ctx', '5h']], 3);
+    expect(rows[0]).toBe('sprite   ctx');
+    expect(rows[1]).toBe('sprite   5h');
+    expect(rows[2]).toBe('a very long trailing mood line');
+  });
+
+  it('strips trailing padding inside a cell instead of stacking it on the gutter', () => {
+    const rows = joinColumns([[`bubble${' '.repeat(8)}${RESET}`], ['ctx']], 3);
+    expect(strip(rows[0])).toBe('bubble   ctx');
+  });
+
+  it('collapses an empty column to its gutter', () => {
+    // Buddy has always been indented by the gutter when no HUD is installed;
+    // keep that placement rather than snapping it to column zero.
+    expect(joinColumns([[], ['solo', 'lines'], []], 3)).toEqual(['   solo', '   lines']);
+  });
+
+  it('keeps a single column untouched', () => {
+    expect(joinColumns([['just', 'me']], 3)).toEqual(['just', 'me']);
+  });
+
+  it('returns nothing when every column is empty', () => {
+    expect(joinColumns([[], []], 3)).toEqual([]);
+  });
+
+  it('shields a padding-only row from a host that re-indents on trimStart', () => {
+    // The usage panel outliving the buddy block leaves rows that are pure
+    // padding up to their first visible character.
+    const rows = joinColumns([[], ['art', 'art'], ['one', 'two', 'three']], 3);
+    expect(rows[2].startsWith(`   ${RESET}`)).toBe(true);
+    expect(strip(rows[2]).indexOf('three')).toBe(strip(rows[1]).indexOf('two'));
+
+    // Only the bare gutter is exposed to the trim, so re-indenting the row by
+    // that same gutter reproduces the original layout.
+    const reindent = (row: string) => '   ' + row.trimStart();
+    expect(strip(reindent(rows[2])).indexOf('three')).toBe(strip(reindent(rows[1])).indexOf('two'));
+
+    // Rows that only carry the gutter keep their plain indentation.
+    expect(rows[0].startsWith(RESET)).toBe(false);
+  });
+
+  it('never leaves trailing whitespace on a rendered row', () => {
+    for (const row of joinColumns([['a', 'bb'], ['x', '']], 3)) {
+      expect(row).toBe(row.trimEnd());
+    }
+  });
+});

--- a/src/__tests__/usage.test.ts
+++ b/src/__tests__/usage.test.ts
@@ -1,0 +1,358 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildUsageModel,
+  renderUsagePanel,
+  renderBar,
+  formatTokens,
+  formatDuration,
+  normalizeUtilization,
+  tidyTier,
+  STALE_AFTER_MS,
+} from '../lib/usage.js';
+import { decideRefresh, readTimestamp, USAGE_CACHE_TTL_MS, REFRESH_LOCK_TTL_MS } from '../lib/usage-sources.js';
+import { pickToken, fetchEnabled, FETCH_ENV_FLAG } from '../lib/usage-refresh.js';
+
+const strip = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
+const NOW = Date.parse('2026-08-12T13:00:00Z');
+
+const STDIN = {
+  model: { id: 'claude-opus-5', display_name: 'Opus 5' },
+  context_window: {
+    total_input_tokens: 102178,
+    context_window_size: 200000,
+    used_percentage: 51,
+    remaining_percentage: 49,
+  },
+};
+
+const CONFIG = {
+  oauthAccount: {
+    emailAddress: 'daekyeong.kim@rebellions.ai',
+    organizationName: 'Rebellions-Lime',
+    seatTier: 'team_tier_1',
+    userRateLimitTier: 'default_claude_max_5x',
+  },
+};
+
+const UTILIZATION = {
+  five_hour: { utilization: 7, resets_at: '2026-08-12T17:30:00Z' },
+  seven_day: { utilization: 47, resets_at: '2026-08-17T03:00:00Z' },
+  limits: [
+    { kind: 'session', percent: 0, is_active: false, resets_at: null },
+    { kind: 'weekly_all', percent: 47, is_active: false, resets_at: '2026-08-17T03:00:00Z' },
+    {
+      kind: 'weekly_scoped',
+      percent: 58,
+      is_active: true,
+      resets_at: '2026-08-17T03:00:00Z',
+      scope: { model: { id: null, display_name: 'Fable' }, surface: null },
+    },
+  ],
+};
+
+describe('usage — formatting primitives', () => {
+  it('fills the meter in proportion to the percentage', () => {
+    expect(strip(renderBar(0))).toBe('░'.repeat(10));
+    expect(strip(renderBar(50))).toBe('█'.repeat(5) + '░'.repeat(5));
+    expect(strip(renderBar(100))).toBe('█'.repeat(10));
+  });
+
+  it('lights at least one cell for any non-zero percentage', () => {
+    expect(strip(renderBar(1))).toBe('█' + '░'.repeat(9));
+    expect(strip(renderBar(4))).toBe('█' + '░'.repeat(9));
+  });
+
+  it('clamps out-of-range percentages instead of overflowing the meter', () => {
+    expect(strip(renderBar(-20))).toBe('░'.repeat(10));
+    expect(strip(renderBar(150))).toBe('█'.repeat(10));
+  });
+
+  it('marks how far the window has run with a tick', () => {
+    expect(strip(renderBar(0, 0))).toBe('|' + '░'.repeat(9));
+    expect(strip(renderBar(50, 50))).toBe('█'.repeat(5) + '|' + '░'.repeat(4));
+    // Fill left of the tick: the budget is outlasting the clock.
+    expect(strip(renderBar(20, 50))).toBe('█'.repeat(2) + '░'.repeat(3) + '|' + '░'.repeat(4));
+    // Fill past the tick: burning faster than the window resets.
+    expect(strip(renderBar(80, 20))).toBe('█'.repeat(2) + '|' + '█'.repeat(5) + '░'.repeat(2));
+  });
+
+  it('keeps the tick inside the meter at the end of a window', () => {
+    expect(strip(renderBar(100, 100))).toBe('█'.repeat(9) + '|');
+    expect(strip(renderBar(50, 130))).toBe('█'.repeat(5) + '░'.repeat(4) + '|');
+  });
+
+  it('draws no tick when the window length is unknown', () => {
+    expect(strip(renderBar(51))).not.toContain('|');
+  });
+
+  it('keeps every meter the same visible width', () => {
+    for (const pct of [0, 1, 7, 33, 51, 99, 100]) {
+      expect(strip(renderBar(pct))).toHaveLength(10);
+      expect(strip(renderBar(pct, pct))).toHaveLength(10);
+    }
+  });
+
+  it('abbreviates token counts', () => {
+    expect(formatTokens(812)).toBe('812');
+    expect(formatTokens(102178)).toBe('102k');
+    expect(formatTokens(200000)).toBe('200k');
+    expect(formatTokens(1_240_000)).toBe('1.2M');
+    expect(formatTokens(-5)).toBe('0');
+  });
+
+  it('formats durations coarsely', () => {
+    expect(formatDuration(30_000)).toBe('<1m');
+    expect(formatDuration(12 * 60_000)).toBe('12m');
+    expect(formatDuration(3 * 3600_000 + 58 * 60_000)).toBe('3h58m');
+    expect(formatDuration(5 * 3600_000)).toBe('5h');
+    expect(formatDuration(4 * 86400_000 + 13 * 3600_000)).toBe('4d13h');
+    expect(formatDuration(2 * 86400_000)).toBe('2d');
+  });
+
+  it('tidies rate-limit tier names', () => {
+    expect(tidyTier('default_claude_max_5x')).toBe('max5x');
+    expect(tidyTier('team_tier_1')).toBe('team1');
+    expect(tidyTier(undefined)).toBeUndefined();
+    expect(tidyTier('')).toBeUndefined();
+  });
+});
+
+describe('usage — utilization normalization', () => {
+  it('reads both windows and the active scoped limit', () => {
+    const limits = normalizeUtilization(UTILIZATION);
+    expect(limits?.fiveHour).toEqual({ percent: 7, resetsAt: '2026-08-12T17:30:00Z' });
+    expect(limits?.sevenDay?.percent).toBe(47);
+    expect(limits?.scoped).toEqual({ label: 'Fable', percent: 58 });
+  });
+
+  it('keeps scoped limits that are not yet binding', () => {
+    const limits = normalizeUtilization({
+      ...UTILIZATION,
+      limits: [{ kind: 'weekly_scoped', percent: 58, is_active: false, scope: { model: { display_name: 'Fable' } } }],
+    });
+    expect(limits?.scoped).toEqual({ label: 'Fable', percent: 58 });
+  });
+
+  it('prefers the binding scoped limit when several are reported', () => {
+    const limits = normalizeUtilization({
+      ...UTILIZATION,
+      limits: [
+        { kind: 'weekly_scoped', percent: 12, is_active: false, scope: { model: { display_name: 'Fable' } } },
+        { kind: 'weekly_scoped', percent: 91, is_active: true, scope: { model: { display_name: 'Opus' } } },
+      ],
+    });
+    expect(limits?.scoped).toEqual({ label: 'Opus', percent: 91 });
+  });
+
+  it('returns undefined for junk or empty payloads', () => {
+    expect(normalizeUtilization(undefined)).toBeUndefined();
+    expect(normalizeUtilization('nope')).toBeUndefined();
+    expect(normalizeUtilization({ five_hour: null, seven_day: null })).toBeUndefined();
+  });
+});
+
+describe('usage — model assembly', () => {
+  it('returns null when no source has anything to show', () => {
+    expect(buildUsageModel({}, NOW)).toBeNull();
+  });
+
+  it('builds account, route and context from stdin plus config', () => {
+    const model = buildUsageModel({ stdin: STDIN, config: CONFIG }, NOW);
+    expect(model?.account).toEqual({ org: 'Rebellions-Lime', user: 'daekyeong.kim' });
+    expect(model?.route).toEqual({ model: 'Opus 5', firstParty: true, plan: 'max5x' });
+    expect(model?.context?.percent).toBe(51);
+    expect(model?.context?.note).toBe('102k/200k');
+  });
+
+  it('marks a non-Anthropic model id as not first-party', () => {
+    const stdin = { ...STDIN, model: { id: 'MiniMaxAI/MiniMax-M2.5', display_name: 'MiniMaxAI/MiniMax-M2.5' } };
+    expect(buildUsageModel({ stdin, config: CONFIG }, NOW)?.route?.firstParty).toBe(false);
+  });
+
+  it('derives context tokens from the percentage when the token count is absent', () => {
+    const stdin = { context_window: { context_window_size: 200000, used_percentage: 25 } };
+    expect(buildUsageModel({ stdin }, NOW)?.context?.note).toBe('50k/200k');
+  });
+
+  it('prefers live stdin rate limits and reports no age', () => {
+    const stdin = {
+      ...STDIN,
+      rate_limits: {
+        five_hour: { used_percentage: 12, resets_at: '2026-08-12T17:30:00Z' },
+        seven_day: { used_percentage: 44, resets_at: '2026-08-17T03:00:00Z' },
+      },
+    };
+    const model = buildUsageModel({ stdin, config: { ...CONFIG, cachedUsageUtilization: { fetchedAtMs: NOW - 60_000, utilization: UTILIZATION } } }, NOW);
+    expect(model?.limits.map((l) => [l.label, l.percent])).toEqual([['5h', 12], ['week', 44]]);
+    expect(model?.limitsAgeMs).toBeUndefined();
+  });
+
+  it('keeps the cached model-scoped cap when stdin supplies the live windows', () => {
+    const stdin = {
+      ...STDIN,
+      rate_limits: {
+        five_hour: { used_percentage: 12, resets_at: '2026-08-12T17:30:00Z' },
+        seven_day: { used_percentage: 44, resets_at: '2026-08-17T03:00:00Z' },
+      },
+    };
+    // stdin carries the plan-wide windows only, so the scoped cap has to come
+    // from the cache or it disappears in exactly these sessions.
+    const model = buildUsageModel({ stdin, cache: { fetchedAtMs: NOW - 30_000, utilization: UTILIZATION } }, NOW);
+    const week = model?.limits.find((l) => l.label === 'week');
+    expect(week?.percent).toBe(44);
+    expect(week?.note).toBe('Fable 58%');
+    expect(model?.limitsAgeMs).toBeUndefined();
+  });
+
+  it('falls back to the freshest cache and records its age', () => {
+    const model = buildUsageModel(
+      {
+        stdin: STDIN,
+        config: { ...CONFIG, cachedUsageUtilization: { fetchedAtMs: NOW - 6 * 3600_000, utilization: { ...UTILIZATION, seven_day: { utilization: 39, resets_at: null } } } },
+        cache: { fetchedAtMs: NOW - 30_000, utilization: UTILIZATION },
+      },
+      NOW,
+    );
+    expect(model?.limits.find((l) => l.label === 'week')?.percent).toBe(47);
+    expect(model?.limitsAgeMs).toBe(30_000);
+  });
+
+  it('uses Claude Code’s own cache when buddy has never refreshed', () => {
+    const model = buildUsageModel(
+      { stdin: STDIN, config: { ...CONFIG, cachedUsageUtilization: { fetchedAtMs: NOW - 45_000, utilization: UTILIZATION } } },
+      NOW,
+    );
+    expect(model?.limits).toHaveLength(2);
+    expect(model?.limitsAgeMs).toBe(45_000);
+  });
+
+  it('attaches an active scoped limit to the weekly gauge', () => {
+    const model = buildUsageModel({ stdin: STDIN, cache: { fetchedAtMs: NOW, utilization: UTILIZATION } }, NOW);
+    expect(model?.limits.find((l) => l.label === 'week')?.note).toBe('Fable 58%');
+  });
+});
+
+describe('usage — panel rendering', () => {
+  const model = buildUsageModel({ stdin: STDIN, config: CONFIG, cache: { fetchedAtMs: NOW, utilization: UTILIZATION } }, NOW);
+  const lines = renderUsagePanel(model, NOW).map(strip);
+
+  it('renders one line per element, in a stable order', () => {
+    expect(lines).toHaveLength(5);
+    expect(lines[0]).toBe('acct Rebellions-Lime | daekyeong.kim');
+    expect(lines[1]).toBe('via  Opus 5 | max5x');
+    expect(lines[2]).toBe('ctx  █████░░░░░   51%  102k/200k');
+    expect(lines[3]).toBe('5h   █|░░░░░░░░    7%  4h30m');
+    expect(lines[4]).toBe('week ███|█░░░░░   47%  4d14h | Fable 58%');
+  });
+
+  it('ticks each window at its own elapsed fraction', () => {
+    // 30m into a 5h window, 2d10h into a 7d one.
+    expect(lines[3].indexOf('|')).toBe(6);
+    expect(lines[4].indexOf('|')).toBe(8);
+  });
+
+  it('leaves the context gauge untickable — it has no window to run out', () => {
+    expect(lines[2]).not.toContain('|');
+  });
+
+  it('tags a gateway session on the route line', () => {
+    const gateway = buildUsageModel({ stdin: { ...STDIN, model: { id: 'MiniMaxAI/MiniMax-M2.5', display_name: 'MiniMaxAI/MiniMax-M2.5' } }, config: CONFIG }, NOW);
+    expect(strip(renderUsagePanel(gateway, NOW)[1])).toBe('via  MiniMaxAI/MiniMax-M2.5 (gateway)');
+  });
+
+  it('marks stale rate limits on the last gauge only', () => {
+    const stale = buildUsageModel({ stdin: STDIN, config: CONFIG, cache: { fetchedAtMs: NOW - STALE_AFTER_MS, utilization: UTILIZATION } }, NOW);
+    const out = renderUsagePanel(stale, NOW).map(strip);
+    expect(out[3]).toBe('5h   █|░░░░░░░░    7%  4h30m');
+    expect(out[4]).toBe('week ███|█░░░░░   47%  4d14h | (10m) | Fable 58%');
+  });
+
+  it('omits the staleness marker while the cache is still fresh', () => {
+    expect(lines.join('\n')).not.toContain('(');
+  });
+
+  it('reads the Unix-seconds reset stamps that stdin sends', () => {
+    // Claude Code sends epoch seconds here; the usage API sends ISO strings.
+    const stdin = {
+      ...STDIN,
+      rate_limits: { five_hour: { used_percentage: 5, resets_at: Math.floor(NOW / 1000) + 3 * 3600 } },
+    };
+    expect(strip(renderUsagePanel(buildUsageModel({ stdin }, NOW), NOW).at(-1)!)).toBe('5h   █░░░|░░░░░    5%  3h');
+  });
+
+  it('drops reset hints for windows that have already reset', () => {
+    const past = buildUsageModel(
+      { stdin: STDIN, cache: { fetchedAtMs: NOW, utilization: { five_hour: { utilization: 7, resets_at: '2026-08-12T12:00:00Z' } } } },
+      NOW,
+    );
+    expect(strip(renderUsagePanel(past, NOW).at(-1)!)).toBe('5h   █░░░░░░░░░    7%');
+  });
+
+  it('renders nothing for a null model', () => {
+    expect(renderUsagePanel(null, NOW)).toEqual([]);
+  });
+
+  it('keeps the label column aligned across every line', () => {
+    for (const line of lines) {
+      expect(line.slice(0, 5)).toMatch(/^[a-z0-9]+ +$/);
+    }
+  });
+});
+
+describe('usage — refresh policy', () => {
+  const base = { enabled: true, now: NOW };
+
+  it('never refreshes when the opt-in is off', () => {
+    expect(decideRefresh({ ...base, enabled: false })).toBe('disabled');
+  });
+
+  it('skips while another refresh is in flight', () => {
+    expect(decideRefresh({ ...base, lockStartedAtMs: NOW - (REFRESH_LOCK_TTL_MS - 1) })).toBe('in-flight');
+  });
+
+  it('refreshes again once a stuck lock has aged out', () => {
+    expect(decideRefresh({ ...base, lockStartedAtMs: NOW - REFRESH_LOCK_TTL_MS })).toBe('refresh');
+  });
+
+  it('skips while the cache is inside its TTL, refreshes after', () => {
+    expect(decideRefresh({ ...base, cacheFetchedAtMs: NOW - (USAGE_CACHE_TTL_MS - 1) })).toBe('fresh');
+    expect(decideRefresh({ ...base, cacheFetchedAtMs: NOW - USAGE_CACHE_TTL_MS })).toBe('refresh');
+  });
+
+  it('refreshes when there is no cache at all', () => {
+    expect(decideRefresh(base)).toBe('refresh');
+  });
+
+  it('reads timestamps defensively', () => {
+    expect(readTimestamp({ fetchedAtMs: 42 }, 'fetchedAtMs')).toBe(42);
+    expect(readTimestamp({ fetchedAtMs: 'soon' }, 'fetchedAtMs')).toBeUndefined();
+    expect(readTimestamp(undefined, 'fetchedAtMs')).toBeUndefined();
+  });
+
+  it('fetches by default and only stops when explicitly switched off', () => {
+    expect(fetchEnabled({})).toBe(true);
+    expect(fetchEnabled({ [FETCH_ENV_FLAG]: '1' })).toBe(true);
+    expect(fetchEnabled({ [FETCH_ENV_FLAG]: '0' })).toBe(false);
+  });
+});
+
+describe('usage — credential selection', () => {
+  it('takes a valid access token', () => {
+    expect(pickToken({ claudeAiOauth: { accessToken: 'tok', expiresAt: NOW + 3600_000 } }, NOW)).toBe('tok');
+  });
+
+  it('accepts a token with no stated expiry', () => {
+    expect(pickToken({ claudeAiOauth: { accessToken: 'tok' } }, NOW)).toBe('tok');
+  });
+
+  it('refuses an expired or nearly expired token instead of spending a 401', () => {
+    expect(pickToken({ claudeAiOauth: { accessToken: 'tok', expiresAt: NOW - 1 } }, NOW)).toBeUndefined();
+    expect(pickToken({ claudeAiOauth: { accessToken: 'tok', expiresAt: NOW + 10_000 } }, NOW)).toBeUndefined();
+  });
+
+  it('ignores credentials that are missing, malformed, or for other services', () => {
+    expect(pickToken(undefined, NOW)).toBeUndefined();
+    expect(pickToken({ mcpOAuth: { something: { accessToken: 'tok' } } }, NOW)).toBeUndefined();
+    expect(pickToken({ claudeAiOauth: { accessToken: '' } }, NOW)).toBeUndefined();
+  });
+});

--- a/src/lib/columns.ts
+++ b/src/lib/columns.ts
@@ -1,0 +1,54 @@
+// src/lib/columns.ts — side-by-side layout for the statusline's blocks
+
+import { RESET, stripAnsi } from "./ansi.js";
+
+/** Drop the run of spaces that only ANSI codes follow, so padding is not doubled. */
+const trimCell = (cell: string): string => cell.replace(/[ \t]+(?=(?:\x1b\[[0-9;]*m)*$)/, "");
+
+const visibleLength = (cell: string): number => stripAnsi(cell).length;
+
+/**
+ * Lay blocks out side by side, padding each column so the next one starts at a
+ * fixed offset.
+ *
+ * A column is only widened by the rows where something is actually printed to
+ * its right. Rows that trail past every other column — the name and mood lines
+ * under a speech bubble, say — stand alone, so letting them set the column
+ * width would shove the shorter rows far to the right and push the rightmost
+ * block off a narrow terminal.
+ */
+export function joinColumns(columns: string[][], gutter: number): string[] {
+  const height = Math.max(0, ...columns.map((col) => col.length));
+  if (height === 0) return [];
+
+  const hasContentRight = (row: number, col: number): boolean =>
+    columns.slice(col + 1).some((other) => (stripAnsi(other[row] || "")).trim() !== "");
+
+  const widths = columns.map((col, index) =>
+    Math.max(0, ...col.map((cell, row) => (hasContentRight(row, index) ? visibleLength(trimCell(cell)) : 0))),
+  );
+
+  const rows: string[] = [];
+  for (let row = 0; row < height; row++) {
+    let line = "";
+    for (let col = 0; col < columns.length; col++) {
+      const cell = trimCell(columns[col][row] || "");
+      line += cell;
+      if (col < columns.length - 1) {
+        line += " ".repeat(Math.max(0, widths[col] + gutter - visibleLength(cell)));
+      }
+    }
+    // A row whose left columns are all empty — the usage panel running past the
+    // bottom of the buddy, say — is nothing but padding up to its first visible
+    // character. Claude Code re-indents each statusline row as
+    // `indent + row.trimStart()`, which swallows that padding whole and drops
+    // the row back to column zero. Every other row survives because its own
+    // padding ends at a colour escape the trim stops on, so give these rows the
+    // same shape: leave the gutter bare for the host to reclaim, then a reset,
+    // then the rest of the padding. Output is visually identical either way.
+    const laidOut = line.trimEnd();
+    const indent = laidOut.length - laidOut.trimStart().length;
+    rows.push(indent > gutter ? laidOut.slice(0, gutter) + RESET + laidOut.slice(gutter) : laidOut);
+  }
+  return rows;
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -8,3 +8,12 @@ const CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".cla
 
 export const BUDDY_STATUS_PATH = join(CLAUDE_CONFIG_DIR, "buddy-status.json");
 export const BUDDY_DB_PATH = join(homedir(), ".buddy", "buddy.db");
+
+// Claude Code's own config file — holds the signed-in account and its last
+// cached rate-limit utilization, both read by the statusline usage panel.
+export const CLAUDE_CONFIG_FILE = join(homedir(), ".claude.json");
+// Where the optional usage refresh stores what it fetched, plus its in-flight marker.
+export const BUDDY_USAGE_CACHE_PATH = join(CLAUDE_CONFIG_DIR, "buddy-usage-cache.json");
+export const BUDDY_USAGE_LOCK_PATH = join(CLAUDE_CONFIG_DIR, "buddy-usage-cache.lock");
+// Linux/Windows keep Claude Code credentials in a file; macOS keeps them in the keychain.
+export const CLAUDE_CREDENTIALS_FILE = join(CLAUDE_CONFIG_DIR, ".credentials.json");

--- a/src/lib/usage-refresh.ts
+++ b/src/lib/usage-refresh.ts
@@ -1,0 +1,151 @@
+// src/lib/usage-refresh.ts — optional background refresh of Claude rate-limit usage
+//
+// Claude Code only caches its rate-limit utilization when it fetches it itself,
+// which never happens in sessions answered through a gateway — the cached
+// numbers then drift hours behind. When the user opts in, the statusline spawns
+// this module as a detached child that refreshes the snapshot on its own.
+//
+// The render path NEVER waits on this: it reads whatever the cache holds and
+// returns. A refresh started now shows up on a later render, seconds later.
+
+import { spawn, execFileSync } from "child_process";
+import { writeFileSync, renameSync, rmSync } from "fs";
+import { userInfo } from "os";
+import { fileURLToPath } from "url";
+import {
+  BUDDY_USAGE_CACHE_PATH,
+  BUDDY_USAGE_LOCK_PATH,
+  CLAUDE_CREDENTIALS_FILE,
+} from "./constants.js";
+import { decideRefresh, readJsonFile, readTimestamp } from "./usage-sources.js";
+
+/**
+ * Refreshing is on by default — stale rate-limit numbers are worse than no
+ * numbers, and Claude Code's own cache goes hours stale in gateway sessions.
+ * Set the flag to "0" to keep the statusline off the network entirely.
+ */
+export const FETCH_ENV_FLAG = "BUDDY_STATUSLINE_USAGE_FETCH";
+const KEYCHAIN_SERVICE = "Claude Code-credentials";
+const FETCH_TIMEOUT_MS = 8_000;
+/** Refuse a token that is about to expire rather than spend a request on a 401. */
+const TOKEN_SKEW_MS = 30_000;
+
+const apiBase = () => process.env.BUDDY_USAGE_API_BASE || "https://api.anthropic.com";
+
+export const fetchEnabled = (env: NodeJS.ProcessEnv = process.env): boolean =>
+  env[FETCH_ENV_FLAG] !== "0";
+
+/**
+ * Claude Code's OAuth credential: the macOS keychain on darwin, a file
+ * elsewhere. Returns undefined whenever it is missing, unreadable, or expired —
+ * the panel then keeps showing the cached numbers.
+ */
+export function readOAuthToken(now: number): string | undefined {
+  let raw: string | undefined;
+
+  if (process.platform === "darwin") {
+    try {
+      raw = execFileSync(
+        "security",
+        ["find-generic-password", "-s", KEYCHAIN_SERVICE, "-a", userInfo().username, "-w"],
+        { encoding: "utf-8", timeout: 5_000, stdio: ["ignore", "pipe", "ignore"] },
+      );
+    } catch { /* not stored in the keychain */ }
+  }
+
+  const parsed = raw ? safeParse(raw) : readJsonFile(CLAUDE_CREDENTIALS_FILE);
+  return pickToken(parsed, now);
+}
+
+function safeParse(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Pure token selection, so expiry handling is testable without a keychain. */
+export function pickToken(credentials: unknown, now: number): string | undefined {
+  if (typeof credentials !== "object" || credentials === null) return undefined;
+  const oauth = (credentials as Record<string, unknown>).claudeAiOauth;
+  if (typeof oauth !== "object" || oauth === null) return undefined;
+
+  const record = oauth as Record<string, unknown>;
+  const token = record.accessToken;
+  if (typeof token !== "string" || !token) return undefined;
+
+  const expiresAt = record.expiresAt;
+  if (typeof expiresAt === "number" && expiresAt - TOKEN_SKEW_MS <= now) return undefined;
+
+  return token;
+}
+
+async function fetchUtilization(token: string): Promise<unknown> {
+  const response = await fetch(`${apiBase()}/api/oauth/usage`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "anthropic-beta": "oauth-2025-04-20",
+      "Content-Type": "application/json",
+    },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!response.ok) throw new Error(`usage fetch failed: ${response.status}`);
+  return response.json();
+}
+
+function writeJsonAtomic(path: string, value: unknown): void {
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(value));
+  renameSync(tmp, path);
+}
+
+/** The detached child's whole job: fetch once, cache it, release the lock. */
+export async function runRefresh(now: number = Date.now()): Promise<void> {
+  try {
+    const token = readOAuthToken(now);
+    if (!token) return;
+    const utilization = await fetchUtilization(token);
+    writeJsonAtomic(BUDDY_USAGE_CACHE_PATH, { fetchedAtMs: Date.now(), source: "api", utilization });
+  } catch {
+    // Network down, token rejected, disk read-only — the panel falls back to
+    // the previous snapshot, so a failed refresh is never worth reporting.
+  } finally {
+    try { rmSync(BUDDY_USAGE_LOCK_PATH, { force: true }); } catch { /* already gone */ }
+  }
+}
+
+/**
+ * Start a refresh if the policy allows one. Returns the decision so the caller
+ * (and tests) can see why nothing happened. Never throws, never blocks.
+ */
+export function maybeSpawnRefresh(opts: { now: number }): string {
+  try {
+    const decision = decideRefresh({
+      enabled: fetchEnabled(),
+      cacheFetchedAtMs: readTimestamp(readJsonFile(BUDDY_USAGE_CACHE_PATH), "fetchedAtMs"),
+      lockStartedAtMs: readTimestamp(readJsonFile(BUDDY_USAGE_LOCK_PATH), "startedAtMs"),
+      now: opts.now,
+    });
+    if (decision !== "refresh") return decision;
+
+    // Claim the lock before spawning so parallel statusline renders — one per
+    // Claude Code window — cannot pile up requests on the same endpoint.
+    writeJsonAtomic(BUDDY_USAGE_LOCK_PATH, { startedAtMs: opts.now, pid: process.pid });
+
+    const child = spawn(process.execPath, [fileURLToPath(import.meta.url), "--refresh"], {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref();
+    return decision;
+  } catch {
+    return "error";
+  }
+}
+
+// Child-process entry point. Guarded so importing the module (tests, the
+// statusline itself) never kicks off a fetch.
+if (process.argv[1] === fileURLToPath(import.meta.url) && process.argv.includes("--refresh")) {
+  void runRefresh();
+}

--- a/src/lib/usage-sources.ts
+++ b/src/lib/usage-sources.ts
@@ -1,0 +1,77 @@
+// src/lib/usage-sources.ts — where the usage panel's numbers come from
+//
+// Reading files is the only side effect here; every read is best-effort and
+// returns undefined instead of throwing, because the statusline must render
+// even when Claude Code's config is missing, partial, or mid-write.
+
+import { readFileSync } from "fs";
+import { CLAUDE_CONFIG_FILE, BUDDY_USAGE_CACHE_PATH } from "./constants.js";
+import type { UsageSources } from "./usage.js";
+
+/** How long a fetched utilization snapshot is considered current. */
+export const USAGE_CACHE_TTL_MS = 60_000;
+/** How long a refresh is assumed to still be running before another may start. */
+export const REFRESH_LOCK_TTL_MS = 15_000;
+
+export function readJsonFile(path: string): unknown | undefined {
+  try {
+    return JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return undefined;
+  }
+}
+
+function parseStdin(stdinData: string): unknown | undefined {
+  if (!stdinData) return undefined;
+  try {
+    return JSON.parse(stdinData);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Gather every input the panel can draw from. Missing sources are simply absent. */
+export function collectUsageSources(stdinData: string): UsageSources {
+  return {
+    stdin: parseStdin(stdinData),
+    config: readJsonFile(CLAUDE_CONFIG_FILE),
+    cache: readJsonFile(BUDDY_USAGE_CACHE_PATH),
+  };
+}
+
+export type RefreshDecision = "disabled" | "fresh" | "in-flight" | "refresh";
+
+/**
+ * Decide whether a background refresh is worth starting. Pure so the policy can
+ * be tested without touching the network, the clock, or the filesystem.
+ *
+ * Live numbers on stdin are not a reason to skip the fetch: that payload covers
+ * the two plan-wide windows only, so the model-scoped cap would go stale in
+ * exactly the sessions Claude Code reports limits for. The TTL and the lock are
+ * what keep the request rate down.
+ *
+ * `cacheFetchedAtMs` / `lockStartedAtMs` are undefined when the file is absent.
+ */
+export function decideRefresh(opts: {
+  enabled: boolean;
+  cacheFetchedAtMs?: number;
+  lockStartedAtMs?: number;
+  now: number;
+}): RefreshDecision {
+  if (!opts.enabled) return "disabled";
+
+  if (opts.lockStartedAtMs !== undefined && opts.now - opts.lockStartedAtMs < REFRESH_LOCK_TTL_MS) {
+    return "in-flight";
+  }
+  if (opts.cacheFetchedAtMs !== undefined && opts.now - opts.cacheFetchedAtMs < USAGE_CACHE_TTL_MS) {
+    return "fresh";
+  }
+  return "refresh";
+}
+
+/** Timestamp helper shared by the cache and lock files; undefined when unreadable. */
+export function readTimestamp(value: unknown, key: string): number | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const ts = (value as Record<string, unknown>)[key];
+  return typeof ts === "number" ? ts : undefined;
+}

--- a/src/lib/usage.ts
+++ b/src/lib/usage.ts
@@ -1,0 +1,417 @@
+// src/lib/usage.ts — Claude Code usage panel rendered beside the buddy
+//
+// Everything here is pure: the model is built from already-read data and every
+// time-dependent value takes `now` as an argument, so the panel is fully
+// deterministic under test. All IO lives in usage-sources.ts / usage-refresh.ts.
+
+import { RESET, DIM, CYAN, GREEN, YELLOW, RED } from "./ansi.js";
+
+export type UsageGauge = {
+  /** Short column label: "ctx", "5h", "week". */
+  label: string;
+  /** 0-100. */
+  percent: number;
+  /**
+   * When the window resets. The two sources disagree on the encoding: stdin
+   * sends Unix seconds, the usage API sends an ISO string. Both are accepted.
+   */
+  resetsAt?: string | number | null;
+  /** Trailing annotation, e.g. the token count or an active scoped limit. */
+  note?: string;
+  /**
+   * Length of the window this gauge measures. With `resetsAt` it yields how much
+   * of the window is already gone, which the meter marks with a tick.
+   */
+  windowMs?: number;
+};
+
+export type UsageAccount = {
+  org?: string;
+  /** Local part of the account email — enough to tell two logins apart. */
+  user?: string;
+};
+
+export type UsageRoute = {
+  /** Model name as Claude Code reports it. */
+  model: string;
+  /** False when the session is answered by a non-Anthropic model (gateway/proxy). */
+  firstParty: boolean;
+  /** Tidied rate-limit tier, e.g. "max5x". Only meaningful for first-party sessions. */
+  plan?: string;
+};
+
+export type UsageModel = {
+  account?: UsageAccount;
+  route?: UsageRoute;
+  context?: UsageGauge;
+  limits: UsageGauge[];
+  /**
+   * Age of the rate-limit data in ms. Undefined when it arrived live on stdin;
+   * a number when it came from a cache, which the panel marks as stale.
+   */
+  limitsAgeMs?: number;
+};
+
+/** Raw inputs, already parsed. Any of them may be missing. */
+export type UsageSources = {
+  /** The statusline JSON Claude Code writes to stdin. */
+  stdin?: unknown;
+  /** ~/.claude.json — holds oauthAccount and Claude Code's own utilization cache. */
+  config?: unknown;
+  /** buddy's own refresh cache: { fetchedAtMs, utilization }. */
+  cache?: unknown;
+};
+
+/**
+ * Meter width in cells. The percentage is printed after it, not over it, so the
+ * bar stays narrow enough that the panel's longest row still fits an 80-column
+ * terminal — a wider line gets its left padding eaten and lands under the buddy.
+ */
+const BAR_CELLS = 10;
+const BAR_FILLED = "█";
+const BAR_EMPTY = "░";
+/** Marks how far into the window we are, so pace can be read off the meter. */
+const BAR_TICK = "|";
+/** Rate-limit data older than this is shown with a staleness marker. */
+export const STALE_AFTER_MS = 10 * 60_000;
+/** Window lengths, needed to turn a reset stamp into "how much of it is gone". */
+const FIVE_HOUR_MS = 5 * 3600_000;
+const SEVEN_DAY_MS = 7 * 86400_000;
+
+const isRecord = (v: unknown): v is Record<string, any> =>
+  typeof v === "object" && v !== null;
+
+const clampPercent = (percent: number): number =>
+  Number.isFinite(percent) ? Math.max(0, Math.min(100, percent)) : 0;
+
+const percentColor = (percent: number): string =>
+  percent >= 85 ? RED : percent >= 60 ? YELLOW : GREEN;
+
+/**
+ * Fixed-width meter. A non-zero percentage always lights at least one cell.
+ *
+ * `elapsedPercent` marks how far the window itself has run with a tick, so the
+ * two can be compared at a glance: fill left of the tick means the budget is
+ * lasting, fill past it means it is burning faster than the clock.
+ */
+export function renderBar(percent: number, elapsedPercent?: number): string {
+  const clamped = clampPercent(percent);
+  const scaled = Math.round((clamped / 100) * BAR_CELLS);
+  const filled = clamped === 0 ? 0 : Math.max(1, scaled);
+
+  const tick = elapsedPercent === undefined
+    ? -1
+    : Math.min(BAR_CELLS - 1, Math.floor((clampPercent(elapsedPercent) / 100) * BAR_CELLS));
+
+  const color = percentColor(clamped);
+  let out = "";
+  let open = "";
+  for (let cell = 0; cell < BAR_CELLS; cell++) {
+    // The tick keeps its own color so it reads as a mark on the bar rather than
+    // as part of the fill it sits in.
+    const want = cell === tick ? CYAN : cell < filled ? color : DIM;
+    if (want !== open) {
+      out += (open ? RESET : "") + want;
+      open = want;
+    }
+    out += cell === tick ? BAR_TICK : cell < filled ? BAR_FILLED : BAR_EMPTY;
+  }
+  return out + (open ? RESET : "");
+}
+
+/** 812 → "812", 102178 → "102k", 1_240_000 → "1.2M". */
+export function formatTokens(tokens: number): string {
+  if (!Number.isFinite(tokens) || tokens < 0) return "0";
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`;
+  if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}k`;
+  return String(Math.round(tokens));
+}
+
+/** Coarse duration: "3h58m", "4d13h", "12m", "<1m". */
+export function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return "<1m";
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 1) return "<1m";
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    const rem = minutes % 60;
+    return rem ? `${hours}h${rem}m` : `${hours}h`;
+  }
+  const days = Math.floor(hours / 24);
+  const rem = hours % 24;
+  return rem ? `${days}d${rem}h` : `${days}d`;
+}
+
+/** Epoch seconds (stdin) or an ISO string (usage API) → epoch ms; NaN when unusable. */
+function toEpochMs(value: string | number | null | undefined): number {
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || value <= 0) return NaN;
+    // Anything below ~2001 in ms is really a seconds-based timestamp.
+    return value < 1e12 ? value * 1000 : value;
+  }
+  if (typeof value === "string" && value) return Date.parse(value);
+  return NaN;
+}
+
+/** Time left in the window, e.g. "3h58m"; empty when unknown or already past. */
+function formatReset(resetsAt: string | number | null | undefined, now: number): string {
+  const at = toEpochMs(resetsAt);
+  if (Number.isNaN(at) || at <= now) return "";
+  return formatDuration(at - now);
+}
+
+/**
+ * How much of the gauge's window has already run, 0-100. Undefined when the
+ * window length is unknown (the context gauge) or the reset stamp is unusable —
+ * the meter then draws no tick rather than guessing a position.
+ */
+function elapsedPercent(gauge: UsageGauge, now: number): number | undefined {
+  if (!gauge.windowMs) return undefined;
+  const at = toEpochMs(gauge.resetsAt);
+  if (Number.isNaN(at) || at <= now) return undefined;
+  const remaining = Math.min(gauge.windowMs, at - now);
+  return ((gauge.windowMs - remaining) / gauge.windowMs) * 100;
+}
+
+/** "default_claude_max_5x" → "max5x"; "team_tier_1" → "team1". */
+export function tidyTier(tier: unknown): string | undefined {
+  if (typeof tier !== "string" || !tier) return undefined;
+  const cleaned = tier.replace(/^default_/, "").replace(/^claude_/, "");
+  const compact = cleaned.replace(/_tier_/, "").replace(/_/g, "");
+  return compact || undefined;
+}
+
+type NormalizedLimits = {
+  fiveHour?: { percent: number; resetsAt?: string | number | null };
+  sevenDay?: { percent: number; resetsAt?: string | number | null };
+  /** Model-scoped weekly limit, e.g. the per-model weekly cap. */
+  scoped?: { label: string; percent: number };
+};
+
+const readWindow = (w: unknown, percentKey: "utilization" | "used_percentage") => {
+  if (!isRecord(w)) return undefined;
+  const percent = w[percentKey];
+  if (typeof percent !== "number") return undefined;
+  const resetsAt = w.resets_at;
+  return {
+    percent,
+    resetsAt: typeof resetsAt === "string" || typeof resetsAt === "number" ? resetsAt : null,
+  };
+};
+
+/**
+ * The /api/oauth/usage shape (also cached in ~/.claude.json), where windows
+ * carry `utilization` and `limits[]` may hold an active model-scoped cap.
+ */
+export function normalizeUtilization(util: unknown): NormalizedLimits | undefined {
+  if (!isRecord(util)) return undefined;
+  const out: NormalizedLimits = {
+    fiveHour: readWindow(util.five_hour, "utilization"),
+    sevenDay: readWindow(util.seven_day, "utilization"),
+  };
+
+  if (Array.isArray(util.limits)) {
+    // A model-scoped cap is worth showing even while `is_active` is false: the
+    // flag marks which limit is currently binding, not whether the cap exists.
+    // Models carrying their own allowance (Fable) report the scoped bucket
+    // inactive right up until it becomes the constraint, and hiding it until
+    // then leaves the panel silent about the budget actually being spent.
+    const candidates = util.limits.filter(
+      (l: unknown) => isRecord(l) && l.kind === "weekly_scoped" && typeof l.percent === "number",
+    );
+    // Still prefer the binding one when several models report a cap.
+    const scoped = candidates.find((l: Record<string, any>) => l.is_active === true) ?? candidates[0];
+    if (isRecord(scoped)) {
+      const model = isRecord(scoped.scope) && isRecord(scoped.scope.model) ? scoped.scope.model.display_name : undefined;
+      out.scoped = { label: typeof model === "string" && model ? model : "scoped", percent: scoped.percent };
+    }
+  }
+
+  if (!out.fiveHour && !out.sevenDay && !out.scoped) return undefined;
+  return out;
+}
+
+/**
+ * The `rate_limits` block Claude Code puts on stdin, where windows carry
+ * `used_percentage`. It reports the two plan-wide windows only — model-scoped
+ * caps are absent from the payload, so `scoped` is filled in from the cache by
+ * `pickLimits` rather than here.
+ */
+function normalizeStdinLimits(rateLimits: unknown): NormalizedLimits | undefined {
+  if (!isRecord(rateLimits)) return undefined;
+  const out: NormalizedLimits = {
+    fiveHour: readWindow(rateLimits.five_hour, "used_percentage"),
+    sevenDay: readWindow(rateLimits.seven_day, "used_percentage"),
+  };
+  if (!out.fiveHour && !out.sevenDay) return undefined;
+  return out;
+}
+
+/**
+ * Rate-limit precedence: live stdin first, then buddy's own refresh cache, then
+ * whatever Claude Code last cached. Cached sources carry their age so the panel
+ * can mark them stale.
+ */
+function pickLimits(sources: UsageSources, now: number): { limits: NormalizedLimits; ageMs?: number } | undefined {
+  const stdin = isRecord(sources.stdin) ? sources.stdin : undefined;
+  const live = normalizeStdinLimits(stdin?.rate_limits);
+
+  const candidates: Array<{ util: unknown; fetchedAtMs: unknown }> = [];
+  if (isRecord(sources.cache)) candidates.push({ util: sources.cache.utilization, fetchedAtMs: sources.cache.fetchedAtMs });
+  const configCache = isRecord(sources.config) ? sources.config.cachedUsageUtilization : undefined;
+  if (isRecord(configCache)) candidates.push({ util: configCache.utilization, fetchedAtMs: configCache.fetchedAtMs });
+
+  let best: { limits: NormalizedLimits; ageMs: number } | undefined;
+  for (const candidate of candidates) {
+    const limits = normalizeUtilization(candidate.util);
+    if (!limits) continue;
+    const fetchedAt = typeof candidate.fetchedAtMs === "number" ? candidate.fetchedAtMs : 0;
+    const ageMs = Math.max(0, now - fetchedAt);
+    if (!best || ageMs < best.ageMs) best = { limits, ageMs };
+  }
+
+  // Live numbers win for the plan-wide windows, but stdin never carries the
+  // model-scoped cap, so dropping to stdin alone would hide it exactly in the
+  // sessions that report live limits. Graft the cached scoped entry onto the
+  // live windows instead; the plan-wide gauges stay live either way.
+  if (live) return { limits: { ...live, scoped: best?.limits.scoped } };
+
+  return best;
+}
+
+function buildAccount(config: unknown): UsageAccount | undefined {
+  const account = isRecord(config) ? config.oauthAccount : undefined;
+  if (!isRecord(account)) return undefined;
+  const org = typeof account.organizationName === "string" ? account.organizationName : undefined;
+  const email = typeof account.emailAddress === "string" ? account.emailAddress : undefined;
+  const user = email ? email.split("@")[0] : undefined;
+  if (!org && !user) return undefined;
+  return { org, user };
+}
+
+function buildRoute(stdin: unknown, config: unknown): UsageRoute | undefined {
+  const model = isRecord(stdin) ? stdin.model : undefined;
+  if (!isRecord(model)) return undefined;
+  const id = typeof model.id === "string" ? model.id : "";
+  const name = typeof model.display_name === "string" && model.display_name ? model.display_name : id;
+  if (!name) return undefined;
+
+  const firstParty = /^claude/i.test(id);
+  const account = isRecord(config) ? config.oauthAccount : undefined;
+  const plan = isRecord(account) ? tidyTier(account.userRateLimitTier) : undefined;
+  return { model: name, firstParty, plan };
+}
+
+function buildContext(stdin: unknown): UsageGauge | undefined {
+  const cw = isRecord(stdin) ? stdin.context_window : undefined;
+  if (!isRecord(cw) || typeof cw.used_percentage !== "number") return undefined;
+
+  const size = typeof cw.context_window_size === "number" ? cw.context_window_size : 0;
+  const used = typeof cw.total_input_tokens === "number"
+    ? cw.total_input_tokens
+    : Math.round((cw.used_percentage / 100) * size);
+
+  return {
+    label: "ctx",
+    percent: cw.used_percentage,
+    note: size ? `${formatTokens(used)}/${formatTokens(size)}` : formatTokens(used),
+  };
+}
+
+/** Assemble the panel model. Returns null when no source yielded anything to show. */
+export function buildUsageModel(sources: UsageSources, now: number): UsageModel | null {
+  const model: UsageModel = { limits: [] };
+
+  model.account = buildAccount(sources.config);
+  model.route = buildRoute(sources.stdin, sources.config);
+  model.context = buildContext(sources.stdin);
+
+  const picked = pickLimits(sources, now);
+  if (picked) {
+    const { limits, ageMs } = picked;
+    if (limits.fiveHour) {
+      model.limits.push({
+        label: "5h",
+        percent: limits.fiveHour.percent,
+        resetsAt: limits.fiveHour.resetsAt,
+        windowMs: FIVE_HOUR_MS,
+      });
+    }
+    if (limits.sevenDay) {
+      model.limits.push({
+        label: "week",
+        percent: limits.sevenDay.percent,
+        resetsAt: limits.sevenDay.resetsAt,
+        note: limits.scoped ? `${limits.scoped.label} ${Math.round(limits.scoped.percent)}%` : undefined,
+        windowMs: SEVEN_DAY_MS,
+      });
+    }
+    if (ageMs !== undefined) model.limitsAgeMs = ageMs;
+  }
+
+  const empty = !model.account && !model.route && !model.context && model.limits.length === 0;
+  return empty ? null : model;
+}
+
+const LABEL_WIDTH = 4;
+
+function renderGaugeLine(gauge: UsageGauge, now: number, suffix: string): string {
+  const label = `${DIM}${gauge.label.padEnd(LABEL_WIDTH)}${RESET}`;
+  const clamped = clampPercent(gauge.percent);
+  // Right-aligned so the numbers form a column no matter how wide they get.
+  const percent = `${percentColor(clamped)}${`${Math.round(clamped)}%`.padStart(4)}${RESET}`;
+  const reset = formatReset(gauge.resetsAt, now);
+  // Scoped-model annotations trail everything else: they are the least common
+  // element, so keeping them last stops the gauge columns from shifting.
+  const trailer = [reset, suffix, gauge.note].filter(Boolean).join(" | ");
+  const bar = renderBar(gauge.percent, elapsedPercent(gauge, now));
+  return `${label} ${bar}  ${percent}${trailer ? `  ${DIM}${trailer}${RESET}` : ""}`;
+}
+
+/**
+ * Render the panel, at most one line per element. Every line shares the same
+ * label column so the block reads as one table:
+ *   acct Rebellions-Lime | daekyeong.kim
+ *   via  MiniMaxAI/MiniMax-M2.5 (gateway)
+ *   ctx  █████░░░░░   51%  102k/200k
+ *   5h   █|░░░░░░░░    7%  3h58m
+ *   week ███|█░░░░░   47%  4d13h | (5h) | Fable 58%
+ *
+ * On the timed gauges the `|` marks how much of the window has already run, so
+ * fill sitting left of the tick means the budget is outlasting the clock.
+ *
+ * Trailers are bare on purpose: a countdown to the window reset, then the age
+ * of the snapshot in parentheses when it came from a stale cache, then any
+ * model-scoped cap.
+ */
+export function renderUsagePanel(model: UsageModel | null, now: number): string[] {
+  if (!model) return [];
+  const lines: string[] = [];
+
+  if (model.account) {
+    const parts = [model.account.org, model.account.user].filter(Boolean).join(`${RESET}${DIM} | ${RESET}${CYAN}`);
+    lines.push(`${DIM}${"acct".padEnd(LABEL_WIDTH)}${RESET} ${CYAN}${parts}${RESET}`);
+  }
+
+  if (model.route) {
+    const tag = model.route.firstParty
+      ? (model.route.plan ? ` | ${model.route.plan}` : "")
+      : " (gateway)";
+    lines.push(`${DIM}${"via".padEnd(LABEL_WIDTH)} ${model.route.model}${tag}${RESET}`);
+  }
+
+  if (model.context) lines.push(renderGaugeLine(model.context, now, ""));
+
+  // Age of a cached snapshot, parenthesized so it cannot be mistaken for the
+  // reset countdown sitting next to it.
+  const stale = model.limitsAgeMs !== undefined && model.limitsAgeMs >= STALE_AFTER_MS
+    ? `(${formatDuration(model.limitsAgeMs)})`
+    : "";
+  model.limits.forEach((gauge, i) => {
+    // The staleness marker rides the last cached gauge instead of taking its own line.
+    lines.push(renderGaugeLine(gauge, now, i === model.limits.length - 1 ? stale : ""));
+  });
+
+  return lines;
+}

--- a/src/statusline-wrapper.ts
+++ b/src/statusline-wrapper.ts
@@ -9,6 +9,10 @@ import { colorFor } from "./lib/color.js";
 import { BUDDY_STATUS_PATH } from "./lib/constants.js";
 import { getAnimationProfile, getAnimationState, pickFrame, DEFAULT_DWELL_MS } from "./lib/animation.js";
 import { seededIndex } from "./lib/rng.js";
+import { joinColumns } from "./lib/columns.js";
+import { buildUsageModel, renderUsagePanel } from "./lib/usage.js";
+import { collectUsageSources } from "./lib/usage-sources.js";
+import { maybeSpawnRefresh } from "./lib/usage-refresh.js";
 
 const toUnix = (p: string) => p.replace(/\\/g, "/");
 // Legacy fallback tick interval (SPRITE_BODIES path uses animation.ts profiles instead)
@@ -299,38 +303,26 @@ try {
   }
 } catch { /* no buddy status file */ }
 
-// Merge: HUD lines on the left, buddy on the right (side-by-side)
-if (hudLines.length === 0 && buddyRight.length === 0) {
+// Claude Code usage panel — account, context window and rate-limit gauges.
+// Purely decorative: any failure leaves the rest of the statusline untouched.
+let usageLines: string[] = [];
+if (process.env.BUDDY_STATUSLINE_USAGE !== "0") {
+  try {
+    const now = Date.now();
+    const sources = collectUsageSources(stdinData);
+    usageLines = renderUsagePanel(buildUsageModel(sources, now), now);
+    // Fire-and-forget; this render already used whatever the cache holds.
+    maybeSpawnRefresh({ now });
+  } catch { /* usage panel unavailable */ }
+}
+
+// Merge: HUD on the left, buddy in the middle, usage panel on the right
+if (hudLines.length === 0 && buddyRight.length === 0 && usageLines.length === 0) {
   process.exit(0);
 }
 
-if (buddyRight.length === 0) {
-  // No buddy, just output HUD as-is
-  for (const line of hudLines) {
-    console.log(line);
-  }
-} else {
-  // Find the max visible width of HUD lines for padding
-  const hudVisibleWidths = hudLines.map((l) => stripAnsi(l).length);
-  const maxHudWidth = Math.max(...hudVisibleWidths, 0);
-  // Add a gutter between HUD and buddy
-  const gutter = 3;
-  const padWidth = maxHudWidth + gutter;
-
-  const totalLines = Math.max(hudLines.length, buddyRight.length);
-  for (let i = 0; i < totalLines; i++) {
-    const hudPart = hudLines[i] || "";
-    const buddyPart = buddyRight[i] || "";
-
-    if (buddyPart) {
-      // Pad the HUD line to align buddy column
-      const visibleLen = stripAnsi(hudPart).length;
-      const padding = " ".repeat(Math.max(0, padWidth - visibleLen));
-      console.log(`${hudPart}${padding}${buddyPart}`);
-    } else {
-      console.log(hudPart);
-    }
-  }
+for (const line of joinColumns([hudLines, buddyRight, usageLines], 3)) {
+  console.log(line);
 }
 
 function moodColor(mood: string): string {


### PR DESCRIPTION
## What

Claude Code's statusline payload already carries the answers people leave the terminal to look up — which account is signed in, how much context is left, how deep into the 5-hour and weekly rate limits the session is. Buddy was ignoring all of it, so the space to the right of the sprite stayed empty.

This renders it as a third column:

```
     (\   /)     Pebble (Rabbit) Lv.21   acct Rebellions-Lime | daekyeong.kim
     (\_._/)     curious XP:9687 ★       via  Opus 5 | max5x
     ( ·.· )     · ready to critique     ctx  ██░░░░░░░░   23%  229k/1.0M
      > ^ <                              5h   █░|░░░░░░░    5%  3h50m
     (") (")                             week ███|█░░░░░   46%  4d13h
```

- `acct` — organization and account, so two logins are told apart at a glance
- `via` — the answering model, tagged `(gateway)` when it is not an Anthropic model
- `ctx` / `5h` / `week` — meters with the time left until each window resets
- `|` — how much of that window has already run, derived from its reset stamp. Fill left of the tick means the budget is outlasting the clock; fill past it means it is burning faster. The context meter has no window, so it carries no tick.

A percentage alone does not say whether it is on track — 46% of the weekly limit is comfortable on day five and alarming on day one — which is what the tick is for. It sits beside the percentage rather than replacing it, and the percentage sits beside the bar rather than over it, which keeps the panel's widest row inside a terminal that is not wide.

## Where the numbers come from

Rate limits fall back through three sources: the `rate_limits` block on stdin, buddy's own snapshot, then the utilization Claude Code last cached in `~/.claude.json`. A cached value older than ten minutes shows its age in parentheses (`4d13h | (5h)`).

The stdin block carries the two plan-wide windows only, so a model-scoped weekly cap is read from the refreshed snapshot and grafted onto the live windows; without that it would disappear in exactly the sessions Claude Code reports limits for. Scoped caps show whether or not they currently bind: `is_active` marks which limit constrains the session right now, not whether the cap exists, and a model with its own allowance reports the cap inactive until it starts rejecting work.

That fallback exists because Claude Code only refreshes its own cache when it fetches utilization itself, which never happens in sessions answered through a gateway — observed drift there was ~6 hours (39% cached vs 47% live).

Because of that drift, buddy keeps the snapshot current itself: it reads the Claude Code OAuth credential (macOS keychain, or `~/.claude/.credentials.json` elsewhere) and calls the same usage endpoint Claude Code does. A gauge that silently shows six-hour-old numbers is worse than one that costs a background request a minute, so this is on by default; `BUDDY_STATUSLINE_USAGE_FETCH=0` turns it off and keeps the statusline entirely off the network and off the credential store.

The fetch runs in a detached child, at most once a minute, guarded by a lock file so parallel Claude Code windows cannot pile up requests. Nothing leaves the machine except that one request, and nothing is stored beyond the snapshot in `~/.claude/buddy-usage-cache.json`. Failures are silent — the previous snapshot stays on screen.

`BUDDY_STATUSLINE_USAGE=0` hides the panel entirely.

**Happy to flip the fetch back to opt-in if you would rather ship it that way** — it is a one-line default in `usage-refresh.ts` plus its test.

## Notes for review

- Two encodings had to be handled: stdin sends `resets_at` as Unix seconds, the usage API sends an ISO string. Both are accepted; this was caught against a live payload, not assumed.
- Window length is a local constant (5h, 7d) because the payload only states when a window resets, never when it opened. That is what turns a reset stamp into the tick position, and it is why an unusable or already-past stamp draws no tick instead of guessing one.
- The meter is 10 cells wide. Tick resolution is therefore 10% — enough to read pace, and narrow enough that the widest row (weekly gauge plus an active model-scoped cap) stays around 80 columns.
- The column merge in `statusline-wrapper.ts` is generalized from two blocks to N, with each column padded to its own width, and lives in `lib/columns.ts` so it can be tested directly. A missing column collapses to nothing, so HUD-only and buddy-only layouts render exactly as before.
- All parsing and rendering is pure and takes `now` as an argument, so the panel is deterministic under test. IO lives in `usage-sources.ts`; the credential read and fetch live in `usage-refresh.ts`.
- Everything is best-effort: a missing, partial, or mid-write config never breaks the statusline.

## Testing

- `npx tsc --noEmit` clean
- 54 tests across `src/__tests__/usage.test.ts` and `src/__tests__/columns.test.ts` covering meter geometry, clamping and tick placement (including a window that has run out), both `resets_at` encodings, source precedence and staleness, gateway detection, refresh policy (lock/TTL/off switch), token expiry handling, and the scoped-cap graft; plus the column layout, including a padding-only row surviving a host that re-indents rows as `indent + trimStart()`
- Full suite: `953 passed | 9 failed`. The failures are pre-existing on `master` — a run of the same files on a clean checkout fails identically (Penguin sprite width, doctor diagnostics, reasoning detectors)
- Rendered against live Claude Code payloads on macOS in both a first-party and a gateway session, and the refresh path verified end to end: a gateway render first showed the stale cache (`4d13h | (6h6m)`), and the next render after the background fetch showed live numbers with the marker gone

## History

Force-pushed twice. The first rewrite folded the elapsed-window tick and the narrower meter into the first commit rather than landing them as a follow-up. The second squashed the branch to a single commit — the layout had been added inline in the wrapper and then moved to `lib/columns.ts`, and the refresh had shipped opt-in and then been flipped to opt-out, so both were churn a reviewer would have had to read twice — and rebased it onto current `master`.
